### PR TITLE
Use revive instead of golint for linting

### DIFF
--- a/adapter/build.gradle
+++ b/adapter/build.gradle
@@ -29,15 +29,15 @@ release {
     tagTemplate = '${project.name}-${project.version}'
 }
 
-tasks.named('go_lint_run').configure { 
+tasks.named('go_revive_run').configure { 
     finalizedBy go_tidy
 }
 
 tasks.named('go_build').configure {
-    dependsOn go_lint_run
+    dependsOn go_revive_run
     dependsOn go_vet
     finalizedBy docker_build
-} 
+}
 
 tasks.named('build').configure {
     dependsOn go_build

--- a/adapter/internal/oasparser/envoyconf/routes_with_clusters.go
+++ b/adapter/internal/oasparser/envoyconf/routes_with_clusters.go
@@ -1505,7 +1505,7 @@ func createAddress(remoteHost string, port uint32) *corev3.Address {
 
 // getMaxStreamDuration configures a maximum duration for a websocket route.
 func getMaxStreamDuration(apiType string) *routev3.RouteAction_MaxStreamDuration {
-	var maxStreamDuration *routev3.RouteAction_MaxStreamDuration = nil
+	var maxStreamDuration *routev3.RouteAction_MaxStreamDuration
 	if apiType == constants.WS {
 		maxStreamDuration = &routev3.RouteAction_MaxStreamDuration{
 			MaxStreamDuration: &durationpb.Duration{

--- a/adapter/internal/oasparser/model/api_env.go
+++ b/adapter/internal/oasparser/model/api_env.go
@@ -30,7 +30,7 @@ func retrieveEndpointsFromEnv(apiHashValue string) ([]Endpoint, []Endpoint) {
 	// set production Endpoints
 	i := 0
 	for {
-		var productionEndpointURL string = resolveEnvValueForEndpointConfig("api_"+apiHashValue+"_prod_endpoint_"+strconv.Itoa(i), "")
+		var productionEndpointURL = resolveEnvValueForEndpointConfig("api_"+apiHashValue+"_prod_endpoint_"+strconv.Itoa(i), "")
 		if productionEndpointURL == "" {
 			break
 		}
@@ -47,7 +47,7 @@ func retrieveEndpointsFromEnv(apiHashValue string) ([]Endpoint, []Endpoint) {
 	// set sandbox Endpoints
 	j := 0
 	for {
-		var sandboxEndpointURL string = resolveEnvValueForEndpointConfig("api_"+apiHashValue+"_sand_endpoint_"+strconv.Itoa(j), "")
+		var sandboxEndpointURL = resolveEnvValueForEndpointConfig("api_"+apiHashValue+"_sand_endpoint_"+strconv.Itoa(j), "")
 		if sandboxEndpointURL == "" {
 			break
 		}
@@ -64,7 +64,7 @@ func retrieveEndpointsFromEnv(apiHashValue string) ([]Endpoint, []Endpoint) {
 	return productionEndpoints, sandboxEndpoints
 }
 
-//RetrieveEndpointBasicAuthCredentialsFromEnv retrieve endpoint security credentials from env variables
+// RetrieveEndpointBasicAuthCredentialsFromEnv retrieve endpoint security credentials from env variables
 func RetrieveEndpointBasicAuthCredentialsFromEnv(apiHashValue string, keyType string, endpointSecurity EndpointSecurity) EndpointSecurity {
 	// production Endpoint security
 	endpointSecurity.Username = resolveEnvValueForEndpointConfig("api_"+apiHashValue+"_"+keyType+

--- a/adapter/internal/oasparser/model/api_yaml.go
+++ b/adapter/internal/oasparser/model/api_yaml.go
@@ -179,9 +179,9 @@ func (apiYaml *APIYaml) FormatAndUpdateInfo() {
 
 // ValidateMandatoryFields check and populates the mandatory fields if null
 func (apiYaml *APIYaml) ValidateMandatoryFields() error {
-	var errMsg string = ""
-	var apiName string = apiYaml.Data.Name
-	var apiVersion string = apiYaml.Data.Version
+	var errMsg string
+	var apiName = apiYaml.Data.Name
+	var apiVersion = apiYaml.Data.Version
 
 	if apiName == "" {
 		apiName = "unknownAPIName"

--- a/adapter/internal/oasparser/model/graphql_api.go
+++ b/adapter/internal/oasparser/model/graphql_api.go
@@ -94,7 +94,7 @@ func (swagger *MgwSwagger) SetInfoGraphQLAPI(apiYaml APIYaml) error {
 	}
 	swagger.resources = resources
 
-	var corsConfig *CorsConfig = generateGlobalCors()
+	var corsConfig = generateGlobalCors()
 	if apiYaml.Data.CorsConfiguration.CorsConfigurationEnabled == true {
 		corsConfig.AccessControlAllowOrigins = apiYaml.Data.CorsConfiguration.AccessControlAllowOrigins
 		corsConfig.AccessControlAllowCredentials = apiYaml.Data.CorsConfiguration.AccessControlAllowCredentials

--- a/adapter/internal/oasparser/model/open_api.go
+++ b/adapter/internal/oasparser/model/open_api.go
@@ -134,7 +134,7 @@ func setResourcesOpenAPI(openAPI openapi3.T) ([]*Resource, error) {
 			// Checks for resource level security. (security is disabled in resource level using x-wso2-disable-security extension)
 			isResourceLvlSecurityDisabled, foundInResourceLevel := resolveDisableSecurity(pathItem.ExtensionProps)
 			methodsArray := make([]*Operation, len(pathItem.Operations()))
-			var arrayIndex int = 0
+			var arrayIndex int
 			for httpMethod, operation := range pathItem.Operations() {
 				if operation != nil {
 					if foundInResourceLevel {

--- a/adapter/revive.toml
+++ b/adapter/revive.toml
@@ -1,0 +1,28 @@
+ignoreGeneratedHeader = false
+severity = "warning"
+confidence = 0.8
+errorCode = 0
+warningCode = 0
+
+[rule.blank-imports]
+[rule.context-as-argument]
+[rule.context-keys-type]
+[rule.dot-imports]
+[rule.error-return]
+[rule.error-strings]
+[rule.error-naming]
+[rule.exported]
+[rule.if-return]
+[rule.increment-decrement]
+[rule.var-naming]
+[rule.var-declaration]
+[rule.range]
+[rule.receiver-naming]
+[rule.time-naming]
+[rule.unexported-return]
+[rule.indent-error-flow]
+[rule.errorf]
+[rule.empty-block]
+[rule.superfluous-else]
+[rule.unreachable-code]
+[rule.redefines-builtin-id]

--- a/common-gradle-scripts/go.gradle
+++ b/common-gradle-scripts/go.gradle
@@ -24,10 +24,10 @@ tasks.register('go_clean', Exec) {
     commandLine 'go', 'clean'
 }
 
-tasks.register('go_lint_run', Exec) {
+tasks.register('go_revive_run', Exec) {
     group 'go'
-    description 'Running golint.'
-    commandLine 'golint', '-set_exit_status', './...'
+    description 'Running revive.'
+    commandLine 'revive', '-config', 'revive.toml', '-set_exit_status', './...'
 }
 
 tasks.register('go_vet', Exec) {

--- a/management-server/build.gradle
+++ b/management-server/build.gradle
@@ -29,15 +29,15 @@ release {
     tagTemplate = '${project.name}-${project.version}'
 }
 
-tasks.named('go_lint_run').configure { 
+tasks.named('go_revive_run').configure { 
     finalizedBy go_tidy
 }
 
 tasks.named('go_build').configure {
-    dependsOn go_lint_run
+    dependsOn go_revive_run
     dependsOn go_vet
     finalizedBy docker_build
-} 
+}
 
 tasks.named('build').configure {
     dependsOn go_build

--- a/management-server/internal/database/dao.go
+++ b/management-server/internal/database/dao.go
@@ -79,9 +79,7 @@ func GetCachedApplicationByUUID(uuid string) (*apkmgt.Application, error) {
 
 // getSubscriptionsForApplication returns all subscriptions from DB, for a given application.
 func getSubscriptionsForApplication(appUUID string) ([]*apkmgt.Subscription, error) {
-	rows, err := ExecDBQuery(queryGetAllSubscriptionsForApplication, appUUID)
-	if err != nil {
-	}
+	rows, _ := ExecDBQuery(queryGetAllSubscriptionsForApplication, appUUID)
 	var subs []*apkmgt.Subscription
 	for rows.Next() {
 		values, err := rows.Values()
@@ -102,9 +100,7 @@ func getSubscriptionsForApplication(appUUID string) ([]*apkmgt.Subscription, err
 
 // getConsumerKeysForApplication returns all Consumer Keys from DB, for a given application.
 func getConsumerKeysForApplication(appUUID string) ([]*apkmgt.ConsumerKey, error) {
-	rows, err := ExecDBQuery(queryConsumerKeysForApplication, appUUID)
-	if err != nil {
-	}
+	rows, _ := ExecDBQuery(queryConsumerKeysForApplication, appUUID)
 	var keys []*apkmgt.ConsumerKey
 	for rows.Next() {
 		values, err := rows.Values()

--- a/management-server/revive.toml
+++ b/management-server/revive.toml
@@ -1,0 +1,28 @@
+ignoreGeneratedHeader = false
+severity = "warning"
+confidence = 0.8
+errorCode = 0
+warningCode = 0
+
+[rule.blank-imports]
+[rule.context-as-argument]
+[rule.context-keys-type]
+[rule.dot-imports]
+[rule.error-return]
+[rule.error-strings]
+[rule.error-naming]
+[rule.exported]
+[rule.if-return]
+[rule.increment-decrement]
+[rule.var-naming]
+[rule.var-declaration]
+[rule.range]
+[rule.receiver-naming]
+[rule.time-naming]
+[rule.unexported-return]
+[rule.indent-error-flow]
+[rule.errorf]
+[rule.empty-block]
+[rule.superfluous-else]
+[rule.unreachable-code]
+[rule.redefines-builtin-id]


### PR DESCRIPTION
## Purpose

This is to use [revive](https://github.com/mgechev/revive) for linting since [golint](https://github.com/golang/lint) is archived.

Revive binary should be installed globally using:
```
go install github.com/mgechev/revive@latest
```