### PR TITLE
[Runtime DS]  Add listing and search functionality of the runtime mediation policies

### DIFF
--- a/runtime/runtime-domain-service/ballerina/APIClient.bal
+++ b/runtime/runtime-domain-service/ballerina/APIClient.bal
@@ -2635,6 +2635,10 @@ public class APIClient {
             sortedMediationPolicies = from var mediationPolicy in clonedMediationPolicyList
                 order by mediationPolicy.id ascending
                 select mediationPolicy;
+        } else if sortBy == SORT_BY_ID && sortOrder == SORT_ORDER_DESC {
+            sortedMediationPolicies = from var mediationPolicy in clonedMediationPolicyList
+                order by mediationPolicy.id descending
+                select mediationPolicy;
         } else {
             BadRequestError badRequest = {body: {code: 90912, message: "Invalid Sort By/Sort Order Value "}};
             return badRequest;

--- a/runtime/runtime-domain-service/ballerina/APIClient.bal
+++ b/runtime/runtime-domain-service/ballerina/APIClient.bal
@@ -2665,7 +2665,7 @@ public class APIClient {
         if (mediationPolicyIDAvailable && string:length(id.toString()) > 0)
         {
             lock {
-                foreach model:MediationPolicy mediationPolicy in avilableMediationPolicyList {
+                foreach model:MediationPolicy mediationPolicy in getAvailableMediaionPolicies(organization) {
                     if mediationPolicy.id == id {
                         MediationPolicy matchedPolicy = convertPolicyModeltoPolicy(mediationPolicy);
                         return matchedPolicy.cloneReadOnly();
@@ -2690,15 +2690,9 @@ public class APIClient {
     # + return - Return list of Mediation Policies.
     public isolated function getMediationPolicyList(string? query, int 'limit, int offset, string sortBy, string sortOrder, commons:Organization organization) returns MediationPolicyList|BadRequestError|NotFoundError|InternalServerErrorError|commons:APKError {
         MediationPolicy[] mediationPolicyList = [];
-        model:MediationPolicy[] avilableMediationPolicies;
-        lock {
-            avilableMediationPolicies = avilableMediationPolicyList.clone();
-        }
-
-        foreach model:MediationPolicy mediationPolicy in avilableMediationPolicies {
+        foreach model:MediationPolicy mediationPolicy in getAvailableMediaionPolicies(organization) {
             MediationPolicy policyItem = convertPolicyModeltoPolicy(mediationPolicy);
             mediationPolicyList.push(policyItem);
-
         } on fail var e {
             return error("Error occured while getting Mediation policy list", e, message = "Internal Server Error", code = 909000, description = "Internal Server Error", statusCode = 500);
         }

--- a/runtime/runtime-domain-service/ballerina/APIClient.bal
+++ b/runtime/runtime-domain-service/ballerina/APIClient.bal
@@ -2580,8 +2580,8 @@ public class APIClient {
         }
     }
 
-    private isolated function filterMediationPoliciesBasedOnQuery(MediationPolicyData[] mediationPolicyList, string query, int 'limit, int offset, string sortBy, string sortOrder) returns MediationPolicyDataList|BadRequestError {
-        MediationPolicyData[] filteredList = [];
+    private isolated function filterMediationPoliciesBasedOnQuery(MediationPolicy[] mediationPolicyList, string query, int 'limit, int offset, string sortBy, string sortOrder) returns MediationPolicyList|BadRequestError {
+        MediationPolicy[] filteredList = [];
         if query.length() > 0 {
             int? semiCollonIndex = string:indexOf(query, ":", 0);
             if semiCollonIndex is int && semiCollonIndex > 0 {
@@ -2589,13 +2589,13 @@ public class APIClient {
                 string keyWordValue = query.substring(keyWord.length() + 1, query.length());
                 keyWordValue = keyWordValue + "|\\w+" + keyWordValue + "\\w+" + "|" + keyWordValue + "\\w+" + "|\\w+" + keyWordValue;
                 if keyWord.trim() == SEARCH_CRITERIA_NAME {
-                    foreach MediationPolicyData mediationPolicy in mediationPolicyList {
+                    foreach MediationPolicy mediationPolicy in mediationPolicyList {
                         if (regex:matches(mediationPolicy.name, keyWordValue)) {
                             filteredList.push(mediationPolicy);
                         }
                     }
                 } else if keyWord.trim() == SEARCH_CRITERIA_TYPE {
-                    foreach MediationPolicyData mediationPolicy in mediationPolicyList {
+                    foreach MediationPolicy mediationPolicy in mediationPolicyList {
                         if (regex:matches(mediationPolicy.'type, keyWordValue)) {
                             filteredList.push(mediationPolicy);
                         }
@@ -2607,7 +2607,7 @@ public class APIClient {
             } else {
                 string keyWordValue = query + "|\\w+" + query + "\\w+" + "|" + query + "\\w+" + "|\\w+" + query;
 
-                foreach MediationPolicyData mediationPolicy in mediationPolicyList {
+                foreach MediationPolicy mediationPolicy in mediationPolicyList {
 
                     if (regex:matches(mediationPolicy.name, keyWordValue)) {
                         filteredList.push(mediationPolicy);
@@ -2620,9 +2620,9 @@ public class APIClient {
         return self.filterMediationPolicies(filteredList, 'limit, offset, sortBy, sortOrder);
     }
 
-    private isolated function filterMediationPolicies(MediationPolicyData[] mediationPolicyList, int 'limit, int offset, string sortBy, string sortOrder) returns MediationPolicyDataList|BadRequestError {
-        MediationPolicyData[] clonedMediationPolicyList = mediationPolicyList.clone();
-        MediationPolicyData[] sortedMediationPolicies = [];
+    private isolated function filterMediationPolicies(MediationPolicy[] mediationPolicyList, int 'limit, int offset, string sortBy, string sortOrder) returns MediationPolicyList|BadRequestError {
+        MediationPolicy[] clonedMediationPolicyList = mediationPolicyList.clone();
+        MediationPolicy[] sortedMediationPolicies = [];
         if sortBy == SORT_BY_POLICY_NAME && sortOrder == SORT_ORDER_ASC {
             sortedMediationPolicies = from var mediationPolicy in clonedMediationPolicyList
                 order by mediationPolicy.name ascending
@@ -2643,7 +2643,7 @@ public class APIClient {
             BadRequestError badRequest = {body: {code: 90912, message: "Invalid Sort By/Sort Order Value "}};
             return badRequest;
         }
-        MediationPolicyData[] limitSet = [];
+        MediationPolicy[] limitSet = [];
         if sortedMediationPolicies.length() > offset {
             foreach int i in offset ... (sortedMediationPolicies.length() - 1) {
                 if limitSet.length() < 'limit {
@@ -2655,15 +2655,19 @@ public class APIClient {
 
     }
 
-    //Get Mediation policies by mediationPolicyId.
-    public isolated function getMediationPolicyById(string id, commons:Organization organization) returns MediationPolicyData|NotFoundError|commons:APKError {
+    # This return a Mediation policy by id.
+    #
+    # + id - Policy Id
+    # + organization - Organization
+    # + return - Return a Mediation Policy.
+    public isolated function getMediationPolicyById(string id, commons:Organization organization) returns MediationPolicy|NotFoundError|commons:APKError {
         boolean mediationPolicyIDAvailable = id.length() > 0 ? true : false;
         if (mediationPolicyIDAvailable && string:length(id.toString()) > 0)
         {
             lock {
                 foreach model:MediationPolicy mediationPolicy in avilableMediationPolicyList {
                     if mediationPolicy.id == id {
-                        MediationPolicyData matchedPolicy = convertPolicyModeltoPolicy(mediationPolicy);
+                        MediationPolicy matchedPolicy = convertPolicyModeltoPolicy(mediationPolicy);
                         return matchedPolicy.cloneReadOnly();
                     }
                 }
@@ -2684,15 +2688,15 @@ public class APIClient {
     # + sortOrder - SortOrder  Parameter
     # + organization - Organization
     # + return - Return list of Mediation Policies.
-    public isolated function getMediationPolicyList(string? query, int 'limit, int offset, string sortBy, string sortOrder, commons:Organization organization) returns MediationPolicyDataList|BadRequestError|NotFoundError|InternalServerErrorError|commons:APKError {
-        MediationPolicyData[] mediationPolicyList = [];
+    public isolated function getMediationPolicyList(string? query, int 'limit, int offset, string sortBy, string sortOrder, commons:Organization organization) returns MediationPolicyList|BadRequestError|NotFoundError|InternalServerErrorError|commons:APKError {
+        MediationPolicy[] mediationPolicyList = [];
         model:MediationPolicy[] avilableMediationPolicies;
         lock {
             avilableMediationPolicies = avilableMediationPolicyList.clone();
         }
 
         foreach model:MediationPolicy mediationPolicy in avilableMediationPolicies {
-            MediationPolicyData policyItem = convertPolicyModeltoPolicy(mediationPolicy);
+            MediationPolicy policyItem = convertPolicyModeltoPolicy(mediationPolicy);
             mediationPolicyList.push(policyItem);
 
         } on fail var e {

--- a/runtime/runtime-domain-service/ballerina/APIClient.bal
+++ b/runtime/runtime-domain-service/ballerina/APIClient.bal
@@ -2579,6 +2579,56 @@ public class APIClient {
             return internalError;
         }
     }
+
+    # This returns list of Policies.
+    #
+    # + query - Parameter Description  
+    # + 'limit - Parameter Description  
+    # + offset - Parameter Description  
+    # + sortBy - Parameter Description  
+    # + sortOrder - Parameter Description  
+    # + organization - Parameter Description
+    # + return - Return list of Policies.
+    public isolated function getMediationPolicyList(string? query, int 'limit, int offset, string sortBy, string sortOrder, commons:Organization organization) returns MediationPolicyDataList|BadRequestError|NotFoundError|InternalServerErrorError|commons:APKError {
+        MediationPolicyData[] MediationPolicyList = [];
+        
+        model:MediationPolicy[] MediationPolicylst;
+        lock {
+            MediationPolicylst = avilableMediationPolicyList.clone();
+         }
+
+        foreach model:MediationPolicy MediationPolicy in MediationPolicylst {
+            MediationPolicyData policyItem = {
+                id: MediationPolicy.id,
+                'type: MediationPolicy.'type,
+                name: MediationPolicy.name,
+                displayName: MediationPolicy.displayName,
+                description: MediationPolicy.description,
+                applicableFlows: MediationPolicy.applicableFlows,
+                supportedApiTypes: MediationPolicy.supportedApiTypes,
+                isApplicableforAPILevel: MediationPolicy.isApplicableforAPILevel,
+                isApplicableforOperationLevel: MediationPolicy.isApplicableforOperationLevel,
+                policyAttributes: MediationPolicy.policyAttributes
+
+            };
+            MediationPolicyList.push(policyItem);
+            
+        } on fail var e {
+            //return error("Error occured while getting API list", e, message = "Internal Server Error", code = 909000, description = "Internal Server Error", statusCode = 500);
+            log:printError("Error occured importing API", e);
+        }
+        // if query is string && query.toString().trim().length() > 0 {
+        //     return self.filterAPISBasedOnQuery(apilist, query, 'limit, offset, sortBy, sortOrder);
+        // } else {
+        //     return self.filterAPIS(apilist, 'limit, offset, sortBy, sortOrder);
+        // }
+        MediationPolicyDataList oplist = {
+            list: MediationPolicyList,
+            count: MediationPolicyList.length()
+        };
+        return oplist ;
+    }
+
 }
 
 type ImportDefintionRequest record {

--- a/runtime/runtime-domain-service/ballerina/APIClient.bal
+++ b/runtime/runtime-domain-service/ballerina/APIClient.bal
@@ -2580,7 +2580,7 @@ public class APIClient {
         }
     }
 
-      private isolated function filterMediationPoliciesBasedOnQuery(MediationPolicyData[] mediationPolicyList, string query, int 'limit, int offset, string sortBy, string sortOrder) returns MediationPolicyDataList|BadRequestError {
+    private isolated function filterMediationPoliciesBasedOnQuery(MediationPolicyData[] mediationPolicyList, string query, int 'limit, int offset, string sortBy, string sortOrder) returns MediationPolicyDataList|BadRequestError {
         MediationPolicyData[] filteredList = [];
         if query.length() > 0 {
             int? semiCollonIndex = string:indexOf(query, ":", 0);
@@ -2659,18 +2659,7 @@ public class APIClient {
             lock {
                 foreach model:MediationPolicy mediationPolicy in avilableMediationPolicyList {
                     if mediationPolicy.id == id {
-                         MediationPolicyData matchedPolicy = {
-                            id: mediationPolicy.id,
-                            'type: mediationPolicy.'type,
-                            name: mediationPolicy.name,
-                            displayName: mediationPolicy.displayName,
-                            description: mediationPolicy.description,
-                            applicableFlows: mediationPolicy.applicableFlows,
-                            supportedApiTypes: mediationPolicy.supportedApiTypes,
-                            isApplicableforAPILevel: mediationPolicy.isApplicableforAPILevel,
-                            isApplicableforOperationLevel: mediationPolicy.isApplicableforOperationLevel,
-                            policyAttributes: mediationPolicy.policyAttributes
-                        };
+                        MediationPolicyData matchedPolicy = convertPolicyModeltoPolicy(mediationPolicy);
                         return matchedPolicy.cloneReadOnly();
                     }
                 }
@@ -2696,24 +2685,12 @@ public class APIClient {
         model:MediationPolicy[] avilableMediationPolicies;
         lock {
             avilableMediationPolicies = avilableMediationPolicyList.clone();
-         }
+        }
 
         foreach model:MediationPolicy mediationPolicy in avilableMediationPolicies {
-            MediationPolicyData policyItem = {
-                id: mediationPolicy.id,
-                'type: mediationPolicy.'type,
-                name: mediationPolicy.name,
-                displayName: mediationPolicy.displayName,
-                description: mediationPolicy.description,
-                applicableFlows: mediationPolicy.applicableFlows,
-                supportedApiTypes: mediationPolicy.supportedApiTypes,
-                isApplicableforAPILevel: mediationPolicy.isApplicableforAPILevel,
-                isApplicableforOperationLevel: mediationPolicy.isApplicableforOperationLevel,
-                policyAttributes: mediationPolicy.policyAttributes
-
-            };
+            MediationPolicyData policyItem = convertPolicyModeltoPolicy(mediationPolicy);
             mediationPolicyList.push(policyItem);
-            
+
         } on fail var e {
             return error("Error occured while getting Mediation policy list", e, message = "Internal Server Error", code = 909000, description = "Internal Server Error", statusCode = 500);
         }

--- a/runtime/runtime-domain-service/ballerina/APIClient.bal
+++ b/runtime/runtime-domain-service/ballerina/APIClient.bal
@@ -2651,6 +2651,37 @@ public class APIClient {
 
     }
 
+    //Get Mediation policies by mediationPolicyId.
+    public isolated function getMediationPolicyById(string id, commons:Organization organization) returns MediationPolicyData|NotFoundError|commons:APKError {
+        boolean mediationPolicyIDAvailable = id.length() > 0 ? true : false;
+        if (mediationPolicyIDAvailable && string:length(id.toString()) > 0)
+        {
+            lock {
+                foreach model:MediationPolicy mediationPolicy in avilableMediationPolicyList {
+                    if mediationPolicy.id == id {
+                         MediationPolicyData matchedPolicy = {
+                            id: mediationPolicy.id,
+                            'type: mediationPolicy.'type,
+                            name: mediationPolicy.name,
+                            displayName: mediationPolicy.displayName,
+                            description: mediationPolicy.description,
+                            applicableFlows: mediationPolicy.applicableFlows,
+                            supportedApiTypes: mediationPolicy.supportedApiTypes,
+                            isApplicableforAPILevel: mediationPolicy.isApplicableforAPILevel,
+                            isApplicableforOperationLevel: mediationPolicy.isApplicableforOperationLevel,
+                            policyAttributes: mediationPolicy.policyAttributes
+                        };
+                        return matchedPolicy.cloneReadOnly();
+                    }
+                }
+            } on fail var e {
+                return error("Error while retrieving Mediation policy", e, message = "Error while retrieving Mediation policy", description = "Error while retrieving Mediation policy", code = 909000, statusCode = 500);
+            }
+        }
+        NotFoundError notfound = {body: {code: 909100, message: id + " not found."}};
+        return notfound;
+    }
+
     # This returns list of Mediation Policies.
     #
     # + query - Search Query

--- a/runtime/runtime-domain-service/ballerina/APIMapping.bal
+++ b/runtime/runtime-domain-service/ballerina/APIMapping.bal
@@ -90,3 +90,20 @@ isolated function convertOperationPolicies(model:OperationPolicies? operation) r
         return ();
     }
 }
+
+isolated function convertPolicyModeltoPolicy(model:MediationPolicy mediationPolicy) returns MediationPolicyData {
+    MediationPolicyData mediationPolicyData = {
+        id: mediationPolicy.id,
+        'type: mediationPolicy.'type,
+        name: mediationPolicy.name,
+        displayName: mediationPolicy.displayName,
+        description: mediationPolicy.description,
+        applicableFlows: mediationPolicy.applicableFlows,
+        supportedApiTypes: mediationPolicy.supportedApiTypes,
+        canApplyforAPILevel: mediationPolicy.canApplyforAPILevel,
+        canApplyforOperationLevel: mediationPolicy.canApplyforOperationLevel,
+        policyAttributes: mediationPolicy.policyAttributes
+
+    };
+    return mediationPolicyData;
+}

--- a/runtime/runtime-domain-service/ballerina/APIMapping.bal
+++ b/runtime/runtime-domain-service/ballerina/APIMapping.bal
@@ -91,8 +91,8 @@ isolated function convertOperationPolicies(model:OperationPolicies? operation) r
     }
 }
 
-isolated function convertPolicyModeltoPolicy(model:MediationPolicy mediationPolicy) returns MediationPolicyData {
-    MediationPolicyData mediationPolicyData = {
+isolated function convertPolicyModeltoPolicy(model:MediationPolicy mediationPolicy) returns MediationPolicy {
+    MediationPolicy mediationPolicyData = {
         id: mediationPolicy.id,
         'type: mediationPolicy.'type,
         name: mediationPolicy.name,
@@ -100,8 +100,6 @@ isolated function convertPolicyModeltoPolicy(model:MediationPolicy mediationPoli
         description: mediationPolicy.description,
         applicableFlows: mediationPolicy.applicableFlows,
         supportedApiTypes: mediationPolicy.supportedApiTypes,
-        canApplyforAPILevel: mediationPolicy.canApplyforAPILevel,
-        canApplyforOperationLevel: mediationPolicy.canApplyforOperationLevel,
         policyAttributes: mediationPolicy.policyAttributes
 
     };

--- a/runtime/runtime-domain-service/ballerina/MediationPolicyList.bal
+++ b/runtime/runtime-domain-service/ballerina/MediationPolicyList.bal
@@ -21,13 +21,11 @@ isolated final model:MediationPolicy[] avilableMediationPolicyList = [
     {
         id: "1",
         'type: MEDIATION_POLICY_TYPE_REQUEST_HEADER_MODIFIER,
-        name: "addHeader",
+        name: MEDIATION_POLICY_NAME_ADD_HEADER,
         displayName: "Add Header",
         description: "This policy allows you to add a new header to the request",
         applicableFlows: [MEDIATION_POLICY_FLOW_REQUEST],
         supportedApiTypes: [API_TYPE_REST],
-        canApplyforAPILevel: true,
-        canApplyforOperationLevel: true,
         policyAttributes: [
             {
                 name: "headerName",
@@ -48,13 +46,11 @@ isolated final model:MediationPolicy[] avilableMediationPolicyList = [
     {
         id: "2",
         'type: MEDIATION_POLICY_TYPE_REQUEST_HEADER_MODIFIER,
-        name: "removeHeader",
+        name: MEDIATION_POLICY_NAME_REMOVE_HEADER,
         displayName: "Remove Header",
         description: "This policy allows you to remove a header from the request",
         applicableFlows: [MEDIATION_POLICY_FLOW_REQUEST],
         supportedApiTypes: [API_TYPE_REST],
-        canApplyforAPILevel: true,
-        canApplyforOperationLevel: true,
         policyAttributes: [
             {
                 name: "headerName",
@@ -68,13 +64,11 @@ isolated final model:MediationPolicy[] avilableMediationPolicyList = [
     {
         id: "3",
         'type: MEDIATION_POLICY_TYPE_RESPONSE_HEADER_MODIFIER,
-        name: "addHeader",
+        name: MEDIATION_POLICY_NAME_ADD_HEADER,
         displayName: "Add Header",
         description: "This policy allows you to add a new header to the response",
         applicableFlows: [MEDIATION_POLICY_FLOW_RESPONSE],
         supportedApiTypes: [API_TYPE_REST],
-        canApplyforAPILevel: true,
-        canApplyforOperationLevel: true,
         policyAttributes: [
             {
                 name: "headerName",
@@ -95,13 +89,11 @@ isolated final model:MediationPolicy[] avilableMediationPolicyList = [
     {
         id: "4",
         'type: MEDIATION_POLICY_TYPE_RESPONSE_HEADER_MODIFIER,
-        name: "removeHeader",
+        name: MEDIATION_POLICY_NAME_REMOVE_HEADER,
         displayName: "Remove Header",
         description: "This policy allows you to remove a header from the response",
         applicableFlows: [MEDIATION_POLICY_FLOW_RESPONSE],
         supportedApiTypes: [API_TYPE_REST],
-        canApplyforAPILevel: true,
-        canApplyforOperationLevel: true,
         policyAttributes: [
             {
                 name: "headerName",

--- a/runtime/runtime-domain-service/ballerina/MediationPolicyList.bal
+++ b/runtime/runtime-domain-service/ballerina/MediationPolicyList.bal
@@ -17,13 +17,6 @@
 //
 import runtime_domain_service.model;
 
-
-
-enum PolicyFlows {
-    request,
-    response
-}
-
 isolated final model:MediationPolicy[] avilableMediationPolicyList = [
     {
         id: "1",
@@ -31,10 +24,10 @@ isolated final model:MediationPolicy[] avilableMediationPolicyList = [
         name: "addHeader",
         displayName: "Add Header",
         description: "This policy allows you to add a new header to the request",
-        applicableFlows: [request],
+        applicableFlows: [MEDIATION_POLICY_FLOW_REQUEST],
         supportedApiTypes: [API_TYPE_REST],
-        isApplicableforAPILevel: true,
-        isApplicableforOperationLevel: true,
+        canApplyforAPILevel: true,
+        canApplyforOperationLevel: true,
         policyAttributes: [
             {
                 name: "headerName",
@@ -58,10 +51,10 @@ isolated final model:MediationPolicy[] avilableMediationPolicyList = [
         name: "removeHeader",
         displayName: "Remove Header",
         description: "This policy allows you to remove a header from the request",
-        applicableFlows: [request],
+        applicableFlows: [MEDIATION_POLICY_FLOW_REQUEST],
         supportedApiTypes: [API_TYPE_REST],
-        isApplicableforAPILevel: true,
-        isApplicableforOperationLevel: true,
+        canApplyforAPILevel: true,
+        canApplyforOperationLevel: true,
         policyAttributes: [
             {
                 name: "headerName",
@@ -78,10 +71,10 @@ isolated final model:MediationPolicy[] avilableMediationPolicyList = [
         name: "addHeader",
         displayName: "Add Header",
         description: "This policy allows you to add a new header to the response",
-        applicableFlows: [response],
+        applicableFlows: [MEDIATION_POLICY_FLOW_RESPONSE],
         supportedApiTypes: [API_TYPE_REST],
-        isApplicableforAPILevel: true,
-        isApplicableforOperationLevel: true,
+        canApplyforAPILevel: true,
+        canApplyforOperationLevel: true,
         policyAttributes: [
             {
                 name: "headerName",
@@ -105,10 +98,10 @@ isolated final model:MediationPolicy[] avilableMediationPolicyList = [
         name: "removeHeader",
         displayName: "Remove Header",
         description: "This policy allows you to remove a header from the response",
-        applicableFlows: [response],
+        applicableFlows: [MEDIATION_POLICY_FLOW_RESPONSE],
         supportedApiTypes: [API_TYPE_REST],
-        isApplicableforAPILevel: true,
-        isApplicableforOperationLevel: true,
+        canApplyforAPILevel: true,
+        canApplyforOperationLevel: true,
         policyAttributes: [
             {
                 name: "headerName",

--- a/runtime/runtime-domain-service/ballerina/MediationPolicyList.bal
+++ b/runtime/runtime-domain-service/ballerina/MediationPolicyList.bal
@@ -1,0 +1,76 @@
+//
+// Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+import runtime_domain_service.model;
+
+
+
+enum PolicyFlows {
+    request,
+    response
+}
+
+
+isolated model:MediationPolicy[] avilableMediationPolicyList = [
+    {
+        id: "1",
+        'type: MEDIATION_POLICY_TYPE_REQUEST_HEADER_MODIFIER,
+        name: "addHeader",
+        displayName: "Add Header",
+        description: "This policy allows you to add a new header to the request",
+        applicableFlows: [request],
+        supportedApiTypes: [API_TYPE_REST],
+        isApplicableforAPILevel: true,
+        isApplicableforOperationLevel: true,
+        policyAttributes: [
+            {
+                name: "headerName",
+                description: "Name of the header to be added",
+                'type: "String",
+                required: true,
+                validationRegex: "^([a-zA-Z_][a-zA-Z\\d_\\-\\ ]*)$"
+            },
+            {
+                name: "headerValue",
+                description: "Value of the header",
+                'type: "String",
+                required: true,
+                validationRegex: "^([a-zA-Z_][a-zA-Z\\d_\\-\\ ]*)$"
+            }
+        ]
+    },
+        {
+        id: "2",
+        'type: MEDIATION_POLICY_TYPE_REQUEST_HEADER_MODIFIER,
+        name: "removeHeader",
+        displayName: "Remove Header",
+        description: "This policy allows you to remove a header from the request",
+        applicableFlows: [request],
+        supportedApiTypes: [API_TYPE_REST],
+        isApplicableforAPILevel: true,
+        isApplicableforOperationLevel: true,
+        policyAttributes: [
+            {
+                name: "headerName",
+                description: "Name of the header to be removed",
+                'type: "String",
+                required: true,
+                validationRegex: "^([a-zA-Z_][a-zA-Z\\d_\\-\\ ]*)$"
+            }
+        ]
+    }
+];

--- a/runtime/runtime-domain-service/ballerina/MediationPolicyList.bal
+++ b/runtime/runtime-domain-service/ballerina/MediationPolicyList.bal
@@ -15,7 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 //
-import runtime_domain_service.model;
+import runtime_domain_service.model as model;
+import wso2/apk_common_lib as commons;
 
 isolated final model:MediationPolicy[] avilableMediationPolicyList = [
     {
@@ -105,3 +106,14 @@ isolated final model:MediationPolicy[] avilableMediationPolicyList = [
         ]
     }
 ];
+
+isolated function getAvailableMediaionPolicies(commons:Organization organization) returns MediationPolicy[] {
+    lock {
+        MediationPolicy[]|error & readonly readOnlyMediationPolicyList = trap avilableMediationPolicyList.cloneReadOnly();
+        if readOnlyMediationPolicyList is MediationPolicy[] & readonly {
+            return readOnlyMediationPolicyList;
+        } else {
+            return [];
+        }
+    }
+}

--- a/runtime/runtime-domain-service/ballerina/MediationPolicyList.bal
+++ b/runtime/runtime-domain-service/ballerina/MediationPolicyList.bal
@@ -24,8 +24,7 @@ enum PolicyFlows {
     response
 }
 
-
-isolated model:MediationPolicy[] avilableMediationPolicyList = [
+isolated final model:MediationPolicy[] avilableMediationPolicyList = [
     {
         id: "1",
         'type: MEDIATION_POLICY_TYPE_REQUEST_HEADER_MODIFIER,
@@ -53,13 +52,60 @@ isolated model:MediationPolicy[] avilableMediationPolicyList = [
             }
         ]
     },
-        {
+    {
         id: "2",
         'type: MEDIATION_POLICY_TYPE_REQUEST_HEADER_MODIFIER,
         name: "removeHeader",
         displayName: "Remove Header",
         description: "This policy allows you to remove a header from the request",
         applicableFlows: [request],
+        supportedApiTypes: [API_TYPE_REST],
+        isApplicableforAPILevel: true,
+        isApplicableforOperationLevel: true,
+        policyAttributes: [
+            {
+                name: "headerName",
+                description: "Name of the header to be removed",
+                'type: "String",
+                required: true,
+                validationRegex: "^([a-zA-Z_][a-zA-Z\\d_\\-\\ ]*)$"
+            }
+        ]
+    },
+    {
+        id: "3",
+        'type: MEDIATION_POLICY_TYPE_RESPONSE_HEADER_MODIFIER,
+        name: "addHeader",
+        displayName: "Add Header",
+        description: "This policy allows you to add a new header to the response",
+        applicableFlows: [response],
+        supportedApiTypes: [API_TYPE_REST],
+        isApplicableforAPILevel: true,
+        isApplicableforOperationLevel: true,
+        policyAttributes: [
+            {
+                name: "headerName",
+                description: "Name of the header to be added",
+                'type: "String",
+                required: true,
+                validationRegex: "^([a-zA-Z_][a-zA-Z\\d_\\-\\ ]*)$"
+            },
+            {
+                name: "headerValue",
+                description: "Value of the header",
+                'type: "String",
+                required: true,
+                validationRegex: "^([a-zA-Z_][a-zA-Z\\d_\\-\\ ]*)$"
+            }
+        ]
+    },
+    {
+        id: "4",
+        'type: MEDIATION_POLICY_TYPE_RESPONSE_HEADER_MODIFIER,
+        name: "removeHeader",
+        displayName: "Remove Header",
+        description: "This policy allows you to remove a header from the response",
+        applicableFlows: [response],
         supportedApiTypes: [API_TYPE_REST],
         isApplicableforAPILevel: true,
         isApplicableforOperationLevel: true,

--- a/runtime/runtime-domain-service/ballerina/api_service.bal
+++ b/runtime/runtime-domain-service/ballerina/api_service.bal
@@ -129,9 +129,11 @@ http:Service runtimeService = service object {
         commons:Organization organization = authenticatedUserContext.organization;
         return serviceClient.getServiceUsageByServiceId(serviceId, organization);
     }
-    isolated resource function get policies(string? query, int 'limit = 25, int offset = 0, string sortBy = "createdTime", string sortOrder = "desc", @http:Header string? accept = "application/json") returns MediationPolicyList|InternalServerErrorError {
-        InternalServerErrorError internalError = {body: {code: 900910, message: "Not implemented"}};
-        return internalError;
+    isolated resource function get policies(http:RequestContext requestContext, string? query, int 'limit = 25, int offset = 0, string sortBy = "createdTime", string sortOrder = "desc", @http:Header string? accept = "application/json") returns MediationPolicyDataList|BadRequestError|NotFoundError|InternalServerErrorError|commons:APKError {
+        final APIClient apiService = new ();
+        commons:UserContext authenticatedUserContext = check commons:getAuthenticatedUserContext(requestContext);
+        commons:Organization organization = authenticatedUserContext.organization;
+        return apiService.getMediationPolicyList(query, 'limit, offset, sortBy, sortOrder, organization);
     }
     isolated resource function get policies/[string policyId]() returns MediationPolicy|NotFoundError|InternalServerErrorError {
         InternalServerErrorError internalError = {body: {code: 900910, message: "Not implemented"}};

--- a/runtime/runtime-domain-service/ballerina/api_service.bal
+++ b/runtime/runtime-domain-service/ballerina/api_service.bal
@@ -129,7 +129,7 @@ http:Service runtimeService = service object {
         commons:Organization organization = authenticatedUserContext.organization;
         return serviceClient.getServiceUsageByServiceId(serviceId, organization);
     }
-    isolated resource function get policies(http:RequestContext requestContext, string? query, int 'limit = 25, int offset = 0, string sortBy = "createdTime", string sortOrder = "desc", @http:Header string? accept = "application/json") returns MediationPolicyDataList|BadRequestError|NotFoundError|InternalServerErrorError|commons:APKError {
+    isolated resource function get policies(http:RequestContext requestContext, string? query, int 'limit = 25, int offset = 0, string sortBy = "id", string sortOrder = "asc", @http:Header string? accept = "application/json") returns MediationPolicyDataList|BadRequestError|NotFoundError|InternalServerErrorError|commons:APKError {
         final APIClient apiService = new ();
         commons:UserContext authenticatedUserContext = check commons:getAuthenticatedUserContext(requestContext);
         commons:Organization organization = authenticatedUserContext.organization;

--- a/runtime/runtime-domain-service/ballerina/api_service.bal
+++ b/runtime/runtime-domain-service/ballerina/api_service.bal
@@ -135,8 +135,10 @@ http:Service runtimeService = service object {
         commons:Organization organization = authenticatedUserContext.organization;
         return apiService.getMediationPolicyList(query, 'limit, offset, sortBy, sortOrder, organization);
     }
-    isolated resource function get policies/[string policyId]() returns MediationPolicy|NotFoundError|InternalServerErrorError {
-        InternalServerErrorError internalError = {body: {code: 900910, message: "Not implemented"}};
-        return internalError;
+    isolated resource function get policies/[string policyId](http:RequestContext requestContext) returns MediationPolicyData|NotFoundError|InternalServerErrorError|commons:APKError {
+        final APIClient apiService = new ();
+        commons:UserContext authenticatedUserContext = check commons:getAuthenticatedUserContext(requestContext);
+        commons:Organization organization = authenticatedUserContext.organization;
+        return apiService.getMediationPolicyById(policyId, organization);
     }
 };

--- a/runtime/runtime-domain-service/ballerina/api_service.bal
+++ b/runtime/runtime-domain-service/ballerina/api_service.bal
@@ -129,13 +129,13 @@ http:Service runtimeService = service object {
         commons:Organization organization = authenticatedUserContext.organization;
         return serviceClient.getServiceUsageByServiceId(serviceId, organization);
     }
-    isolated resource function get policies(http:RequestContext requestContext, string? query, int 'limit = 25, int offset = 0, string sortBy = "id", string sortOrder = "asc", @http:Header string? accept = "application/json") returns MediationPolicyDataList|BadRequestError|NotFoundError|InternalServerErrorError|commons:APKError {
+    isolated resource function get policies(http:RequestContext requestContext, string? query, int 'limit = 25, int offset = 0, string sortBy = "id", string sortOrder = "asc", @http:Header string? accept = "application/json") returns MediationPolicyList|BadRequestError|NotFoundError|InternalServerErrorError|commons:APKError {
         final APIClient apiService = new ();
         commons:UserContext authenticatedUserContext = check commons:getAuthenticatedUserContext(requestContext);
         commons:Organization organization = authenticatedUserContext.organization;
         return apiService.getMediationPolicyList(query, 'limit, offset, sortBy, sortOrder, organization);
     }
-    isolated resource function get policies/[string policyId](http:RequestContext requestContext) returns MediationPolicyData|NotFoundError|InternalServerErrorError|commons:APKError {
+    isolated resource function get policies/[string policyId](http:RequestContext requestContext) returns MediationPolicy|NotFoundError|InternalServerErrorError|commons:APKError {
         final APIClient apiService = new ();
         commons:UserContext authenticatedUserContext = check commons:getAuthenticatedUserContext(requestContext);
         commons:Organization organization = authenticatedUserContext.organization;

--- a/runtime/runtime-domain-service/ballerina/constants.bal
+++ b/runtime/runtime-domain-service/ballerina/constants.bal
@@ -39,6 +39,8 @@ isolated string[] ALLOWED_API_TYPES = [API_TYPE_REST];
 
 const string MEDIATION_POLICY_TYPE_REQUEST_HEADER_MODIFIER = "RequestHeaderModifier";
 const string MEDIATION_POLICY_TYPE_RESPONSE_HEADER_MODIFIER = "ResponseHeaderModifier";
+const string MEDIATION_POLICY_NAME_ADD_HEADER = "addHeader";
+const string MEDIATION_POLICY_NAME_REMOVE_HEADER = "removeHeader";
 const string MEDIATION_POLICY_TYPE_URL_REWRITE = "URLRewrite";
 const string MEDIATION_POLICY_FLOW_REQUEST  = "request";
 const string MEDIATION_POLICY_FLOW_RESPONSE  = "response";

--- a/runtime/runtime-domain-service/ballerina/constants.bal
+++ b/runtime/runtime-domain-service/ballerina/constants.bal
@@ -41,5 +41,5 @@ const string MEDIATION_POLICY_TYPE_REQUEST_HEADER_MODIFIER = "RequestHeaderModif
 const string MEDIATION_POLICY_TYPE_RESPONSE_HEADER_MODIFIER = "ResponseHeaderModifier";
 const string MEDIATION_POLICY_TYPE_URL_REWRITE = "URLRewrite";
 const string MEDIATION_POLICY_FLOW_REQUEST  = "request";
-const string MEDIATION_POLICY_FLOW_RESPONSET  = "response";
+const string MEDIATION_POLICY_FLOW_RESPONSE  = "response";
 

--- a/runtime/runtime-domain-service/ballerina/constants.bal
+++ b/runtime/runtime-domain-service/ballerina/constants.bal
@@ -34,3 +34,10 @@ const string ZIP_FILE_EXTENSTION = ".zip";
 const string PROTOCOL_HTTP = "http";
 const string PROTOCOL_HTTPS = "https";
 isolated string[] ALLOWED_API_TYPES = [API_TYPE_REST];
+
+const string MEDIATION_POLICY_TYPE_REQUEST_HEADER_MODIFIER = "RequestHeaderModifier";
+const string MEDIATION_POLICY_TYPE_RESPONSE_HEADER_MODIFIER = "ResponseHeaderModifier";
+const string MEDIATION_POLICY_TYPE_URL_REWRITE = "URLRewrite";
+const string MEDIATION_POLICY_FLOW_REQUEST  = "request";
+const string MEDIATION_POLICY_FLOW_RESPONSET  = "response";
+

--- a/runtime/runtime-domain-service/ballerina/constants.bal
+++ b/runtime/runtime-domain-service/ballerina/constants.bal
@@ -17,6 +17,8 @@ const string APK_USER = "apkuser";
 const string CURRENT_NAMESPACE = "CURRENT_NAME_SPACE";
 
 const string SORT_BY_API_NAME = "apiName";
+const string SORT_BY_POLICY_NAME = "policyName";
+const string SORT_BY_ID = "id";
 const string SORT_BY_CREATED_TIME = "createdTime";
 const string SORT_ORDER_ASC = "asc";
 const string SORT_ORDER_DESC = "desc";

--- a/runtime/runtime-domain-service/ballerina/modules/model/RuntimeAPI.bal
+++ b/runtime/runtime-domain-service/ballerina/modules/model/RuntimeAPI.bal
@@ -36,8 +36,8 @@ public type OperationPolicy record {
 };
 
 public type MediationPolicy record {
+    string id;
     string 'type;
-    string id?;
     string name;
     string displayName?;
     string description?;

--- a/runtime/runtime-domain-service/ballerina/modules/model/RuntimeAPI.bal
+++ b/runtime/runtime-domain-service/ballerina/modules/model/RuntimeAPI.bal
@@ -43,23 +43,15 @@ public type MediationPolicy record {
     string description?;
     string[] applicableFlows?;
     string[] supportedApiTypes?;
-    boolean canApplyforAPILevel?;
-    boolean canApplyforOperationLevel?;
     MediationPolicySpecAttribute[] policyAttributes?;
 };
 
 public type MediationPolicySpecAttribute record {
-    # Name of the attibute
     string name?;
-    # Description of the attibute
     string description?;
-    # Is this option mandetory for the policy
     boolean required?;
-    # UI validation regex for the attibute
     string validationRegex?;
-    # Type of the attibute
     string 'type?;
-    # Default value for the attribute
     string defaultValue?;
 };
 

--- a/runtime/runtime-domain-service/ballerina/modules/model/RuntimeAPI.bal
+++ b/runtime/runtime-domain-service/ballerina/modules/model/RuntimeAPI.bal
@@ -35,6 +35,34 @@ public type OperationPolicy record {
     map<string> parameters?;
 };
 
+public type MediationPolicy record {
+    string 'type?;
+    string id?;
+    string name?;
+    string displayName?;
+    string description?;
+    string[] applicableFlows?;
+    string[] supportedApiTypes?;
+    boolean isApplicableforAPILevel?;
+    boolean isApplicableforOperationLevel?;
+    MediationPolicySpecAttribute[] policyAttributes?;
+};
+
+public type MediationPolicySpecAttribute record {
+    # Name of the attibute
+    string name?;
+    # Description of the attibute
+    string description?;
+    # Is this option mandetory for the policy
+    boolean required?;
+    # UI validation regex for the attibute
+    string validationRegex?;
+    # Type of the attibute
+    string 'type?;
+    # Default value for the attribute
+    string defaultValue?;
+};
+
 public type OperationPolicies record {|
     OperationPolicy[] request = [];
     OperationPolicy[] response=[];

--- a/runtime/runtime-domain-service/ballerina/modules/model/RuntimeAPI.bal
+++ b/runtime/runtime-domain-service/ballerina/modules/model/RuntimeAPI.bal
@@ -43,8 +43,8 @@ public type MediationPolicy record {
     string description?;
     string[] applicableFlows?;
     string[] supportedApiTypes?;
-    boolean isApplicableforAPILevel?;
-    boolean isApplicableforOperationLevel?;
+    boolean canApplyforAPILevel?;
+    boolean canApplyforOperationLevel?;
     MediationPolicySpecAttribute[] policyAttributes?;
 };
 

--- a/runtime/runtime-domain-service/ballerina/modules/model/RuntimeAPI.bal
+++ b/runtime/runtime-domain-service/ballerina/modules/model/RuntimeAPI.bal
@@ -36,9 +36,9 @@ public type OperationPolicy record {
 };
 
 public type MediationPolicy record {
-    string 'type?;
+    string 'type;
     string id?;
-    string name?;
+    string name;
     string displayName?;
     string description?;
     string[] applicableFlows?;

--- a/runtime/runtime-domain-service/ballerina/resources/api.yaml
+++ b/runtime/runtime-domain-service/ballerina/resources/api.yaml
@@ -974,7 +974,7 @@ paths:
         This operation can be used to retrieve a particular common mediation policy.
       operationId: getMediationPolicyByPolicyId
       parameters:
-        - name: mediationPolicyId
+        - name: policyId
           in: path
           description: Mediation policy Id
           required: true
@@ -1271,10 +1271,10 @@ components:
           items:
             type: string
             example: REST
-        isApplicableforAPILevel:
+        canApplyforAPILevel:
           type: boolean
           example: true
-        isApplicableforOperationLevel:
+        canApplyforOperationLevel:
           type: boolean
           example: true
         policyAttributes:

--- a/runtime/runtime-domain-service/ballerina/resources/api.yaml
+++ b/runtime/runtime-domain-service/ballerina/resources/api.yaml
@@ -1241,16 +1241,17 @@ components:
     MediationPolicyData:
       title: Mediation Policy Data
       required:
+        - id
         - name
         - type
       type: object
       properties:
-        type:
-          type: string
-          example: RequestHeaderModifier
         id:
           type: string
           example: 1
+        type:
+          type: string
+          example: RequestHeaderModifier
         name:
           type: string
           example: addHeader

--- a/runtime/runtime-domain-service/ballerina/resources/api.yaml
+++ b/runtime/runtime-domain-service/ballerina/resources/api.yaml
@@ -875,12 +875,12 @@ paths:
   /policies:
     get:
       tags:
-        - Operation Policies
+        - Mediation Policies
       summary: |
-        Get all common operation policies to all the APIs
+        Get all common meiation policies to all the APIs
       description: |
         This operation provides you a list of available operation Policies that can be used by any API
-      operationId: getAllCommonOperationPolicies
+      operationId: getMediationPolicyList
       parameters:
         - name: limit
           in: query
@@ -946,7 +946,7 @@ paths:
             type: string
             default: application/json
       responses:
-        200:
+        "200":
           description: |
             OK.
             List of qualifying policies is returned.
@@ -969,12 +969,12 @@ paths:
     get:
       tags:
         - Mediation Policies
-      summary: Get the details of a common operation policy by providing policy ID
+      summary: Get the details of a common mediation policy by providing mediation policy ID
       description: |
-        This operation can be used to retrieve a particular common operation policy.
-      operationId: getCommonOperationPolicyByPolicyId
+        This operation can be used to retrieve a particular common mediation policy.
+      operationId: getMediationPolicyByPolicyId
       parameters:
-        - name: policyId
+        - name: mediationPolicyId
           in: path
           description: Mediation policy Id
           required: true
@@ -983,7 +983,7 @@ paths:
           schema:
             type: string
       responses:
-        200:
+        "200":
           description: |
             OK.
             Mediation policy returned.
@@ -1230,7 +1230,7 @@ components:
         count:
           type: integer
           description: |
-            Number of operation policies returned.
+            Number of mediation policies returned.
           example: 1
         list:
           type: array
@@ -1240,6 +1240,9 @@ components:
           $ref: '#/components/schemas/Pagination'
     MediationPolicyData:
       title: Mediation Policy Data
+      required:
+        - name
+        - type
       type: object
       properties:
         type:

--- a/runtime/runtime-domain-service/ballerina/resources/api.yaml
+++ b/runtime/runtime-domain-service/ballerina/resources/api.yaml
@@ -958,7 +958,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MediationPolicyDataList'
+                $ref: '#/components/schemas/MediationPolicyList'
         "400":
           $ref: "#/components/responses/BadRequest"
         "404":
@@ -996,7 +996,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MediationPolicyData'
+                $ref: '#/components/schemas/MediationPolicy'
         "404":
           $ref: "#/components/responses/NotFound"
         "500":
@@ -1223,8 +1223,8 @@ components:
           example: admin--HackerNewsAPI.graphql
         schemaDefinition:
           type: string
-    MediationPolicyDataList:
-      title: Mediation policy List
+    MediationPolicyList:
+      title: Paginated List of Policies
       type: object
       properties:
         count:
@@ -1235,10 +1235,10 @@ components:
         list:
           type: array
           items:
-            $ref: '#/components/schemas/MediationPolicyData'
+            $ref: '#/components/schemas/MediationPolicy'
         pagination:
           $ref: '#/components/schemas/Pagination'
-    MediationPolicyData:
+    MediationPolicy:
       title: Mediation Policy Data
       required:
         - id
@@ -1271,18 +1271,12 @@ components:
           items:
             type: string
             example: REST
-        canApplyforAPILevel:
-          type: boolean
-          example: true
-        canApplyforOperationLevel:
-          type: boolean
-          example: true
         policyAttributes:
           type: array
           items:
             $ref: '#/components/schemas/MediationPolicySpecAttribute'
     MediationPolicySpecAttribute:
-      title: MediationPolicySpecAttribute
+      title: Mediation Policy Attribute Specs
       type: object
       properties:
         name:
@@ -1308,29 +1302,6 @@ components:
           type: string
           description: Default value for the attribute
           example: true
-    MediationPolicyList:
-      title: Paginated List of Policies
-      type: object
-      properties:
-        list:
-          title: List of Policies
-          type: array
-          items:
-            $ref: "#/components/schemas/MediationPolicy"
-        pagination:
-          $ref: "#/components/schemas/Pagination"
-    MediationPolicy:
-      title: Mediation Policy
-      required:
-        - name
-      type: object
-      properties:
-        name:
-          type: string
-          example: log_in_message
-        type:
-          type: string
-          example: in
     Error:
       title: Error object returned with 4XX HTTP Status
       required:

--- a/runtime/runtime-domain-service/ballerina/resources/api.yaml
+++ b/runtime/runtime-domain-service/ballerina/resources/api.yaml
@@ -875,12 +875,12 @@ paths:
   /policies:
     get:
       tags:
-        - Policies
+        - Operation Policies
       summary: |
-        Retrieve/Search Policies
+        Get all common operation policies to all the APIs
       description: |
-        This operation provides you a list of available Policies
-      operationId: getAllPolicies
+        This operation provides you a list of available operation Policies that can be used by any API
+      operationId: getAllCommonOperationPolicies
       parameters:
         - name: limit
           in: query
@@ -946,57 +946,57 @@ paths:
             type: string
             default: application/json
       responses:
-        "200":
+        200:
           description: |
             OK.
-            List of Policies is returned.
+            List of qualifying policies is returned.
           headers:
             Content-Type:
               description: The content type of the body.
-              style: simple
-              explode: false
               schema:
                 type: string
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/MediationPolicyList"
+                $ref: '#/components/schemas/MediationPolicyDataList'
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
         "500":
           $ref: "#/components/responses/InternalServerError"
   /policies/{policyId}:
     get:
       tags:
-        - Policies
-      summary: Get Details of a Policy
+        - Mediation Policies
+      summary: Get the details of a common operation policy by providing policy ID
       description: |
-        Using this operation, you can retrieve complete details of a single Policy. You need to provide the Id of the Policy to retrive it.
-      operationId: getPolicy
+        This operation can be used to retrieve a particular common operation policy.
+      operationId: getCommonOperationPolicyByPolicyId
       parameters:
         - name: policyId
           in: path
-          description: name of the gateway
+          description: Mediation policy Id
           required: true
           style: simple
           explode: false
           schema:
             type: string
       responses:
-        "200":
+        200:
           description: |
             OK.
-            Requested Policy is returned
+            Mediation policy returned.
           headers:
             Content-Type:
               description: |
                 The content type of the body.
-              style: simple
-              explode: false
               schema:
                 type: string
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/MediationPolicy"
+                $ref: '#/components/schemas/MediationPolicyData'
         "404":
           $ref: "#/components/responses/NotFound"
         "500":
@@ -1223,6 +1223,87 @@ components:
           example: admin--HackerNewsAPI.graphql
         schemaDefinition:
           type: string
+    MediationPolicyDataList:
+      title: Mediation policy List
+      type: object
+      properties:
+        count:
+          type: integer
+          description: |
+            Number of operation policies returned.
+          example: 1
+        list:
+          type: array
+          items:
+            $ref: '#/components/schemas/MediationPolicyData'
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+    MediationPolicyData:
+      title: Mediation Policy Data
+      type: object
+      properties:
+        type:
+          type: string
+          example: RequestHeaderModifier
+        id:
+          type: string
+          example: 1
+        name:
+          type: string
+          example: addHeader
+        displayName:
+          type: string
+          example: Add Header
+        description:
+          type: string
+          example: With this policy, user can add a new header to the request
+        applicableFlows:
+          type: array
+          items:
+            type: string
+            example: request
+        supportedApiTypes:
+          type: array
+          items:
+            type: string
+            example: REST
+        isApplicableforAPILevel:
+          type: boolean
+          example: true
+        isApplicableforOperationLevel:
+          type: boolean
+          example: true
+        policyAttributes:
+          type: array
+          items:
+            $ref: '#/components/schemas/MediationPolicySpecAttribute'
+    MediationPolicySpecAttribute:
+      title: MediationPolicySpecAttribute
+      type: object
+      properties:
+        name:
+          type: string
+          description: Name of the attibute
+          example: headerName
+        description:
+          type: string
+          description: Description of the attibute
+          example:  Name of the header to be added
+        required:
+          type: boolean
+          description: Is this option mandetory for the policy
+          example: true
+        validationRegex:
+          type: string
+          description: UI validation regex for the attibute
+        type:
+          type: string
+          description: Type of the attibute
+          example: string
+        defaultValue:
+          type: string
+          description: Default value for the attribute
+          example: true
     MediationPolicyList:
       title: Paginated List of Policies
       type: object

--- a/runtime/runtime-domain-service/ballerina/tests/APIClientTest.bal
+++ b/runtime/runtime-domain-service/ballerina/tests/APIClientTest.bal
@@ -436,9 +436,9 @@ public function testgetApiById(string apiid, commons:Organization organization, 
     APIClient apiclient = new ();
     API|NotFoundError|commons:APKError aPIById = apiclient.getAPIById(apiid, organization);
     if aPIById is any {
-        test:assertEquals(aPIById.toBalString(),expectedData);
+        test:assertEquals(aPIById.toBalString(), expectedData);
     } else {
-        test:assertEquals(aPIById.toBalString(),expectedData);
+        test:assertEquals(aPIById.toBalString(), expectedData);
     }
 }
 
@@ -2798,6 +2798,888 @@ function createAPIDataProvider() returns map<[string, string, API, model:ConfigM
         ]
     };
     return data;
+}
+
+@test:Config {dataProvider: mediationPolicyByIdDataProvider}
+public function testGetMediationPolicyById(string policyId, commons:Organization organization, anydata expectedData) {
+    APIClient apiclient = new ();
+    MediationPolicy|NotFoundError|commons:APKError mediationPolicyById = apiclient.getMediationPolicyById(policyId, organization);
+    if mediationPolicyById is any {
+        test:assertEquals(mediationPolicyById.toBalString(), expectedData);
+    } else {
+        test:assertEquals(mediationPolicyById.toBalString(), expectedData);
+    }
+}
+
+public function mediationPolicyByIdDataProvider() returns map<[string, commons:Organization, anydata]> {
+    MediationPolicy & readonly mediationPolicy1 =    {
+        id: "1",
+        'type: MEDIATION_POLICY_TYPE_REQUEST_HEADER_MODIFIER,
+        name: MEDIATION_POLICY_NAME_ADD_HEADER,
+        displayName: "Add Header",
+        description: "This policy allows you to add a new header to the request",
+        applicableFlows: [MEDIATION_POLICY_FLOW_REQUEST],
+        supportedApiTypes: [API_TYPE_REST],
+        policyAttributes: [
+            {
+                name: "headerName",
+                description: "Name of the header to be added",
+                'type: "String",
+                required: true,
+                validationRegex: "^([a-zA-Z_][a-zA-Z\\d_\\-\\ ]*)$"
+            },
+            {
+                name: "headerValue",
+                description: "Value of the header",
+                'type: "String",
+                required: true,
+                validationRegex: "^([a-zA-Z_][a-zA-Z\\d_\\-\\ ]*)$"
+            }
+        ]
+    };
+    NotFoundError notfound = {body: {code: 909100, message: "6 not found."}};
+    map<[string, commons:Organization, anydata]> dataset = {
+        "1": ["1", organiztion1, mediationPolicy1.toBalString()],
+        "2": ["6", organiztion1, notfound.toBalString()]
+    };
+    return dataset;
+}
+
+@test:Config {dataProvider: getMediationPolicyListDataProvider}
+public function testGetMediationPolicyList(string? query, int 'limit, int offset, string sortBy, string sortOrder, anydata expected) {
+    APIClient apiclient = new ();
+    any|error mediationPolicyList = apiclient.getMediationPolicyList(query, 'limit, offset, sortBy, sortOrder, organiztion1);
+    if mediationPolicyList is any {
+        test:assertEquals(mediationPolicyList.toBalString(), expected);
+    } else {
+        test:assertEquals(mediationPolicyList.toBalString(), expected);
+    }
+}
+
+function getMediationPolicyListDataProvider() returns map<[string?, int, int, string, string, anydata]> {
+    BadRequestError badRequestError = {"body": {"code": 90912, "message": "Invalid Sort By/Sort Order Value "}};
+    BadRequestError badRequest = {body: {code: 90912, message: "Invalid KeyWord name1"}};
+
+    map<[string?, int, int, string, string, anydata]> dataSet = {
+        "1": [
+            (),
+            10,
+            0,
+            SORT_BY_POLICY_NAME,
+            SORT_ORDER_ASC,
+            {
+                "count": 4,
+                "list": [
+                    {
+                        "id": "1",
+                        "type": "RequestHeaderModifier",
+                        "name": "addHeader",
+                        "displayName": "Add Header",
+                        "description": "This policy allows you to add a new header to the request",
+                        "applicableFlows": [
+                            "request"
+                        ],
+                        "supportedApiTypes": [
+                            "REST"
+                        ],
+                        "policyAttributes": [
+                            {
+                                "name": "headerName",
+                                "description": "Name of the header to be added",
+                                "required": true,
+                                "validationRegex": "^([a-zA-Z_][a-zA-Z\\d_\\-\\ ]*)$",
+                                "type": "String"
+                            },
+                            {
+                                "name": "headerValue",
+                                "description": "Value of the header",
+                                "required": true,
+                                "validationRegex": "^([a-zA-Z_][a-zA-Z\\d_\\-\\ ]*)$",
+                                "type": "String"
+                            }
+                        ]
+                    },
+                    {
+                        "id": "3",
+                        "type": "ResponseHeaderModifier",
+                        "name": "addHeader",
+                        "displayName": "Add Header",
+                        "description": "This policy allows you to add a new header to the response",
+                        "applicableFlows": [
+                            "response"
+                        ],
+                        "supportedApiTypes": [
+                            "REST"
+                        ],
+                        "policyAttributes": [
+                            {
+                                "name": "headerName",
+                                "description": "Name of the header to be added",
+                                "required": true,
+                                "validationRegex": "^([a-zA-Z_][a-zA-Z\\d_\\-\\ ]*)$",
+                                "type": "String"
+                            },
+                            {
+                                "name": "headerValue",
+                                "description": "Value of the header",
+                                "required": true,
+                                "validationRegex": "^([a-zA-Z_][a-zA-Z\\d_\\-\\ ]*)$",
+                                "type": "String"
+                            }
+                        ]
+                    },
+                    {
+                        "id": "2",
+                        "type": "RequestHeaderModifier",
+                        "name": "removeHeader",
+                        "displayName": "Remove Header",
+                        "description": "This policy allows you to remove a header from the request",
+                        "applicableFlows": [
+                            "request"
+                        ],
+                        "supportedApiTypes": [
+                            "REST"
+                        ],
+                        "policyAttributes": [
+                            {
+                                "name": "headerName",
+                                "description": "Name of the header to be removed",
+                                "required": true,
+                                "validationRegex": "^([a-zA-Z_][a-zA-Z\\d_\\-\\ ]*)$",
+                                "type": "String"
+                            }
+                        ]
+                    },
+                    {
+                        "id": "4",
+                        "type": "ResponseHeaderModifier",
+                        "name": "removeHeader",
+                        "displayName": "Remove Header",
+                        "description": "This policy allows you to remove a header from the response",
+                        "applicableFlows": [
+                            "response"
+                        ],
+                        "supportedApiTypes": [
+                            "REST"
+                        ],
+                        "policyAttributes": [
+                            {
+                                "name": "headerName",
+                                "description": "Name of the header to be removed",
+                                "required": true,
+                                "validationRegex": "^([a-zA-Z_][a-zA-Z\\d_\\-\\ ]*)$",
+                                "type": "String"
+                            }
+                        ]
+                    }
+                ],
+                "pagination": {
+                    "offset": 0,
+                    "limit": 10,
+                    "total": 4
+                }
+            }.toBalString()
+        ],
+        "2": [
+            (),
+            10,
+            0,
+            SORT_BY_POLICY_NAME,
+            SORT_ORDER_DESC,
+            {
+                "count": 4,
+                "list": [
+                    {
+                        "id": "2",
+                        "type": "RequestHeaderModifier",
+                        "name": "removeHeader",
+                        "displayName": "Remove Header",
+                        "description": "This policy allows you to remove a header from the request",
+                        "applicableFlows": [
+                            "request"
+                        ],
+                        "supportedApiTypes": [
+                            "REST"
+                        ],
+                        "policyAttributes": [
+                            {
+                                "name": "headerName",
+                                "description": "Name of the header to be removed",
+                                "required": true,
+                                "validationRegex": "^([a-zA-Z_][a-zA-Z\\d_\\-\\ ]*)$",
+                                "type": "String"
+                            }
+                        ]
+                    },
+                    {
+                        "id": "4",
+                        "type": "ResponseHeaderModifier",
+                        "name": "removeHeader",
+                        "displayName": "Remove Header",
+                        "description": "This policy allows you to remove a header from the response",
+                        "applicableFlows": [
+                            "response"
+                        ],
+                        "supportedApiTypes": [
+                            "REST"
+                        ],
+                        "policyAttributes": [
+                            {
+                                "name": "headerName",
+                                "description": "Name of the header to be removed",
+                                "required": true,
+                                "validationRegex": "^([a-zA-Z_][a-zA-Z\\d_\\-\\ ]*)$",
+                                "type": "String"
+                            }
+                        ]
+                    },
+                    {
+                        "id": "1",
+                        "type": "RequestHeaderModifier",
+                        "name": "addHeader",
+                        "displayName": "Add Header",
+                        "description": "This policy allows you to add a new header to the request",
+                        "applicableFlows": [
+                            "request"
+                        ],
+                        "supportedApiTypes": [
+                            "REST"
+                        ],
+                        "policyAttributes": [
+                            {
+                                "name": "headerName",
+                                "description": "Name of the header to be added",
+                                "required": true,
+                                "validationRegex": "^([a-zA-Z_][a-zA-Z\\d_\\-\\ ]*)$",
+                                "type": "String"
+                            },
+                            {
+                                "name": "headerValue",
+                                "description": "Value of the header",
+                                "required": true,
+                                "validationRegex": "^([a-zA-Z_][a-zA-Z\\d_\\-\\ ]*)$",
+                                "type": "String"
+                            }
+                        ]
+                    },
+                    {
+                        "id": "3",
+                        "type": "ResponseHeaderModifier",
+                        "name": "addHeader",
+                        "displayName": "Add Header",
+                        "description": "This policy allows you to add a new header to the response",
+                        "applicableFlows": [
+                            "response"
+                        ],
+                        "supportedApiTypes": [
+                            "REST"
+                        ],
+                        "policyAttributes": [
+                            {
+                                "name": "headerName",
+                                "description": "Name of the header to be added",
+                                "required": true,
+                                "validationRegex": "^([a-zA-Z_][a-zA-Z\\d_\\-\\ ]*)$",
+                                "type": "String"
+                            },
+                            {
+                                "name": "headerValue",
+                                "description": "Value of the header",
+                                "required": true,
+                                "validationRegex": "^([a-zA-Z_][a-zA-Z\\d_\\-\\ ]*)$",
+                                "type": "String"
+                            }
+                        ]
+                    }
+                ],
+                "pagination": {
+                    "offset": 0,
+                    "limit": 10,
+                    "total": 4
+                }
+            }.toBalString()
+        ],
+        "3": [
+            (),
+            10,
+            0,
+            SORT_BY_ID,
+            SORT_ORDER_ASC,
+            {
+                "count": 4,
+                "list": [
+                    {
+                        "id": "1",
+                        "type": "RequestHeaderModifier",
+                        "name": "addHeader",
+                        "displayName": "Add Header",
+                        "description": "This policy allows you to add a new header to the request",
+                        "applicableFlows": [
+                            "request"
+                        ],
+                        "supportedApiTypes": [
+                            "REST"
+                        ],
+                        "policyAttributes": [
+                            {
+                                "name": "headerName",
+                                "description": "Name of the header to be added",
+                                "required": true,
+                                "validationRegex": "^([a-zA-Z_][a-zA-Z\\d_\\-\\ ]*)$",
+                                "type": "String"
+                            },
+                            {
+                                "name": "headerValue",
+                                "description": "Value of the header",
+                                "required": true,
+                                "validationRegex": "^([a-zA-Z_][a-zA-Z\\d_\\-\\ ]*)$",
+                                "type": "String"
+                            }
+                        ]
+                    },
+                    {
+                        "id": "2",
+                        "type": "RequestHeaderModifier",
+                        "name": "removeHeader",
+                        "displayName": "Remove Header",
+                        "description": "This policy allows you to remove a header from the request",
+                        "applicableFlows": [
+                            "request"
+                        ],
+                        "supportedApiTypes": [
+                            "REST"
+                        ],
+                        "policyAttributes": [
+                            {
+                                "name": "headerName",
+                                "description": "Name of the header to be removed",
+                                "required": true,
+                                "validationRegex": "^([a-zA-Z_][a-zA-Z\\d_\\-\\ ]*)$",
+                                "type": "String"
+                            }
+                        ]
+                    },
+                    {
+                        "id": "3",
+                        "type": "ResponseHeaderModifier",
+                        "name": "addHeader",
+                        "displayName": "Add Header",
+                        "description": "This policy allows you to add a new header to the response",
+                        "applicableFlows": [
+                            "response"
+                        ],
+                        "supportedApiTypes": [
+                            "REST"
+                        ],
+                        "policyAttributes": [
+                            {
+                                "name": "headerName",
+                                "description": "Name of the header to be added",
+                                "required": true,
+                                "validationRegex": "^([a-zA-Z_][a-zA-Z\\d_\\-\\ ]*)$",
+                                "type": "String"
+                            },
+                            {
+                                "name": "headerValue",
+                                "description": "Value of the header",
+                                "required": true,
+                                "validationRegex": "^([a-zA-Z_][a-zA-Z\\d_\\-\\ ]*)$",
+                                "type": "String"
+                            }
+                        ]
+                    },
+                    {
+                        "id": "4",
+                        "type": "ResponseHeaderModifier",
+                        "name": "removeHeader",
+                        "displayName": "Remove Header",
+                        "description": "This policy allows you to remove a header from the response",
+                        "applicableFlows": [
+                            "response"
+                        ],
+                        "supportedApiTypes": [
+                            "REST"
+                        ],
+                        "policyAttributes": [
+                            {
+                                "name": "headerName",
+                                "description": "Name of the header to be removed",
+                                "required": true,
+                                "validationRegex": "^([a-zA-Z_][a-zA-Z\\d_\\-\\ ]*)$",
+                                "type": "String"
+                            }
+                        ]
+                    }
+                ],
+                "pagination": {
+                    "offset": 0,
+                    "limit": 10,
+                    "total": 4
+                }
+            }.toBalString()
+        ],
+        "4": [
+            (),
+            10,
+            0,
+            SORT_BY_ID,
+            SORT_ORDER_DESC,
+            {
+                "count": 4,
+                "list": [
+                    {
+                        "id": "4",
+                        "type": "ResponseHeaderModifier",
+                        "name": "removeHeader",
+                        "displayName": "Remove Header",
+                        "description": "This policy allows you to remove a header from the response",
+                        "applicableFlows": [
+                            "response"
+                        ],
+                        "supportedApiTypes": [
+                            "REST"
+                        ],
+                        "policyAttributes": [
+                            {
+                                "name": "headerName",
+                                "description": "Name of the header to be removed",
+                                "required": true,
+                                "validationRegex": "^([a-zA-Z_][a-zA-Z\\d_\\-\\ ]*)$",
+                                "type": "String"
+                            }
+                        ]
+                    },
+                    {
+                        "id": "3",
+                        "type": "ResponseHeaderModifier",
+                        "name": "addHeader",
+                        "displayName": "Add Header",
+                        "description": "This policy allows you to add a new header to the response",
+                        "applicableFlows": [
+                            "response"
+                        ],
+                        "supportedApiTypes": [
+                            "REST"
+                        ],
+                        "policyAttributes": [
+                            {
+                                "name": "headerName",
+                                "description": "Name of the header to be added",
+                                "required": true,
+                                "validationRegex": "^([a-zA-Z_][a-zA-Z\\d_\\-\\ ]*)$",
+                                "type": "String"
+                            },
+                            {
+                                "name": "headerValue",
+                                "description": "Value of the header",
+                                "required": true,
+                                "validationRegex": "^([a-zA-Z_][a-zA-Z\\d_\\-\\ ]*)$",
+                                "type": "String"
+                            }
+                        ]
+                    },
+                    {
+                        "id": "2",
+                        "type": "RequestHeaderModifier",
+                        "name": "removeHeader",
+                        "displayName": "Remove Header",
+                        "description": "This policy allows you to remove a header from the request",
+                        "applicableFlows": [
+                            "request"
+                        ],
+                        "supportedApiTypes": [
+                            "REST"
+                        ],
+                        "policyAttributes": [
+                            {
+                                "name": "headerName",
+                                "description": "Name of the header to be removed",
+                                "required": true,
+                                "validationRegex": "^([a-zA-Z_][a-zA-Z\\d_\\-\\ ]*)$",
+                                "type": "String"
+                            }
+                        ]
+                    },
+                    {
+                        "id": "1",
+                        "type": "RequestHeaderModifier",
+                        "name": "addHeader",
+                        "displayName": "Add Header",
+                        "description": "This policy allows you to add a new header to the request",
+                        "applicableFlows": [
+                            "request"
+                        ],
+                        "supportedApiTypes": [
+                            "REST"
+                        ],
+                        "policyAttributes": [
+                            {
+                                "name": "headerName",
+                                "description": "Name of the header to be added",
+                                "required": true,
+                                "validationRegex": "^([a-zA-Z_][a-zA-Z\\d_\\-\\ ]*)$",
+                                "type": "String"
+                            },
+                            {
+                                "name": "headerValue",
+                                "description": "Value of the header",
+                                "required": true,
+                                "validationRegex": "^([a-zA-Z_][a-zA-Z\\d_\\-\\ ]*)$",
+                                "type": "String"
+                            }
+                        ]
+                    }
+                ],
+                "pagination": {
+                    "offset": 0,
+                    "limit": 10,
+                    "total": 4
+                }
+            }.toBalString()
+        ],
+        "5": [(), 10, 0, "description", SORT_ORDER_DESC, badRequestError.toBalString()],
+        "6": [
+            (),
+            2,
+            0,
+            SORT_BY_POLICY_NAME,
+            SORT_ORDER_ASC,
+            {
+                "count": 2,
+                "list": [
+                    {
+                        "id": "1",
+                        "type": "RequestHeaderModifier",
+                        "name": "addHeader",
+                        "displayName": "Add Header",
+                        "description": "This policy allows you to add a new header to the request",
+                        "applicableFlows": [
+                            "request"
+                        ],
+                        "supportedApiTypes": [
+                            "REST"
+                        ],
+                        "policyAttributes": [
+                            {
+                                "name": "headerName",
+                                "description": "Name of the header to be added",
+                                "required": true,
+                                "validationRegex": "^([a-zA-Z_][a-zA-Z\\d_\\-\\ ]*)$",
+                                "type": "String"
+                            },
+                            {
+                                "name": "headerValue",
+                                "description": "Value of the header",
+                                "required": true,
+                                "validationRegex": "^([a-zA-Z_][a-zA-Z\\d_\\-\\ ]*)$",
+                                "type": "String"
+                            }
+                        ]
+                    },
+                    {
+                        "id": "3",
+                        "type": "ResponseHeaderModifier",
+                        "name": "addHeader",
+                        "displayName": "Add Header",
+                        "description": "This policy allows you to add a new header to the response",
+                        "applicableFlows": [
+                            "response"
+                        ],
+                        "supportedApiTypes": [
+                            "REST"
+                        ],
+                        "policyAttributes": [
+                            {
+                                "name": "headerName",
+                                "description": "Name of the header to be added",
+                                "required": true,
+                                "validationRegex": "^([a-zA-Z_][a-zA-Z\\d_\\-\\ ]*)$",
+                                "type": "String"
+                            },
+                            {
+                                "name": "headerValue",
+                                "description": "Value of the header",
+                                "required": true,
+                                "validationRegex": "^([a-zA-Z_][a-zA-Z\\d_\\-\\ ]*)$",
+                                "type": "String"
+                            }
+                        ]
+                    }
+                ],
+                "pagination": {
+                    "offset": 0,
+                    "limit": 2,
+                    "total": 4
+                }
+            }.toBalString()
+        ],
+        "7": [
+            (),
+            2,
+            2,
+            SORT_BY_POLICY_NAME,
+            SORT_ORDER_DESC,
+            {
+                "count": 2,
+                "list": [
+                    {
+                        "id": "1",
+                        "type": "RequestHeaderModifier",
+                        "name": "addHeader",
+                        "displayName": "Add Header",
+                        "description": "This policy allows you to add a new header to the request",
+                        "applicableFlows": [
+                            "request"
+                        ],
+                        "supportedApiTypes": [
+                            "REST"
+                        ],
+                        "policyAttributes": [
+                            {
+                                "name": "headerName",
+                                "description": "Name of the header to be added",
+                                "required": true,
+                                "validationRegex": "^([a-zA-Z_][a-zA-Z\\d_\\-\\ ]*)$",
+                                "type": "String"
+                            },
+                            {
+                                "name": "headerValue",
+                                "description": "Value of the header",
+                                "required": true,
+                                "validationRegex": "^([a-zA-Z_][a-zA-Z\\d_\\-\\ ]*)$",
+                                "type": "String"
+                            }
+                        ]
+                    },
+                    {
+                        "id": "3",
+                        "type": "ResponseHeaderModifier",
+                        "name": "addHeader",
+                        "displayName": "Add Header",
+                        "description": "This policy allows you to add a new header to the response",
+                        "applicableFlows": [
+                            "response"
+                        ],
+                        "supportedApiTypes": [
+                            "REST"
+                        ],
+                        "policyAttributes": [
+                            {
+                                "name": "headerName",
+                                "description": "Name of the header to be added",
+                                "required": true,
+                                "validationRegex": "^([a-zA-Z_][a-zA-Z\\d_\\-\\ ]*)$",
+                                "type": "String"
+                            },
+                            {
+                                "name": "headerValue",
+                                "description": "Value of the header",
+                                "required": true,
+                                "validationRegex": "^([a-zA-Z_][a-zA-Z\\d_\\-\\ ]*)$",
+                                "type": "String"
+                            }
+                        ]
+                    }
+                ],
+                "pagination": {
+                    "offset": 2,
+                    "limit": 2,
+                    "total": 4
+                }
+            }.toBalString()
+        ],
+        "8": [
+            (),
+            3,
+            6,
+            SORT_BY_POLICY_NAME,
+            SORT_ORDER_ASC,
+            {
+                "count": 0,
+                "list": [],
+                "pagination": {
+                    "offset": 6,
+                    "limit": 3,
+                    "total": 4
+                }
+            }.toBalString()
+        ],
+        "9": [
+            "name:add",
+            10,
+            0,
+            SORT_BY_POLICY_NAME,
+            SORT_ORDER_ASC,
+            {
+                "count": 2,
+                "list": [
+                    {
+                        "id": "1",
+                        "type": "RequestHeaderModifier",
+                        "name": "addHeader",
+                        "displayName": "Add Header",
+                        "description": "This policy allows you to add a new header to the request",
+                        "applicableFlows": [
+                            "request"
+                        ],
+                        "supportedApiTypes": [
+                            "REST"
+                        ],
+                        "policyAttributes": [
+                            {
+                                "name": "headerName",
+                                "description": "Name of the header to be added",
+                                "required": true,
+                                "validationRegex": "^([a-zA-Z_][a-zA-Z\\d_\\-\\ ]*)$",
+                                "type": "String"
+                            },
+                            {
+                                "name": "headerValue",
+                                "description": "Value of the header",
+                                "required": true,
+                                "validationRegex": "^([a-zA-Z_][a-zA-Z\\d_\\-\\ ]*)$",
+                                "type": "String"
+                            }
+                        ]
+                    },
+                    {
+                        "id": "3",
+                        "type": "ResponseHeaderModifier",
+                        "name": "addHeader",
+                        "displayName": "Add Header",
+                        "description": "This policy allows you to add a new header to the response",
+                        "applicableFlows": [
+                            "response"
+                        ],
+                        "supportedApiTypes": [
+                            "REST"
+                        ],
+                        "policyAttributes": [
+                            {
+                                "name": "headerName",
+                                "description": "Name of the header to be added",
+                                "required": true,
+                                "validationRegex": "^([a-zA-Z_][a-zA-Z\\d_\\-\\ ]*)$",
+                                "type": "String"
+                            },
+                            {
+                                "name": "headerValue",
+                                "description": "Value of the header",
+                                "required": true,
+                                "validationRegex": "^([a-zA-Z_][a-zA-Z\\d_\\-\\ ]*)$",
+                                "type": "String"
+                            }
+                        ]
+                    }
+                ],
+                "pagination": {
+                    "offset": 0,
+                    "limit": 10,
+                    "total": 2
+                }
+            }.toBalString()
+        ],
+        "10": [
+            "add",
+            10,
+            0,
+            SORT_BY_POLICY_NAME,
+            SORT_ORDER_ASC,
+            {
+                "count": 2,
+                "list": [
+                    {
+                        "id": "1",
+                        "type": "RequestHeaderModifier",
+                        "name": "addHeader",
+                        "displayName": "Add Header",
+                        "description": "This policy allows you to add a new header to the request",
+                        "applicableFlows": [
+                            "request"
+                        ],
+                        "supportedApiTypes": [
+                            "REST"
+                        ],
+                        "policyAttributes": [
+                            {
+                                "name": "headerName",
+                                "description": "Name of the header to be added",
+                                "required": true,
+                                "validationRegex": "^([a-zA-Z_][a-zA-Z\\d_\\-\\ ]*)$",
+                                "type": "String"
+                            },
+                            {
+                                "name": "headerValue",
+                                "description": "Value of the header",
+                                "required": true,
+                                "validationRegex": "^([a-zA-Z_][a-zA-Z\\d_\\-\\ ]*)$",
+                                "type": "String"
+                            }
+                        ]
+                    },
+                    {
+                        "id": "3",
+                        "type": "ResponseHeaderModifier",
+                        "name": "addHeader",
+                        "displayName": "Add Header",
+                        "description": "This policy allows you to add a new header to the response",
+                        "applicableFlows": [
+                            "response"
+                        ],
+                        "supportedApiTypes": [
+                            "REST"
+                        ],
+                        "policyAttributes": [
+                            {
+                                "name": "headerName",
+                                "description": "Name of the header to be added",
+                                "required": true,
+                                "validationRegex": "^([a-zA-Z_][a-zA-Z\\d_\\-\\ ]*)$",
+                                "type": "String"
+                            },
+                            {
+                                "name": "headerValue",
+                                "description": "Value of the header",
+                                "required": true,
+                                "validationRegex": "^([a-zA-Z_][a-zA-Z\\d_\\-\\ ]*)$",
+                                "type": "String"
+                            }
+                        ]
+                    }
+                ],
+                "pagination": {
+                    "offset": 0,
+                    "limit": 10,
+                    "total": 2
+                }
+            }.toBalString()
+        ],
+        "11": [
+            "type:modify",
+            10,
+            0,
+            SORT_BY_POLICY_NAME,
+            SORT_ORDER_ASC,
+            {
+                "count": 0,
+                "list": [],
+                "pagination": {
+                    "offset": 0,
+                    "limit": 10,
+                    "total": 0
+                }
+            }.toBalString()
+        ],
+        "12": [
+            "name1:add",
+            10,
+            0,
+            SORT_BY_POLICY_NAME,
+            SORT_ORDER_ASC,
+            badRequest.toBalString()
+        ]
+    };
+    return dataSet;
 }
 
 function getOKBackendServiceResponse(model:Service backendService) returns http:Response {

--- a/runtime/runtime-domain-service/ballerina/types.bal
+++ b/runtime/runtime-domain-service/ballerina/types.bal
@@ -156,6 +156,21 @@ public type APIOperationPolicies record {
     OperationPolicy[] fault?;
 };
 
+public type MediationPolicySpecAttribute record {
+    # Name of the attibute
+    string name?;
+    # Description of the attibute
+    string description?;
+    # Is this option mandetory for the policy
+    boolean required?;
+    # UI validation regex for the attibute
+    string validationRegex?;
+    # Type of the attibute
+    string 'type?;
+    # Default value for the attribute
+    string defaultValue?;
+};
+
 public type APIList record {
     # Number of APIs returned.
     int count?;
@@ -166,6 +181,19 @@ public type APIList record {
 public type MediationPolicyList record {
     MediationPolicy[] list?;
     Pagination pagination?;
+};
+
+public type MediationPolicyData record {
+    string 'type?;
+    string id?;
+    string name?;
+    string displayName?;
+    string description?;
+    string[] applicableFlows?;
+    string[] supportedApiTypes?;
+    boolean isApplicableforAPILevel?;
+    boolean isApplicableforOperationLevel?;
+    MediationPolicySpecAttribute[] policyAttributes?;
 };
 
 public type PortMapping record {
@@ -266,6 +294,13 @@ public type APIKey record {
     # API Key
     string apikey?;
     int validityTime?;
+};
+
+public type MediationPolicyDataList record {
+    # Number of operation policies returned.
+    int count?;
+    MediationPolicyData[] list?;
+    Pagination pagination?;
 };
 
 public type OperationPolicy record {

--- a/runtime/runtime-domain-service/ballerina/types.bal
+++ b/runtime/runtime-domain-service/ballerina/types.bal
@@ -63,8 +63,14 @@ public type ErrorListItem record {
 };
 
 public type MediationPolicy record {
+    string id;
+    string 'type;
     string name;
-    string 'type?;
+    string displayName?;
+    string description?;
+    string[] applicableFlows?;
+    string[] supportedApiTypes?;
+    MediationPolicySpecAttribute[] policyAttributes?;
 };
 
 public type Apis_importdefinition_body record {
@@ -179,21 +185,10 @@ public type APIList record {
 };
 
 public type MediationPolicyList record {
+    # Number of mediation policies returned.
+    int count?;
     MediationPolicy[] list?;
     Pagination pagination?;
-};
-
-public type MediationPolicyData record {
-    string id;
-    string 'type;
-    string name;
-    string displayName?;
-    string description?;
-    string[] applicableFlows?;
-    string[] supportedApiTypes?;
-    boolean canApplyforAPILevel?;
-    boolean canApplyforOperationLevel?;
-    MediationPolicySpecAttribute[] policyAttributes?;
 };
 
 public type PortMapping record {
@@ -294,13 +289,6 @@ public type APIKey record {
     # API Key
     string apikey?;
     int validityTime?;
-};
-
-public type MediationPolicyDataList record {
-    # Number of mediation policies returned.
-    int count?;
-    MediationPolicyData[] list?;
-    Pagination pagination?;
 };
 
 public type OperationPolicy record {

--- a/runtime/runtime-domain-service/ballerina/types.bal
+++ b/runtime/runtime-domain-service/ballerina/types.bal
@@ -184,9 +184,9 @@ public type MediationPolicyList record {
 };
 
 public type MediationPolicyData record {
-    string 'type?;
+    string 'type;
     string id?;
-    string name?;
+    string name;
     string displayName?;
     string description?;
     string[] applicableFlows?;
@@ -297,7 +297,7 @@ public type APIKey record {
 };
 
 public type MediationPolicyDataList record {
-    # Number of operation policies returned.
+    # Number of mediation policies returned.
     int count?;
     MediationPolicyData[] list?;
     Pagination pagination?;

--- a/runtime/runtime-domain-service/ballerina/types.bal
+++ b/runtime/runtime-domain-service/ballerina/types.bal
@@ -191,8 +191,8 @@ public type MediationPolicyData record {
     string description?;
     string[] applicableFlows?;
     string[] supportedApiTypes?;
-    boolean isApplicableforAPILevel?;
-    boolean isApplicableforOperationLevel?;
+    boolean canApplyforAPILevel?;
+    boolean canApplyforOperationLevel?;
     MediationPolicySpecAttribute[] policyAttributes?;
 };
 

--- a/runtime/runtime-domain-service/ballerina/types.bal
+++ b/runtime/runtime-domain-service/ballerina/types.bal
@@ -184,8 +184,8 @@ public type MediationPolicyList record {
 };
 
 public type MediationPolicyData record {
+    string id;
     string 'type;
-    string id?;
     string name;
     string displayName?;
     string description?;


### PR DESCRIPTION
## Purpose
This will introduce a mediation policy listing and search functionality to the runtime DS.

## Description
Following are the currently available mediation policies in the runtime.

1. RequestHeaderModifier - addHeader
2. RequestHeaderModifier - removeHeader
3. ResponseHeaderModifier - addHeader
4. ResponseHeaderModifier - removeHeader

**if there are any new policies, we have to add that policy to the avilableMediationPolicyList in the [MediationPolicyList.bal](https://github.com/wso2/apk/pull/789/files#diff-a03aa80955a7acab7ff70067de16944149c8cee78f92f9fa06e48317617c09fe) file.**

### Example responses
This will introduce the following resources.
1. /policies
6. /policies/{policyId}

**Example response for  /policies.**
![image](https://user-images.githubusercontent.com/21282060/223492267-9b4b5f39-de57-4d1b-b151-4e9305732152.png)



**Example response for  /policies/{policyId}**

![image](https://user-images.githubusercontent.com/21282060/223492551-cedeb3ee-e435-45f2-8f81-61cd0dcbdc47.png)



## Automation tests
 - Unit tests: https://github.com/wso2/apk/pull/789/commits/fa9933a7db57d0df83e499496edddc5e72b99ec5
 - Integration tests
   > Details about the test cases and coverage

## Fixes
 - https://github.com/wso2/apk/issues/786


