### PR TITLE
Fix issues in import-defintion flow in Runtime

### DIFF
--- a/runtime/runtime-domain-service/ballerina/APIClient.bal
+++ b/runtime/runtime-domain-service/ballerina/APIClient.bal
@@ -1897,7 +1897,7 @@ public class APIClient {
         string|() fileName = ();
         byte[]|() fileContent = ();
         string|() inlineAPIDefinition = ();
-        string|() additinalProperties = ();
+        string|() additionalProperties = ();
         string|() 'type = ();
         mime:Entity[]|http:ClientError payLoadParts = message.getBodyParts();
         if payLoadParts is mime:Entity[] {
@@ -1912,8 +1912,8 @@ public class APIClient {
                     fileContent = check payLoadPart.getByteArray();
                 } else if fieldName == "inlineAPIDefinition" {
                     inlineAPIDefinition = check payLoadPart.getText();
-                } else if fieldName == "additinalProperties" {
-                    additinalProperties = check payLoadPart.getText();
+                } else if fieldName == "additionalProperties" {
+                    additionalProperties = check payLoadPart.getText();
                 } else if fieldName == "type" {
                     'type = check payLoadPart.getText();
                 }
@@ -1927,11 +1927,11 @@ public class APIClient {
             BadRequestError badRequest = {body: {code: 90914, message: "atleast one of the field required (file,inlineApiDefinition,url)."}};
             return badRequest;
         }
-        if additinalProperties is () || additinalProperties.length() == 0 {
+        if additionalProperties is () || additionalProperties.length() == 0 {
             BadRequestError badRequest = {body: {code: 90914, message: "additionalProperties not provided."}};
             return badRequest;
         }
-        json apiObject = check value:fromJsonString(additinalProperties);
+        json apiObject = check value:fromJsonString(additionalProperties);
         API api = check apiObject.cloneWithType(API);
         ImportDefintionRequest importDefintionRequest = {
             fileName: fileName,

--- a/runtime/runtime-domain-service/java/src/main/java/org/wso2/apk/runtime/definitions/OAS3Parser.java
+++ b/runtime/runtime-domain-service/java/src/main/java/org/wso2/apk/runtime/definitions/OAS3Parser.java
@@ -121,19 +121,6 @@ public class OAS3Parser extends APIDefinition {
                             template = OASParserUtil.setScopesToTemplate(template, opScopes, scopes);
                         }
                     }
-                    Map<String, Object> extensions = operation.getExtensions();
-                    if (extensions != null) {
-                        if (extensions.containsKey(APIConstants.SWAGGER_X_AUTH_TYPE)) {
-                            Boolean authType = (Boolean) extensions.get(APIConstants.SWAGGER_X_AUTH_TYPE);
-                            template.setAuthEnabled(authType);
-                        } else {
-                            template.setAuthEnabled(true);
-                        }
-                        if (extensions.containsKey(APIConstants.SWAGGER_X_THROTTLING_TIER)) {
-                            String throttlingTier = (String) extensions.get(APIConstants.SWAGGER_X_THROTTLING_TIER);
-                            template.setThrottlingTier(throttlingTier);
-                        }
-                    }
                     urlTemplates.add(template);
                 }
             }


### PR DESCRIPTION
## Purpose
This PR fixes the following 2 issues in import-definition flow.

1. 400 Bad Request with missing `additionalProperties`  
2. Error when converting a string value vendor extension to boolean
```
error: java.lang.ClassCastException {"message":"class java.lang.String cannot be cast to class java.lang.Boolean (java.lang.String and java.lang.Boolean are in module java.base of loader 'bootstrap')"}
    at wso2.runtime_domain_service.org.wso2.apk.runtime.api.0:org_wso2_apk_runtime_api_APIDefinition_getURITemplates(APIDefinition.bal:292)
       wso2.runtime_domain_service.org.wso2.apk.runtime.api.0:getURITemplates(APIDefinition.bal:130)
       wso2.runtime_domain_service.0:importDefinition(APIClient.bal:1802)
       wso2.runtime_domain_service.0.$anonType$_2:$post$apis$import-definition(api_service.bal:74)
```