### PR TITLE
Fix operator cache not started error

### DIFF
--- a/adapter/internal/operator/operator.go
+++ b/adapter/internal/operator/operator.go
@@ -131,7 +131,7 @@ func InitOperator() {
 	}
 
 	go synchronizer.HandleAPILifeCycleEvents(&ch)
-	go xds.HandleApplicationEventsFromMgtServer(mgr.GetClient())
+	go xds.HandleApplicationEventsFromMgtServer(mgr.GetClient(), mgr.GetAPIReader())
 
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
 		loggers.LoggerAPKOperator.Errorf("problem running manager", err)

--- a/adapter/internal/xds/application_event_listener.go
+++ b/adapter/internal/xds/application_event_listener.go
@@ -2,53 +2,49 @@ package xds
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/wso2/apk/adapter/internal/loggers"
 	cpv1alpha1 "github.com/wso2/apk/adapter/internal/operator/apis/cp/v1alpha1"
 	"github.com/wso2/apk/adapter/pkg/logging"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+	ctrlcache "sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // HandleApplicationEventsFromMgtServer handles the Application events
-func HandleApplicationEventsFromMgtServer(c client.Client) {
+func HandleApplicationEventsFromMgtServer(c client.Client, cReader client.Reader) {
 	for applicationEvent := range applicationChannel {
 		switch applicationEvent.Type {
 		case APPLICATION_CREATE:
-			err := c.Create(context.Background(), *&applicationEvent.Application)
-			if err != nil {
-				loggers.LoggerXds.ErrorC(logging.ErrorDetails{
-					Message:   fmt.Sprint("Error creating application: ", err.Error()),
-					Severity:  logging.CRITICAL,
-					ErrorCode: 1707,
-				})
-			} else {
-				loggers.LoggerXds.Info("Application created: " + applicationEvent.Application.Name)
+			if err, found, _ := checkApplicationEsists(applicationEvent.Application, c, cReader); err == nil && !found {
+				if err := c.Create(context.Background(), *&applicationEvent.Application); err != nil {
+					loggers.LoggerXds.ErrorC(logging.ErrorDetails{
+						Message:   fmt.Sprint("Error creating application: ", err.Error()),
+						Severity:  logging.CRITICAL,
+						ErrorCode: 1707,
+					})
+				} else {
+					loggers.LoggerXds.Info("Application created: " + applicationEvent.Application.Name)
+				}
 			}
 			break
 		case APPLICATION_UPDATE:
-			var application = new(cpv1alpha1.Application)
-			if err := c.Get(context.Background(), types.NamespacedName{
-				Name:      applicationEvent.Application.Name,
-				Namespace: applicationEvent.Application.Namespace}, application); err != nil {
-				loggers.LoggerXds.ErrorC(logging.ErrorDetails{
-					Message:   fmt.Sprint("Error retrieving application: ", err.Error()),
-					Severity:  logging.CRITICAL,
-					ErrorCode: 1708,
-				})
-				break
-			}
-			application.Spec = applicationEvent.Application.Spec
-			err := c.Update(context.Background(), application)
-			if err != nil {
-				loggers.LoggerXds.ErrorC(logging.ErrorDetails{
-					Message:   fmt.Sprint("Error updating application: ", err.Error()),
-					Severity:  logging.CRITICAL,
-					ErrorCode: 1709,
-				})
-			} else {
-				loggers.LoggerXds.Info("Application updated: " + applicationEvent.Application.Name)
+			if err, found, application := checkApplicationEsists(applicationEvent.Application, c, cReader); err == nil && found {
+				application.Spec = applicationEvent.Application.Spec
+				err := c.Update(context.Background(), application)
+				if err != nil {
+					loggers.LoggerXds.ErrorC(logging.ErrorDetails{
+						Message:   fmt.Sprint("Error updating application: ", err.Error()),
+						Severity:  logging.CRITICAL,
+						ErrorCode: 1709,
+					})
+				} else {
+					loggers.LoggerXds.Info("Application updated: " + applicationEvent.Application.Name)
+				}
 			}
 			break
 		case APPLICATION_DELETE:
@@ -67,4 +63,42 @@ func HandleApplicationEventsFromMgtServer(c client.Client) {
 			loggers.LoggerXds.Info("Unknown Application Event Type")
 		}
 	}
+}
+
+func checkApplicationEsists(application *cpv1alpha1.Application, c client.Client, cReader client.Reader) (error, bool, *cpv1alpha1.Application) {
+	var retrivedApplication = new(cpv1alpha1.Application)
+	// Try reading from cache
+	if err := c.Get(context.Background(), types.NamespacedName{
+		Name:      application.Name,
+		Namespace: application.Namespace}, retrivedApplication); err != nil {
+
+		target := &ctrlcache.ErrCacheNotStarted{}
+		if errors.As(err, &target) {
+			// Try reading from api server directly
+			if err := cReader.Get(context.Background(), types.NamespacedName{
+				Name:      application.Name,
+				Namespace: application.Namespace}, retrivedApplication); err != nil {
+
+				if !apierrors.IsNotFound(err) {
+					loggers.LoggerXds.ErrorC(logging.ErrorDetails{
+						Message:   fmt.Sprint("Error retrieving application: ", err.Error()),
+						Severity:  logging.CRITICAL,
+						ErrorCode: 1711,
+					})
+					return err, false, nil
+				}
+				return nil, false, nil
+			}
+		} else if !apierrors.IsNotFound(err) {
+			loggers.LoggerXds.ErrorC(logging.ErrorDetails{
+				Message:   fmt.Sprint("Error retrieving application: ", err.Error()),
+				Severity:  logging.CRITICAL,
+				ErrorCode: 1712,
+			})
+			return err, false, nil
+		} else {
+			return nil, false, nil
+		}
+	}
+	return nil, true, retrivedApplication
 }

--- a/adapter/internal/xds/application_event_listener.go
+++ b/adapter/internal/xds/application_event_listener.go
@@ -20,7 +20,7 @@ func HandleApplicationEventsFromMgtServer(c client.Client, cReader client.Reader
 	for applicationEvent := range applicationChannel {
 		switch applicationEvent.Type {
 		case APPLICATION_CREATE:
-			if err, found, _ := checkApplicationEsists(applicationEvent.Application, c, cReader); err == nil && !found {
+			if err, found, _ := checkApplicationExists(applicationEvent.Application, c, cReader); err == nil && !found {
 				if err := c.Create(context.Background(), *&applicationEvent.Application); err != nil {
 					loggers.LoggerXds.ErrorC(logging.ErrorDetails{
 						Message:   fmt.Sprint("Error creating application: ", err.Error()),
@@ -33,7 +33,7 @@ func HandleApplicationEventsFromMgtServer(c client.Client, cReader client.Reader
 			}
 			break
 		case APPLICATION_UPDATE:
-			if err, found, application := checkApplicationEsists(applicationEvent.Application, c, cReader); err == nil && found {
+			if err, found, application := checkApplicationExists(applicationEvent.Application, c, cReader); err == nil && found {
 				application.Spec = applicationEvent.Application.Spec
 				err := c.Update(context.Background(), application)
 				if err != nil {
@@ -65,7 +65,7 @@ func HandleApplicationEventsFromMgtServer(c client.Client, cReader client.Reader
 	}
 }
 
-func checkApplicationEsists(application *cpv1alpha1.Application, c client.Client, cReader client.Reader) (error, bool, *cpv1alpha1.Application) {
+func checkApplicationExists(application *cpv1alpha1.Application, c client.Client, cReader client.Reader) (error, bool, *cpv1alpha1.Application) {
 	var retrivedApplication = new(cpv1alpha1.Application)
 	// Try reading from cache
 	if err := c.Get(context.Background(), types.NamespacedName{


### PR DESCRIPTION
## Purpose
$subject

## Issue
When the adapter is restarted it gets the following error:
```
ERRO [application_event_listener.go:23] - [xds.HandleApplicationEventsFromMgtServer] [-] Error retrieving application: the cache is not started, can not read objects [severity=Critical error_code=1708]
```
when adapter is restarted it needs to sync applications with etcd. It does read from the cache (k8s resource) in the operator side, since the adapter just started it has not synced the data from k8s API server. 

## Fix
Until the cache get started we can fallback to directly querying k8s API server (read operations Get / List) and sync applications with etcd server. 

