### PR TITLE
Use ExternalName as hostname when service type is ExternalName

### DIFF
--- a/adapter/internal/oasparser/envoyconf/routes_with_clusters_test.go
+++ b/adapter/internal/oasparser/envoyconf/routes_with_clusters_test.go
@@ -120,7 +120,7 @@ func TestCreateRoutesWithClusters(t *testing.T) {
 	httpRouteState.HTTPRoute = &httpRoute
 	httpRouteState.Authentications = make(map[string]dpv1alpha1.Authentication)
 	httpRouteState.ResourceAuthentications = make(map[string]dpv1alpha1.Authentication)
-	httpRouteState.BackendPropertyMapping = getBackendProperties(&httpRoute)
+	httpRouteState.BackendPropertyMapping = getDefaultBackendProperties(&httpRoute)
 
 	apiState.ProdHTTPRoute = &httpRouteState
 
@@ -216,13 +216,13 @@ func createDefaultBackendRef(serviceName string, port int32, weight int32) gwapi
 	}
 }
 
-func getBackendProperties(httpRoute *gwapiv1b1.HTTPRoute) dpv1alpha1.BackendPropertyMapping {
+func getDefaultBackendProperties(httpRoute *gwapiv1b1.HTTPRoute) dpv1alpha1.BackendPropertyMapping {
 	backendPropertyMapping := make(dpv1alpha1.BackendPropertyMapping)
 	for ruleIndex, rule := range httpRoute.Spec.Rules {
 		backendPropertyMapping[ruleIndex] = make(map[int]dpv1alpha1.BackendProperties)
 		for backendIndex, backend := range rule.BackendRefs {
 			backendPropertyMapping[ruleIndex][backendIndex] = dpv1alpha1.BackendProperties{
-				ResolvedHostname: getHostNameForBackend(backend, httpRoute.Namespace),
+				ResolvedHostname: operatorutils.GetDefaultHostNameForBackend(backend, httpRoute.Namespace),
 			}
 		}
 	}

--- a/adapter/internal/oasparser/envoyconf/routes_with_clusters_test.go
+++ b/adapter/internal/oasparser/envoyconf/routes_with_clusters_test.go
@@ -38,7 +38,6 @@ import (
 )
 
 func TestCreateRoutesWithClusters(t *testing.T) {
-
 	apiState := synchronizer.APIState{}
 	apiDefinition := v1alpha1.API{
 		ObjectMeta: metav1.ObjectMeta{

--- a/adapter/internal/oasparser/model/http_route.go
+++ b/adapter/internal/oasparser/model/http_route.go
@@ -27,13 +27,18 @@ import (
 	dpv1alpha1 "github.com/wso2/apk/adapter/internal/operator/apis/dp/v1alpha1"
 	"github.com/wso2/apk/adapter/internal/operator/utils"
 	"golang.org/x/exp/maps"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	gwapiv1b1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
+
+// HostNameResolverFunc is the function signature for getting the hostname from service
+type HostNameResolverFunc = func(client client.Client, backend gwapiv1b1.HTTPBackendRef,
+	defaultNamespace string) string
 
 // SetInfoHTTPRouteCR populates resources and endpoints of mgwSwagger. httpRoute.Spec.Rules.Matches
 // are used to create resources and httpRoute.Spec.Rules.BackendRefs are used to create EndpointClusters.
 func (swagger *MgwSwagger) SetInfoHTTPRouteCR(httpRoute *gwapiv1b1.HTTPRoute, authSchemes map[string]dpv1alpha1.Authentication,
-	resourceAuthSchemes map[string]dpv1alpha1.Authentication, isProd bool) error {
+	resourceAuthSchemes map[string]dpv1alpha1.Authentication, isProd bool, client client.Client, hostNameResolver HostNameResolverFunc) error {
 	var resources []*Resource
 	var securitySchemes []SecurityScheme
 	//TODO(amali) add gateway level securities after gateway crd has implemented
@@ -114,8 +119,7 @@ func (swagger *MgwSwagger) SetInfoHTTPRouteCR(httpRoute *gwapiv1b1.HTTPRoute, au
 		}
 		for _, backend := range rule.BackendRefs {
 			endPoints = append(endPoints,
-				Endpoint{Host: fmt.Sprintf("%s.%s", backend.Name,
-					utils.GetNamespace(backend.Namespace, httpRoute.Namespace)),
+				Endpoint{Host: hostNameResolver(client, backend, httpRoute.Namespace),
 					URLType: constants.HTTP,
 					Port:    uint32(*backend.Port)})
 		}

--- a/adapter/internal/oasparser/model/http_route.go
+++ b/adapter/internal/oasparser/model/http_route.go
@@ -27,13 +27,8 @@ import (
 	dpv1alpha1 "github.com/wso2/apk/adapter/internal/operator/apis/dp/v1alpha1"
 	"github.com/wso2/apk/adapter/internal/operator/utils"
 	"golang.org/x/exp/maps"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	gwapiv1b1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
-
-// HostNameResolverFunc is the function signature for getting the hostname from service
-type HostNameResolverFunc = func(client client.Client, backend gwapiv1b1.HTTPBackendRef,
-	defaultNamespace string) string
 
 // SetInfoHTTPRouteCR populates resources and endpoints of mgwSwagger. httpRoute.Spec.Rules.Matches
 // are used to create resources and httpRoute.Spec.Rules.BackendRefs are used to create EndpointClusters.

--- a/adapter/internal/operator/apis/dp/v1alpha1/backend_types.go
+++ b/adapter/internal/operator/apis/dp/v1alpha1/backend_types.go
@@ -17,9 +17,11 @@
 
 package v1alpha1
 
+import "k8s.io/apimachinery/pkg/types"
+
 // BackendPropertyMapping keep a two level map using rule index and backend index to
 // a backend properties
-type BackendPropertyMapping map[int]map[int]BackendProperties
+type BackendPropertyMapping map[types.NamespacedName]BackendProperties
 
 // BackendProperties holds backend properties
 type BackendProperties struct {

--- a/adapter/internal/operator/apis/dp/v1alpha1/backend_types.go
+++ b/adapter/internal/operator/apis/dp/v1alpha1/backend_types.go
@@ -1,0 +1,27 @@
+/*
+ *  Copyright (c) 2023, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package v1alpha1
+
+// BackendPropertyMapping keep a two level map using rule index and backend index to
+// a backend properties
+type BackendPropertyMapping map[int]map[int]BackendProperties
+
+// BackendProperties holds backend properties
+type BackendProperties struct {
+	ResolvedHostname string
+}

--- a/adapter/internal/operator/controllers/dp/api_controller.go
+++ b/adapter/internal/operator/controllers/dp/api_controller.go
@@ -282,10 +282,12 @@ func (apiReconciler *APIReconciler) getAuthenticationsForResources(ctx context.C
 func (apiReconciler *APIReconciler) getBackendProperties(ctx context.Context,
 	httpRoute *gwapiv1b1.HTTPRoute) dpv1alpha1.BackendPropertyMapping {
 	backendPropertyMapping := make(dpv1alpha1.BackendPropertyMapping)
-	for ruleIndex, rule := range httpRoute.Spec.Rules {
-		backendPropertyMapping[ruleIndex] = make(map[int]dpv1alpha1.BackendProperties)
-		for backendIndex, backend := range rule.BackendRefs {
-			backendPropertyMapping[ruleIndex][backendIndex] = dpv1alpha1.BackendProperties{
+	for _, rule := range httpRoute.Spec.Rules {
+		for _, backend := range rule.BackendRefs {
+			backendPropertyMapping[types.NamespacedName{
+				Name:      string(backend.Name),
+				Namespace: utils.GetNamespace(backend.Namespace, httpRoute.Namespace),
+			}] = dpv1alpha1.BackendProperties{
 				ResolvedHostname: apiReconciler.getHostNameForBackend(ctx,
 					backend, httpRoute.Namespace),
 			}

--- a/adapter/internal/operator/controllers/dp/api_controller.go
+++ b/adapter/internal/operator/controllers/dp/api_controller.go
@@ -310,8 +310,7 @@ func (apiReconciler *APIReconciler) getHostNameForBackend(ctx context.Context, b
 			return service.Spec.ExternalName
 		}
 	}
-	return fmt.Sprintf("%s.%s", backend.Name,
-		utils.GetNamespace(backend.Namespace, defaultNamespace))
+	return utils.GetDefaultHostNameForBackend(backend, defaultNamespace)
 }
 
 // getAPIForHTTPRoute triggers the API controller reconcile method based on the changes detected

--- a/adapter/internal/operator/controllers/dp/api_controller.go
+++ b/adapter/internal/operator/controllers/dp/api_controller.go
@@ -43,6 +43,7 @@ import (
 	k8client "sigs.k8s.io/controller-runtime/pkg/client"
 
 	dpv1alpha1 "github.com/wso2/apk/adapter/internal/operator/apis/dp/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -50,6 +51,7 @@ const (
 	httpRouteAPIIndex           = "httpRouteAPIIndex"
 	authenticationAPIIndex      = "authenticationAPIIndex"
 	authenticationResourceIndex = "authenticationResourceIndex"
+	serviceHTTPRouteIndex       = "serviceHTTPRouteIndex"
 )
 
 // APIReconciler reconciles a API object
@@ -107,6 +109,16 @@ func NewAPIController(mgr manager.Manager, operatorDataStore *synchronizer.Opera
 			Message:   fmt.Sprintf("Error watching HTTPRoute resources: %v", err),
 			Severity:  logging.BLOCKER,
 			ErrorCode: 2602,
+		})
+		return err
+	}
+
+	if err := c.Watch(&source.Kind{Type: &corev1.Service{}}, handler.EnqueueRequestsFromMapFunc(r.getAPIsForService),
+		predicates...); err != nil {
+		loggers.LoggerAPKOperator.ErrorC(logging.ErrorDetails{
+			Message:   fmt.Sprintf("Error watching Service resources: %v", err),
+			Severity:  logging.BLOCKER,
+			ErrorCode: 2618,
 		})
 		return err
 	}
@@ -311,6 +323,45 @@ func (apiReconciler *APIReconciler) getAPIForHTTPRoute(obj k8client.Object) []re
 	return requests
 }
 
+// getAPIsForService triggers the API controller reconcile method based on the changes detected
+// from Service objects. This generates a reconcile request for a API looking up two indexes;
+// serviceHTTPRouteIndex and httpRouteAPIIndex in that order.
+func (apiReconciler *APIReconciler) getAPIsForService(obj k8client.Object) []reconcile.Request {
+	ctx := context.Background()
+	service, ok := obj.(*corev1.Service)
+	if !ok {
+		loggers.LoggerAPKOperator.ErrorC(logging.ErrorDetails{
+			Message:   fmt.Sprintf("Unexpected object type, bypassing reconciliation: %v", service),
+			Severity:  logging.TRIVIAL,
+			ErrorCode: 2620,
+		})
+		return []reconcile.Request{}
+	}
+
+	httpRouteList := &gwapiv1b1.HTTPRouteList{}
+	if err := apiReconciler.client.List(ctx, httpRouteList, &k8client.ListOptions{
+		FieldSelector: fields.OneTermEqualSelector(serviceHTTPRouteIndex, utils.NamespacedName(service).String()),
+	}); err != nil {
+		loggers.LoggerAPKOperator.ErrorC(logging.ErrorDetails{
+			Message:   fmt.Sprintf("Unable to find associated HTTPRoutes: %s", utils.NamespacedName(service).String()),
+			Severity:  logging.CRITICAL,
+			ErrorCode: 2621,
+		})
+		return []reconcile.Request{}
+	}
+
+	if len(httpRouteList.Items) == 0 {
+		loggers.LoggerAPKOperator.Debugf("HTTPRoutes for Service not found: %s", utils.NamespacedName(service).String())
+		return []reconcile.Request{}
+	}
+
+	requests := []reconcile.Request{}
+	for _, httpRoute := range httpRouteList.Items {
+		requests = append(requests, apiReconciler.getAPIForHTTPRoute(&httpRoute)...)
+	}
+	return requests
+}
+
 // getAPIForAuthentication triggers the API controller reconcile method based on the changes detected
 // from Authentication objects. If the changes are done for an API stored in the Operator Data store,
 // a new reconcile event will be created and added to the reconcile event queue.
@@ -397,6 +448,25 @@ func addIndexes(ctx context.Context, mgr manager.Manager) error {
 					}.String())
 			}
 			return httpRoutes
+		}); err != nil {
+		return err
+	}
+
+	// Service (BackendRefs) to HTTPRoute indexer
+	if err := mgr.GetFieldIndexer().IndexField(ctx, &gwapiv1b1.HTTPRoute{}, serviceHTTPRouteIndex,
+		func(rawObj k8client.Object) []string {
+			httpRoute := rawObj.(*gwapiv1b1.HTTPRoute)
+			var services []string
+			for _, rule := range httpRoute.Spec.Rules {
+				for _, backendRef := range rule.BackendRefs {
+					services = append(services, types.NamespacedName{
+						Namespace: utils.GetNamespace(backendRef.Namespace,
+							httpRoute.ObjectMeta.Namespace),
+						Name: string(backendRef.Name),
+					}.String())
+				}
+			}
+			return services
 		}); err != nil {
 		return err
 	}

--- a/adapter/internal/operator/operator.go
+++ b/adapter/internal/operator/operator.go
@@ -149,7 +149,7 @@ func InitOperator() {
 		})
 	}
 
-	go synchronizer.HandleAPILifeCycleEvents(&ch)
+	go synchronizer.StartSynchronizer(&ch, mgr.GetClient())
 	go synchronizer.SendAPIToAPKMgtServer()
 	go xds.HandleApplicationEventsFromMgtServer(mgr.GetClient(), mgr.GetAPIReader())
 

--- a/adapter/internal/operator/operator.go
+++ b/adapter/internal/operator/operator.go
@@ -149,7 +149,7 @@ func InitOperator() {
 		})
 	}
 
-	go synchronizer.StartSynchronizer(&ch, mgr.GetClient())
+	go synchronizer.HandleAPILifeCycleEvents(&ch)
 	go synchronizer.SendAPIToAPKMgtServer()
 	go xds.HandleApplicationEventsFromMgtServer(mgr.GetClient(), mgr.GetAPIReader())
 

--- a/adapter/internal/operator/synchronizer/api_state.go
+++ b/adapter/internal/operator/synchronizer/api_state.go
@@ -38,4 +38,5 @@ type HTTPRouteState struct {
 	HTTPRoute               *gwapiv1b1.HTTPRoute
 	Authentications         map[string]v1alpha1.Authentication
 	ResourceAuthentications map[string]v1alpha1.Authentication
+	BackendPropertyMapping  v1alpha1.BackendPropertyMapping
 }

--- a/adapter/internal/operator/synchronizer/synchronizer.go
+++ b/adapter/internal/operator/synchronizer/synchronizer.go
@@ -24,6 +24,7 @@ import (
 	"context"
 
 	"github.com/wso2/apk/adapter/internal/discovery/xds"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/wso2/apk/adapter/config"
 	client "github.com/wso2/apk/adapter/internal/grpc-client"
@@ -31,8 +32,11 @@ import (
 	model "github.com/wso2/apk/adapter/internal/oasparser/model"
 	"github.com/wso2/apk/adapter/internal/operator/constants"
 	"github.com/wso2/apk/adapter/internal/operator/services/runtime"
+	"github.com/wso2/apk/adapter/internal/operator/utils"
 	apiProtos "github.com/wso2/apk/adapter/pkg/discovery/api/wso2/discovery/service/apkmgt"
 	"github.com/wso2/apk/adapter/pkg/logging"
+	corev1 "k8s.io/api/core/v1"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	gwapiv1b1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
@@ -47,14 +51,21 @@ type APIEvent struct {
 var (
 	// TODO: Decide on a buffer size and add to config.
 	mgtServerCh chan APIEvent
+	c           ctrlclient.Client
 )
 
 func init() {
 	mgtServerCh = make(chan APIEvent, 10)
 }
 
-// HandleAPILifeCycleEvents handles the API events generated from OperatorDataStore
-func HandleAPILifeCycleEvents(ch *chan APIEvent) {
+// StartSynchronizer sets up the synchronizer
+func StartSynchronizer(ch *chan APIEvent, client ctrlclient.Client) {
+	c = client
+	handleAPILifeCycleEvents(ch)
+}
+
+// handleAPILifeCycleEvents handles the API events generated from OperatorDataStore
+func handleAPILifeCycleEvents(ch *chan APIEvent) {
 	loggers.LoggerAPKOperator.Info("Operator synchronizer listening for API lifecycle events...")
 	for event := range *ch {
 		if event.Event.APIDefinition == nil {
@@ -121,23 +132,24 @@ func deleteAPIFromEnv(httpRoute *gwapiv1b1.HTTPRoute, apiState APIState) error {
 func deployAPIInGateway(apiState APIState) error {
 	var err error
 	if apiState.ProdHTTPRoute != nil {
-		_, err = GenerateMGWSwagger(apiState, apiState.ProdHTTPRoute, true)
+		_, err = GenerateMGWSwagger(apiState, apiState.ProdHTTPRoute, true, getHostNameForBackend)
 	}
 	if err != nil {
 		return err
 	}
 	if apiState.SandHTTPRoute != nil {
-		_, err = GenerateMGWSwagger(apiState, apiState.SandHTTPRoute, false)
+		_, err = GenerateMGWSwagger(apiState, apiState.SandHTTPRoute, false, getHostNameForBackend)
 	}
 	return err
 }
 
 // GenerateMGWSwagger this will populate a mgwswagger representation for an HTTPRoute
-func GenerateMGWSwagger(apiState APIState, httpRoute *HTTPRouteState, isProd bool) (*model.MgwSwagger, error) {
+func GenerateMGWSwagger(apiState APIState, httpRoute *HTTPRouteState, isProd bool,
+	hostNameResolver model.HostNameResolverFunc) (*model.MgwSwagger, error) {
 	var mgwSwagger model.MgwSwagger
 	mgwSwagger.SetInfoAPICR(*apiState.APIDefinition)
 	if err := mgwSwagger.SetInfoHTTPRouteCR(httpRoute.HTTPRoute, httpRoute.Authentications, httpRoute.ResourceAuthentications,
-		isProd); err != nil {
+		isProd, c, hostNameResolver); err != nil {
 		loggers.LoggerAPKOperator.ErrorC(logging.ErrorDetails{
 			Message:   fmt.Sprintf("Error setting HttpRoute CR info to mgwSwagger for isProdEndpoint: %v. %v", isProd, err),
 			Severity:  logging.MAJOR,
@@ -168,6 +180,25 @@ func GenerateMGWSwagger(apiState APIState, httpRoute *HTTPRouteState, isProd boo
 		}
 	}
 	return &mgwSwagger, nil
+}
+
+// getHostNameForService resolves the backed hostname for services.
+// When service type is ExternalName then ExternalName property is used as the hostname.
+// Otherwise defaulted to service name as <namespace>.<service>
+func getHostNameForBackend(client ctrlclient.Client, backend gwapiv1b1.HTTPBackendRef,
+	defaultNamespace string) string {
+	var service = new(corev1.Service)
+	err := client.Get(context.Background(), types.NamespacedName{
+		Name:      string(backend.Name),
+		Namespace: utils.GetNamespace(backend.Namespace, defaultNamespace)}, service)
+	if err == nil {
+		switch service.Spec.Type {
+		case corev1.ServiceTypeExternalName:
+			return service.Spec.ExternalName
+		}
+	}
+	return fmt.Sprintf("%s.%s", backend.Name,
+		utils.GetNamespace(backend.Namespace, defaultNamespace))
 }
 
 // getVhostForAPI returns the vHosts related to an API.

--- a/adapter/internal/operator/utils/utils.go
+++ b/adapter/internal/operator/utils/utils.go
@@ -18,12 +18,15 @@
 package utils
 
 import (
+	"fmt"
+
 	constants "github.com/wso2/apk/adapter/internal/operator/constants"
 	"github.com/wso2/apk/adapter/pkg/utils/envutils"
 	"github.com/wso2/apk/adapter/pkg/utils/stringutils"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/gateway-api/apis/v1beta1"
+	gwapiv1b1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 // NamespacedName generates namespaced name for Kubernetes objects
@@ -80,4 +83,11 @@ func PathMatchTypePtr(pType v1beta1.PathMatchType) *v1beta1.PathMatchType {
 // StringPtr returns a pointer to created string
 func StringPtr(val string) *string {
 	return &val
+}
+
+// GetDefaultHostNameForBackend returns the host in <backend.name>.<namespace> format
+func GetDefaultHostNameForBackend(backend gwapiv1b1.HTTPBackendRef,
+	defaultNamespace string) string {
+	return fmt.Sprintf("%s.%s", backend.Name,
+		GetNamespace(backend.Namespace, defaultNamespace))
 }


### PR DESCRIPTION
## Purpose
Use ExternalName as hostname when service type is ExternalName when creating envoy upstream clusters.

## Tests
Unit tests updated 
