### PR TITLE
[Runtime DS] Attach Mediation Policies to API Resources

### DIFF
--- a/helm-charts/crds/dp.wso2.com_internal_api.yaml
+++ b/helm-charts/crds/dp.wso2.com_internal_api.yaml
@@ -158,9 +158,14 @@ spec:
                                 policyName:
                                   type: string
                                 parameters:
-                                  type: object
-                                  additionalProperties:
+                                  type: array
+                                  items:
                                     type: object
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
                           response:
                             type: array
                             items:
@@ -169,9 +174,14 @@ spec:
                                 policyName:
                                   type: string
                                 parameters:
-                                  type: object
-                                  additionalProperties:
+                                  type: array
+                                  items:
                                     type: object
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
                 serviceInfo:
                   type: object
                   properties:

--- a/helm-charts/crds/dp.wso2.com_internal_api.yaml
+++ b/helm-charts/crds/dp.wso2.com_internal_api.yaml
@@ -162,9 +162,9 @@ spec:
                                   items:
                                     type: object
                                     properties:
-                                      name:
+                                      headerName:
                                         type: string
-                                      value:
+                                      headerValue:
                                         type: string
                           response:
                             type: array
@@ -178,9 +178,9 @@ spec:
                                   items:
                                     type: object
                                     properties:
-                                      name:
+                                      headerName:
                                         type: string
-                                      value:
+                                      headerValue:
                                         type: string
                 serviceInfo:
                   type: object

--- a/runtime/runtime-domain-service/ballerina/APIClient.bal
+++ b/runtime/runtime-domain-service/ballerina/APIClient.bal
@@ -401,6 +401,7 @@ public class APIClient {
                     BadRequestError badRequestError = {body: {code: 90912, message: "Atleast one operation need to specified"}};
                     return badRequestError;
                 }
+                // Validating operation policies.
                 BadRequestError|() badRequestError = self.validateOperationPolicies(api.apiPolicies, operations, organization);
                 if (badRequestError is BadRequestError) {
                     return badRequestError;
@@ -444,7 +445,7 @@ public class APIClient {
                     }
                 } else {
                      // Presence of both resource level and API level operation policies.
-                    BadRequestError badRequestError = {body: {code: 91111, message: "Presence of both resource level and API level operation policies"}};
+                    BadRequestError badRequestError = {body: {code: 90917, message: "Presence of both resource level and API level operation policies is not allowed"}};
                     return badRequestError;
                 }
             }
@@ -462,8 +463,10 @@ public class APIClient {
 
     isolated function validateOperationPolicyData(APIOperationPolicies? operationPolicies, commons:Organization organization) returns BadRequestError|() {
         if operationPolicies is APIOperationPolicies {
+            // Validating request operation policy data.
             BadRequestError|() badRequestError = self.validateData(operationPolicies.request, organization);
             if (badRequestError == ()) {
+                // Validating response operation policy data.
                 return self.validateData(operationPolicies.response, organization);
             } else {
                 return badRequestError;
@@ -480,7 +483,7 @@ public class APIClient {
                 if (policyParameters is OperationPolicyParameters[]) {
                     string[] allowedPolicyAttributes = [];
                     string[] receivedPolicyParameters = [];
-                    any|error mediationPolicyList = self.getMediationPolicyList("name:" + policyName, 1, 0,
+                    any|error mediationPolicyList = self.getMediationPolicyList(SEARCH_CRITERIA_NAME + ":" + policyName, 1, 0,
                         SORT_BY_POLICY_NAME, SORT_ORDER_ASC, organization);
                     if (mediationPolicyList is MediationPolicyList && mediationPolicyList.count > 0) {
                         MediationPolicy[]? listing = mediationPolicyList.list;
@@ -499,13 +502,13 @@ public class APIClient {
                             }
                             if (allowedPolicyAttributes != receivedPolicyParameters) {
                                 // Allowed policy attributes does not match with the parameters provided
-                                BadRequestError badRequestError = {body: {code: 91112, message: "Allowed policy attributes does not match with the parameters provided"}};
+                                BadRequestError badRequestError = {body: {code: 90916, message: "Invalid parameters provided for policy " + policyName}};
                                 return badRequestError;
                             }
                         }
                     } else {
                         // Invalid operation policy name.
-                        BadRequestError badRequestError = {body: {code: 91112, message: "Invalid operation policy name"}};
+                        BadRequestError badRequestError = {body: {code: 90915, message: "Invalid operation policy name"}};
                         return badRequestError;
                     }
                 }

--- a/runtime/runtime-domain-service/ballerina/APIClient.bal
+++ b/runtime/runtime-domain-service/ballerina/APIClient.bal
@@ -733,6 +733,14 @@ public class APIClient {
             return badRequest;
         }
         self.setDefaultOperationsIfNotExist(api);
+        APIOperations[]? operations = api.operations;
+        if operations is APIOperations[] {
+            // Validating operation policies.
+            BadRequestError|() badRequestError = self.validateOperationPolicies(api.apiPolicies, operations, organization);
+            if (badRequestError is BadRequestError) {
+                return badRequestError;
+            }
+        }
         api.context = self.returnFullContext(api.context, api.'version);
         Service|error serviceRetrieved = getServiceById(serviceKey);
         string uniqueId = getUniqueIdForAPI(api.name, api.'version, organization);
@@ -2591,6 +2599,11 @@ public class APIClient {
                 if operations is APIOperations[] {
                     if operations.length() == 0 {
                         BadRequestError badRequestError = {body: {code: 90912, message: "Atleast one operation need to specified"}};
+                        return badRequestError;
+                    }
+                    // Validating operation policies.
+                    BadRequestError|() badRequestError = self.validateOperationPolicies(api.apiPolicies, operations, organization);
+                    if (badRequestError is BadRequestError) {
                         return badRequestError;
                     }
                 } else {

--- a/runtime/runtime-domain-service/ballerina/APIClient.bal
+++ b/runtime/runtime-domain-service/ballerina/APIClient.bal
@@ -464,10 +464,10 @@ public class APIClient {
     isolated function validateOperationPolicyData(APIOperationPolicies? operationPolicies, commons:Organization organization) returns BadRequestError|() {
         if operationPolicies is APIOperationPolicies {
             // Validating request operation policy data.
-            BadRequestError|() badRequestError = self.validateData(operationPolicies.request, organization);
+            BadRequestError|() badRequestError = self.validatePolicyDetails(operationPolicies.request, organization);
             if (badRequestError == ()) {
                 // Validating response operation policy data.
-                return self.validateData(operationPolicies.response, organization);
+                return self.validatePolicyDetails(operationPolicies.response, organization);
             } else {
                 return badRequestError;
             }
@@ -475,7 +475,7 @@ public class APIClient {
         return ();
     }
 
-    isolated function validateData(OperationPolicy[]? policyData, commons:Organization organization) returns BadRequestError|() {
+    isolated function validatePolicyDetails(OperationPolicy[]? policyData, commons:Organization organization) returns BadRequestError|() {
         if (policyData is OperationPolicy[]) {
             foreach OperationPolicy policy in policyData {
                 string policyName = policy.policyName;
@@ -1246,8 +1246,8 @@ public class APIClient {
             }
             OperationPolicy[]? response = operationPoliciesToUse.response;
             if response is OperationPolicy[] {
-                model:HTTPRouteFilter responseHeaderFilter = {'type: "RequestHeaderModifier",
-                    requestHeaderModifier: self.extractHttpHeaderFilterData(response, organization)};
+                model:HTTPRouteFilter responseHeaderFilter = {'type: "ResponseHeaderModifier",
+                    responseHeaderModifier: self.extractHttpHeaderFilterData(response, organization)};
                 routeFilters.push(responseHeaderFilter);
             }
         }

--- a/runtime/runtime-domain-service/ballerina/APIClient.bal
+++ b/runtime/runtime-domain-service/ballerina/APIClient.bal
@@ -455,12 +455,17 @@ public class APIClient {
                     authTypeEnabled: operation.authTypeEnabled ?: true,
                     scopes: operation.scopes ?: []
                 };
-                APIOperationPolicies? operationPolicies = operation.operationPolicies;
+                APIOperationPolicies? operationPoliciesToUse = ();
+                if (api.apiPolicies is APIOperationPolicies) {
+                    operationPoliciesToUse = api.apiPolicies;
+                } else {
+                    operationPoliciesToUse = operation.operationPolicies;
+                }
                 model:OperationPolicy[] runtimeAPIRequestPolicies = [];
                 model:OperationPolicy[] runtimeAPIResponsePolicies = [];
 
-                if operationPolicies is APIOperationPolicies {
-                    OperationPolicy[]? request = operationPolicies.request;
+                if operationPoliciesToUse is APIOperationPolicies {
+                    OperationPolicy[]? request = operationPoliciesToUse.request;
                     if request is OperationPolicy[] {
                         foreach OperationPolicy policy in request {
                             model:OperationPolicy|error runtimeAPIRequestPolicy = policy.cloneWithType(model:OperationPolicy);
@@ -469,7 +474,7 @@ public class APIClient {
                             }
                         }
                     }
-                    OperationPolicy[]? response = operationPolicies.response;
+                    OperationPolicy[]? response = operationPoliciesToUse.response;
                     if response is OperationPolicy[] {
                         foreach OperationPolicy policy in response {
                             model:OperationPolicy|error runtimeAPIResponsePolicy = policy.cloneWithType(model:OperationPolicy);
@@ -1135,15 +1140,20 @@ public class APIClient {
         model:HTTPRouteFilter[] routeFilters = [];
         model:HTTPRouteFilter replacePathFilter = {'type: "URLRewrite", urlRewrite: {path: {'type: "ReplaceFullPath", replaceFullPath: self.generatePrefixMatch(api, endpoint, operation, endpointType)}}};
         routeFilters.push(replacePathFilter);
-        APIOperationPolicies? operationPolicies = operation.operationPolicies;
-        if operationPolicies is APIOperationPolicies {
-            OperationPolicy[]? request = operationPolicies.request;
+        APIOperationPolicies? operationPoliciesToUse = ();
+        if (api.apiPolicies is APIOperationPolicies) {
+            operationPoliciesToUse = api.apiPolicies;
+        } else {
+            operationPoliciesToUse = operation.operationPolicies;
+        }
+        if operationPoliciesToUse is APIOperationPolicies {
+            OperationPolicy[]? request = operationPoliciesToUse.request;
             if request is OperationPolicy[] {
                 model:HTTPRouteFilter requestHeaderFilter = {'type: "RequestHeaderModifier",
                     requestHeaderModifier: self.extractHttpHeaderFilterData(request)};
                 routeFilters.push(requestHeaderFilter);
             }
-            OperationPolicy[]? response = operationPolicies.response;
+            OperationPolicy[]? response = operationPoliciesToUse.response;
             if response is OperationPolicy[] {
                 model:HTTPRouteFilter responseHeaderFilter = {'type: "RequestHeaderModifier",
                     requestHeaderModifier: self.extractHttpHeaderFilterData(response)};

--- a/runtime/runtime-domain-service/ballerina/modules/model/RuntimeAPI.bal
+++ b/runtime/runtime-domain-service/ballerina/modules/model/RuntimeAPI.bal
@@ -36,8 +36,8 @@ public type OperationPolicy record {
 };
 
 public type OperationPolicyParameters record {
-    string name?;
-    string value?;
+    string headerName?;
+    string headerValue?;
 };
 
 public type MediationPolicy record {

--- a/runtime/runtime-domain-service/ballerina/modules/model/RuntimeAPI.bal
+++ b/runtime/runtime-domain-service/ballerina/modules/model/RuntimeAPI.bal
@@ -32,7 +32,12 @@ public type Operations record {|
 
 public type OperationPolicy record {
     string policyName;
-    map<string> parameters?;
+    OperationPolicyParameters[] parameters?;
+};
+
+public type OperationPolicyParameters record {
+    string name?;
+    string value?;
 };
 
 public type MediationPolicy record {

--- a/runtime/runtime-domain-service/ballerina/resources/api.yaml
+++ b/runtime/runtime-domain-service/ballerina/resources/api.yaml
@@ -1209,9 +1209,17 @@ components:
         policyId:
           type: string
         parameters:
-          type: object
-          additionalProperties:
-            type: object
+          type: array
+          items:
+            $ref: "#/components/schemas/OperationPolicyParameters"
+    OperationPolicyParameters:
+      title: API Operation Policy Parameters
+      type: object
+      properties:
+        name:
+          type: string
+        value:
+          type: string
     GraphQLSchema:
       title: GraphQL Schema
       required:

--- a/runtime/runtime-domain-service/ballerina/resources/api.yaml
+++ b/runtime/runtime-domain-service/ballerina/resources/api.yaml
@@ -1216,9 +1216,9 @@ components:
       title: API Operation Policy Parameters
       type: object
       properties:
-        name:
+        headerName:
           type: string
-        value:
+        headerValue:
           type: string
     GraphQLSchema:
       title: GraphQL Schema

--- a/runtime/runtime-domain-service/ballerina/tests/APIClientTest.bal
+++ b/runtime/runtime-domain-service/ballerina/tests/APIClientTest.bal
@@ -2456,6 +2456,206 @@ function getMockHttpRouteWithBackend(API api, string apiUUID, string backenduuid
     };
 }
 
+function getMockHttpRouteWithOperationPolicies(API api, string apiUUID, string backenduuid, string 'type, commons:Organization organization) returns model:Httproute {
+    string hostnames = 'type == PRODUCTION_TYPE ? string:concat(organization.uuid, ".", "gw.wso2.com") : string:concat(organization.uuid, ".", "sandbox.gw.wso2.com");
+    return {
+        "apiVersion": "gateway.networking.k8s.io/v1beta1",
+        "kind": "HTTPRoute",
+        "metadata": {"name": "http-route-ref-name", "namespace": "apk-platform", "labels": {"api-name": api.name, "api-version": api.'version}},
+        "spec": {
+            "hostnames": [
+                hostnames
+            ],
+            "rules": [
+                {
+                    "matches": [
+                        {
+                            "path": {
+                                "type": "RegularExpression",
+                                "value": "/pizzaAPI/1.0.0(.*)"
+                            },
+                            "method": "GET"
+                        }
+                    ],
+                    "filters": [
+                        {
+                            "type": "URLRewrite",
+                            "urlRewrite": {
+                                "path": {
+                                    "type": "ReplaceFullPath",
+                                    "replaceFullPath": "\\1"
+                                }
+                            }
+                        },
+                        {
+                            "type": "RequestHeaderModifier",
+                            "requestHeaderModifier": {
+                                "set": [
+                                    {
+                                        "name": "customadd",
+                                        "value": "customvalue"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "type": "ResponseHeaderModifier",
+                            "responseHeaderModifier": {
+                                "remove": ["content-length"]
+                            }
+                        }
+                    ],
+                    "backendRefs": [
+                        {
+                            "weight": 1,
+                            "group": "",
+                            "kind": "Service",
+                            "name": backenduuid,
+                            "namespace": "apk-platform",
+                            "port": 443
+                        }
+                    ]
+                },
+                {
+                    "matches": [
+                        {
+                            "path": {
+                                "type": "RegularExpression",
+                                "value": "/pizzaAPI/1.0.0(.*)"
+                            },
+                            "method": "PUT"
+                        }
+                    ],
+                    "filters": [
+                        {
+                            "type": "URLRewrite",
+                            "urlRewrite": {
+                                "path": {
+                                    "type": "ReplaceFullPath",
+                                    "replaceFullPath": "\\1"
+                                }
+                            }
+                        }
+                    ],
+                    "backendRefs": [
+                        {
+                            "weight": 1,
+                            "group": "",
+                            "kind": "Service",
+                            "name": backenduuid,
+                            "namespace": "apk-platform",
+                            "port": 443
+                        }
+                    ]
+                },
+                {
+                    "matches": [
+                        {
+                            "path": {
+                                "type": "RegularExpression",
+                                "value": "/pizzaAPI/1.0.0(.*)"
+                            },
+                            "method": "POST"
+                        }
+                    ],
+                    "filters": [
+                        {
+                            "type": "URLRewrite",
+                            "urlRewrite": {
+                                "path": {
+                                    "type": "ReplaceFullPath",
+                                    "replaceFullPath": "\\1"
+                                }
+                            }
+                        }
+                    ],
+                    "backendRefs": [
+                        {
+                            "weight": 1,
+                            "group": "",
+                            "kind": "Service",
+                            "name": backenduuid,
+                            "namespace": "apk-platform",
+                            "port": 443
+                        }
+                    ]
+                },
+                {
+                    "matches": [
+                        {
+                            "path": {
+                                "type": "RegularExpression",
+                                "value": "/pizzaAPI/1.0.0(.*)"
+                            },
+                            "method": "DELETE"
+                        }
+                    ],
+                    "filters": [
+                        {
+                            "type": "URLRewrite",
+                            "urlRewrite": {
+                                "path": {
+                                    "type": "ReplaceFullPath",
+                                    "replaceFullPath": "\\1"
+                                }
+                            }
+                        }
+                    ],
+                    "backendRefs": [
+                        {
+                            "weight": 1,
+                            "group": "",
+                            "kind": "Service",
+                            "name": backenduuid,
+                            "namespace": "apk-platform",
+                            "port": 443
+                        }
+                    ]
+                },
+                {
+                    "matches": [
+                        {
+                            "path": {
+                                "type": "RegularExpression",
+                                "value": "/pizzaAPI/1.0.0(.*)"
+                            },
+                            "method": "PATCH"
+                        }
+                    ],
+                    "filters": [
+                        {
+                            "type": "URLRewrite",
+                            "urlRewrite": {
+                                "path": {
+                                    "type": "ReplaceFullPath",
+                                    "replaceFullPath": "\\1"
+                                }
+                            }
+                        }
+                    ],
+                    "backendRefs": [
+                        {
+                            "weight": 1,
+                            "group": "",
+                            "kind": "Service",
+                            "name": backenduuid,
+                            "namespace": "apk-platform",
+                            "port": 443
+                        }
+                    ]
+                }
+            ],
+            "parentRefs": [
+                {
+                    "group": "gateway.networking.k8s.io",
+                    "kind": "Gateway",
+                    "name": "Default"
+                }
+            ]
+        }
+    };
+}
+
 function createAPIDataProvider() returns map<[string, string, API, model:ConfigMap, any, model:Httproute?, any, model:Httproute?, any, [model:Service, any][], [model:BackendPolicy, any][], model:API, any, model:RuntimeAPI, any, string, anydata]> {
     API api = {
         name: "PizzaAPI",
@@ -2493,6 +2693,147 @@ function createAPIDataProvider() returns map<[string, string, API, model:ConfigM
         'version: "1.0.0"
     };
     BadRequestError contextAlreadyExistError = {body: {code: 90911, message: "API Context - " + contextAlreadyExist.context + " already exist.", description: "API Context " + contextAlreadyExist.context + " already exist."}};
+    API apiWithOperationPolicies = {
+        name: "PizzaAPI",
+        context: "/pizzaAPI/1.0.0",
+        'version: "1.0.0",
+        endpointConfig: {"production_endpoints": {"url": "https://localhost"}},
+        operations: [
+        {
+            "target": "/*",
+            "verb": "GET",
+            "authTypeEnabled": true,
+            "throttlingPolicy": 1000,
+            "operationPolicies": {
+                "request": [
+                    {
+                        "policyName": "addHeader",
+                        "parameters": [{
+                            "headerName": "customadd",
+                            "headerValue": "customvalue"
+                        }]
+                    }
+                ],
+                "response": [
+                    {
+                        "policyName": "removeHeader",
+                        "parameters": [{
+                            "headerName": "content-length"
+                        }]
+                    }
+                ]
+            }
+        },
+        {
+            "target": "/*",
+            "verb": "PUT",
+            "authTypeEnabled": true,
+            "throttlingPolicy": 1000
+        },
+        {
+            "target": "/*",
+            "verb": "POST",
+            "authTypeEnabled": true,
+            "throttlingPolicy": 1000
+        },
+        {
+            "target": "/*",
+            "verb": "DELETE",
+            "authTypeEnabled": true,
+            "throttlingPolicy": 1000
+        },
+        {
+            "target": "/*",
+            "verb": "PATCH",
+            "authTypeEnabled": true,
+            "throttlingPolicy": 1000
+        }]
+    };
+    API apiWithBothPolicies = {
+        name: "PizzaAPIPolicies",
+        context: "/pizzaAPIPolcies/1.0.0",
+        'version: "1.0.0",
+        endpointConfig: {"production_endpoints": {"url": "https://localhost"}},
+        operations: [{
+            "target": "/menu",
+            "verb": "GET",
+            "authTypeEnabled": true,
+            "throttlingPolicy": 1000,
+            "operationPolicies": {
+                "request": [
+                    {
+                        "policyName": "addHeader",
+                        "parameters": [{
+                            "headerName": "customadd",
+                            "headerValue": "customvalue"
+                        }]
+                    }
+                ]
+            }
+        }],
+        apiPolicies: {
+            "request": [
+                {
+                    "policyName": "addHeader",
+                    "parameters": [{
+                        "headerName": "customadd",
+                        "headerValue": "customvalue"
+                    }]
+                }
+            ]
+        }
+    };
+    BadRequestError bothPoliciesPresentError = {body: {code: 90917, message: "Presence of both resource level and API level operation policies is not allowed"}};
+    API apiWithInvalidPolicyName = {
+        name: "PizzaAPIOps",
+        context: "/pizzaAPIOps/1.0.0",
+        'version: "1.0.0",
+        endpointConfig: {"production_endpoints": {"url": "https://localhost"}},
+        operations: [
+        {
+            "target": "/menu",
+            "verb": "GET",
+            "authTypeEnabled": true,
+            "throttlingPolicy": 1000,
+            "operationPolicies": {
+                "request": [
+                    {
+                        "policyName": "addHeader1",
+                        "parameters": [{
+                            "headerName": "customadd",
+                            "headerValue": "customvalue"
+                        }]
+                    }
+                ]
+            }
+        }]
+    };
+    BadRequestError invalidPolicyNameError = {body: {code: 90915, message: "Invalid operation policy name"}};
+    API apiWithInvalidPolicyParameters = {
+        name: "PizzaAPIOps",
+        context: "/pizzaAPIOps/1.0.0",
+        'version: "1.0.0",
+        endpointConfig: {"production_endpoints": {"url": "https://localhost"}},
+        operations: [
+        {
+            "target": "/menu",
+            "verb": "GET",
+            "authTypeEnabled": true,
+            "throttlingPolicy": 1000,
+            "operationPolicies": {
+                "request": [
+                    {
+                        "policyName": "addHeader",
+                        "parameters": [{
+                            "headerName1": "customadd",
+                            "headerValue": "customvalue"
+                        }]
+                    }
+                ]
+            }
+        }]
+    };
+    BadRequestError invalidPolicyParametersError = {body: {code: 90916, message: "Invalid parameters provided for policy " + "addHeader"}};
     string apiUUID = getUniqueIdForAPI(api.name, api.'version, organiztion1);
     string backenduuid = getBackendServiceUid(api, (), PRODUCTION_TYPE, organiztion1);
     string backenduuid1 = getBackendServiceUid(api, (), SANDBOX_TYPE, organiztion1);
@@ -2547,6 +2888,7 @@ function createAPIDataProvider() returns map<[string, string, API, model:ConfigM
     model:ConfigMap configmap = getMockConfigMap1(apiUUID, api);
     model:Httproute prodhttpRoute = getMockHttpRouteWithBackend(api, apiUUID, backenduuid, PRODUCTION_TYPE, organiztion1);
     model:Httproute sandhttpRoute = getMockHttpRouteWithBackend(api, apiUUID, backenduuid1, SANDBOX_TYPE, organiztion1);
+    model:Httproute prodhttpRouteWithPolicies = getMockHttpRouteWithOperationPolicies(api, apiUUID, backenduuid, PRODUCTION_TYPE, organiztion1);
 
     CreatedAPI createdAPI = {body: {name: "PizzaAPI", context: "/pizzaAPI/1.0.0", 'version: "1.0.0", id: k8sapiUUID, createdTime: "2023-01-17T11:23:49Z"}};
     commons:APKError productionEndpointNotSpecifiedError = error("Production Endpoint Not specified", message = "Endpoint Not specified", description = "Production Endpoint Not specified", code = 90911, statusCode = 400);
@@ -2795,6 +3137,86 @@ function createAPIDataProvider() returns map<[string, string, API, model:ConfigM
             getMockRuntimeAPIResponse(getMockRuntimeAPI(api, apiUUID, organiztion1, ())),
             k8sapiUUID,
             invalidAPINameError.toBalString()
+        ]
+        ,
+        "13": [
+            apiUUID,
+            backenduuid,
+            apiWithBothPolicies,
+            configmap,
+            getMockConfigMapResponse(configmap.clone()),
+            prodhttpRoute,
+            getMockHttpRouteResponse(prodhttpRoute.clone()),
+            (),
+            (),
+            services,
+            backendPolicies,
+            getMockAPI(api, apiUUID, organiztion1.uuid),
+            getMockAPIErrorNameExist(),
+            getMockRuntimeAPI(api, apiUUID, organiztion1, ()),
+            getMockRuntimeAPIResponse(getMockRuntimeAPI(api, apiUUID, organiztion1, ())),
+            k8sapiUUID,
+            bothPoliciesPresentError.toBalString()
+        ]
+        ,
+        "14": [
+            apiUUID,
+            backenduuid,
+            apiWithInvalidPolicyName,
+            configmap,
+            getMockConfigMapResponse(configmap.clone()),
+            prodhttpRoute,
+            getMockHttpRouteResponse(prodhttpRoute.clone()),
+            (),
+            (),
+            services,
+            backendPolicies,
+            getMockAPI(api, apiUUID, organiztion1.uuid),
+            getMockAPIErrorNameExist(),
+            getMockRuntimeAPI(api, apiUUID, organiztion1, ()),
+            getMockRuntimeAPIResponse(getMockRuntimeAPI(api, apiUUID, organiztion1, ())),
+            k8sapiUUID,
+            invalidPolicyNameError.toBalString()
+        ]
+        ,
+        "15": [
+            apiUUID,
+            backenduuid,
+            apiWithInvalidPolicyParameters,
+            configmap,
+            getMockConfigMapResponse(configmap.clone()),
+            prodhttpRoute,
+            getMockHttpRouteResponse(prodhttpRoute.clone()),
+            (),
+            (),
+            services,
+            backendPolicies,
+            getMockAPI(api, apiUUID, organiztion1.uuid),
+            getMockAPIErrorNameExist(),
+            getMockRuntimeAPI(api, apiUUID, organiztion1, ()),
+            getMockRuntimeAPIResponse(getMockRuntimeAPI(api, apiUUID, organiztion1, ())),
+            k8sapiUUID,
+            invalidPolicyParametersError.toBalString()
+        ]
+        ,
+        "16": [
+            apiUUID,
+            backenduuid,
+            apiWithOperationPolicies,
+            configmap,
+            getMockConfigMapResponse(configmap.clone()),
+            prodhttpRouteWithPolicies,
+            getMockHttpRouteResponse(prodhttpRouteWithPolicies.clone()),
+            (),
+            (),
+            services,
+            backendPolicies,
+            getMockAPI(api, apiUUID, organiztion1.uuid),
+            getMockAPIResponse(getMockAPI(api, apiUUID, organiztion1.uuid), k8sapiUUID),
+            getMockRuntimeAPI(apiWithOperationPolicies, apiUUID, organiztion1, ()),
+            getMockRuntimeAPIResponse(getMockRuntimeAPI(apiWithOperationPolicies, apiUUID, organiztion1, ())),
+            k8sapiUUID,
+            createdAPI.toBalString()
         ]
     };
     return data;

--- a/runtime/runtime-domain-service/ballerina/tests/APIClientTest.bal
+++ b/runtime/runtime-domain-service/ballerina/tests/APIClientTest.bal
@@ -2656,6 +2656,274 @@ function getMockHttpRouteWithOperationPolicies(API api, string apiUUID, string b
     };
 }
 
+function getMockHttpRouteWithAPIPolicies(API api, string apiUUID, string backenduuid, string 'type, commons:Organization organization) returns model:Httproute {
+    string hostnames = 'type == PRODUCTION_TYPE ? string:concat(organization.uuid, ".", "gw.wso2.com") : string:concat(organization.uuid, ".", "sandbox.gw.wso2.com");
+    return {
+        "apiVersion": "gateway.networking.k8s.io/v1beta1",
+        "kind": "HTTPRoute",
+        "metadata": {"name": "http-route-ref-name", "namespace": "apk-platform", "labels": {"api-name": api.name, "api-version": api.'version}},
+        "spec": {
+            "hostnames": [
+                hostnames
+            ],
+            "rules": [
+                {
+                    "matches": [
+                        {
+                            "path": {
+                                "type": "RegularExpression",
+                                "value": "/pizzaAPI/1.0.0(.*)"
+                            },
+                            "method": "GET"
+                        }
+                    ],
+                    "filters": [
+                        {
+                            "type": "URLRewrite",
+                            "urlRewrite": {
+                                "path": {
+                                    "type": "ReplaceFullPath",
+                                    "replaceFullPath": "\\1"
+                                }
+                            }
+                        },
+                        {
+                            "type": "RequestHeaderModifier",
+                            "requestHeaderModifier": {
+                                "set": [
+                                    {
+                                        "name": "customadd",
+                                        "value": "customvalue"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "type": "ResponseHeaderModifier",
+                            "responseHeaderModifier": {
+                                "remove": ["content-length"]
+                            }
+                        }
+                    ],
+                    "backendRefs": [
+                        {
+                            "weight": 1,
+                            "group": "",
+                            "kind": "Service",
+                            "name": backenduuid,
+                            "namespace": "apk-platform",
+                            "port": 443
+                        }
+                    ]
+                },
+                {
+                    "matches": [
+                        {
+                            "path": {
+                                "type": "RegularExpression",
+                                "value": "/pizzaAPI/1.0.0(.*)"
+                            },
+                            "method": "PUT"
+                        }
+                    ],
+                    "filters": [
+                        {
+                            "type": "URLRewrite",
+                            "urlRewrite": {
+                                "path": {
+                                    "type": "ReplaceFullPath",
+                                    "replaceFullPath": "\\1"
+                                }
+                            }
+                        },
+                        {
+                            "type": "RequestHeaderModifier",
+                            "requestHeaderModifier": {
+                                "set": [
+                                    {
+                                        "name": "customadd",
+                                        "value": "customvalue"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "type": "ResponseHeaderModifier",
+                            "responseHeaderModifier": {
+                                "remove": ["content-length"]
+                            }
+                        }
+                    ],
+                    "backendRefs": [
+                        {
+                            "weight": 1,
+                            "group": "",
+                            "kind": "Service",
+                            "name": backenduuid,
+                            "namespace": "apk-platform",
+                            "port": 443
+                        }
+                    ]
+                },
+                {
+                    "matches": [
+                        {
+                            "path": {
+                                "type": "RegularExpression",
+                                "value": "/pizzaAPI/1.0.0(.*)"
+                            },
+                            "method": "POST"
+                        }
+                    ],
+                    "filters": [
+                        {
+                            "type": "URLRewrite",
+                            "urlRewrite": {
+                                "path": {
+                                    "type": "ReplaceFullPath",
+                                    "replaceFullPath": "\\1"
+                                }
+                            }
+                        },
+                        {
+                            "type": "RequestHeaderModifier",
+                            "requestHeaderModifier": {
+                                "set": [
+                                    {
+                                        "name": "customadd",
+                                        "value": "customvalue"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "type": "ResponseHeaderModifier",
+                            "responseHeaderModifier": {
+                                "remove": ["content-length"]
+                            }
+                        }
+                    ],
+                    "backendRefs": [
+                        {
+                            "weight": 1,
+                            "group": "",
+                            "kind": "Service",
+                            "name": backenduuid,
+                            "namespace": "apk-platform",
+                            "port": 443
+                        }
+                    ]
+                },
+                {
+                    "matches": [
+                        {
+                            "path": {
+                                "type": "RegularExpression",
+                                "value": "/pizzaAPI/1.0.0(.*)"
+                            },
+                            "method": "DELETE"
+                        }
+                    ],
+                    "filters": [
+                        {
+                            "type": "URLRewrite",
+                            "urlRewrite": {
+                                "path": {
+                                    "type": "ReplaceFullPath",
+                                    "replaceFullPath": "\\1"
+                                }
+                            }
+                        },
+                        {
+                            "type": "RequestHeaderModifier",
+                            "requestHeaderModifier": {
+                                "set": [
+                                    {
+                                        "name": "customadd",
+                                        "value": "customvalue"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "type": "ResponseHeaderModifier",
+                            "responseHeaderModifier": {
+                                "remove": ["content-length"]
+                            }
+                        }
+                    ],
+                    "backendRefs": [
+                        {
+                            "weight": 1,
+                            "group": "",
+                            "kind": "Service",
+                            "name": backenduuid,
+                            "namespace": "apk-platform",
+                            "port": 443
+                        }
+                    ]
+                },
+                {
+                    "matches": [
+                        {
+                            "path": {
+                                "type": "RegularExpression",
+                                "value": "/pizzaAPI/1.0.0(.*)"
+                            },
+                            "method": "PATCH"
+                        }
+                    ],
+                    "filters": [
+                        {
+                            "type": "URLRewrite",
+                            "urlRewrite": {
+                                "path": {
+                                    "type": "ReplaceFullPath",
+                                    "replaceFullPath": "\\1"
+                                }
+                            }
+                        },
+                        {
+                            "type": "RequestHeaderModifier",
+                            "requestHeaderModifier": {
+                                "set": [
+                                    {
+                                        "name": "customadd",
+                                        "value": "customvalue"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "type": "ResponseHeaderModifier",
+                            "responseHeaderModifier": {
+                                "remove": ["content-length"]
+                            }
+                        }
+                    ],
+                    "backendRefs": [
+                        {
+                            "weight": 1,
+                            "group": "",
+                            "kind": "Service",
+                            "name": backenduuid,
+                            "namespace": "apk-platform",
+                            "port": 443
+                        }
+                    ]
+                }
+            ],
+            "parentRefs": [
+                {
+                    "group": "gateway.networking.k8s.io",
+                    "kind": "Gateway",
+                    "name": "Default"
+                }
+            ]
+        }
+    };
+}
+
 function createAPIDataProvider() returns map<[string, string, API, model:ConfigMap, any, model:Httproute?, any, model:Httproute?, any, [model:Service, any][], [model:BackendPolicy, any][], model:API, any, model:RuntimeAPI, any, string, anydata]> {
     API api = {
         name: "PizzaAPI",
@@ -2748,6 +3016,62 @@ function createAPIDataProvider() returns map<[string, string, API, model:ConfigM
             "authTypeEnabled": true,
             "throttlingPolicy": 1000
         }]
+    };
+    API apiWithAPIPolicies = {
+        name: "PizzaAPI",
+        context: "/pizzaAPI/1.0.0",
+        'version: "1.0.0",
+        endpointConfig: {"production_endpoints": {"url": "https://localhost"}},
+        operations: [
+        {
+            "target": "/*",
+            "verb": "GET",
+            "authTypeEnabled": true,
+            "throttlingPolicy": 1000
+        },
+        {
+            "target": "/*",
+            "verb": "PUT",
+            "authTypeEnabled": true,
+            "throttlingPolicy": 1000
+        },
+        {
+            "target": "/*",
+            "verb": "POST",
+            "authTypeEnabled": true,
+            "throttlingPolicy": 1000
+        },
+        {
+            "target": "/*",
+            "verb": "DELETE",
+            "authTypeEnabled": true,
+            "throttlingPolicy": 1000
+        },
+        {
+            "target": "/*",
+            "verb": "PATCH",
+            "authTypeEnabled": true,
+            "throttlingPolicy": 1000
+        }],
+        apiPolicies: {
+            "request": [
+                {
+                    "policyName": "addHeader",
+                    "parameters": [{
+                        "headerName": "customadd",
+                        "headerValue": "customvalue"
+                    }]
+                }
+            ],
+            "response": [
+                {
+                    "policyName": "removeHeader",
+                    "parameters": [{
+                        "headerName": "content-length"
+                    }]
+                }
+            ]
+        }
     };
     API apiWithBothPolicies = {
         name: "PizzaAPIPolicies",
@@ -2888,7 +3212,8 @@ function createAPIDataProvider() returns map<[string, string, API, model:ConfigM
     model:ConfigMap configmap = getMockConfigMap1(apiUUID, api);
     model:Httproute prodhttpRoute = getMockHttpRouteWithBackend(api, apiUUID, backenduuid, PRODUCTION_TYPE, organiztion1);
     model:Httproute sandhttpRoute = getMockHttpRouteWithBackend(api, apiUUID, backenduuid1, SANDBOX_TYPE, organiztion1);
-    model:Httproute prodhttpRouteWithPolicies = getMockHttpRouteWithOperationPolicies(api, apiUUID, backenduuid, PRODUCTION_TYPE, organiztion1);
+    model:Httproute prodhttpRouteWithOperationPolicies = getMockHttpRouteWithOperationPolicies(api, apiUUID, backenduuid, PRODUCTION_TYPE, organiztion1);
+    model:Httproute prodhttpRouteWithAPIPolicies = getMockHttpRouteWithAPIPolicies(api, apiUUID, backenduuid, PRODUCTION_TYPE, organiztion1);
 
     CreatedAPI createdAPI = {body: {name: "PizzaAPI", context: "/pizzaAPI/1.0.0", 'version: "1.0.0", id: k8sapiUUID, createdTime: "2023-01-17T11:23:49Z"}};
     commons:APKError productionEndpointNotSpecifiedError = error("Production Endpoint Not specified", message = "Endpoint Not specified", description = "Production Endpoint Not specified", code = 90911, statusCode = 400);
@@ -3205,8 +3530,8 @@ function createAPIDataProvider() returns map<[string, string, API, model:ConfigM
             apiWithOperationPolicies,
             configmap,
             getMockConfigMapResponse(configmap.clone()),
-            prodhttpRouteWithPolicies,
-            getMockHttpRouteResponse(prodhttpRouteWithPolicies.clone()),
+            prodhttpRouteWithOperationPolicies,
+            getMockHttpRouteResponse(prodhttpRouteWithOperationPolicies.clone()),
             (),
             (),
             services,
@@ -3215,6 +3540,26 @@ function createAPIDataProvider() returns map<[string, string, API, model:ConfigM
             getMockAPIResponse(getMockAPI(api, apiUUID, organiztion1.uuid), k8sapiUUID),
             getMockRuntimeAPI(apiWithOperationPolicies, apiUUID, organiztion1, ()),
             getMockRuntimeAPIResponse(getMockRuntimeAPI(apiWithOperationPolicies, apiUUID, organiztion1, ())),
+            k8sapiUUID,
+            createdAPI.toBalString()
+        ]
+        ,
+        "17": [
+            apiUUID,
+            backenduuid,
+            apiWithAPIPolicies,
+            configmap,
+            getMockConfigMapResponse(configmap.clone()),
+            prodhttpRouteWithAPIPolicies,
+            getMockHttpRouteResponse(prodhttpRouteWithAPIPolicies.clone()),
+            (),
+            (),
+            services,
+            backendPolicies,
+            getMockAPI(api, apiUUID, organiztion1.uuid),
+            getMockAPIResponse(getMockAPI(api, apiUUID, organiztion1.uuid), k8sapiUUID),
+            getMockRuntimeAPI(apiWithAPIPolicies, apiUUID, organiztion1, ()),
+            getMockRuntimeAPIResponse(getMockRuntimeAPI(apiWithAPIPolicies, apiUUID, organiztion1, ())),
             k8sapiUUID,
             createdAPI.toBalString()
         ]

--- a/runtime/runtime-domain-service/ballerina/types.bal
+++ b/runtime/runtime-domain-service/ballerina/types.bal
@@ -299,8 +299,8 @@ public type OperationPolicy record {
 };
 
 public type OperationPolicyParameters record {
-    string name?;
-    string value?;
+    string headerName?;
+    string headerValue?;
 };
 
 public type Apis_import_body record {

--- a/runtime/runtime-domain-service/ballerina/types.bal
+++ b/runtime/runtime-domain-service/ballerina/types.bal
@@ -295,7 +295,12 @@ public type OperationPolicy record {
     string policyName;
     string policyVersion = "v1";
     string policyId?;
-    record {} parameters?;
+    OperationPolicyParameters[] parameters?;
+};
+
+public type OperationPolicyParameters record {
+    string name?;
+    string value?;
 };
 
 public type Apis_import_body record {


### PR DESCRIPTION
## Purpose
- This PR will provide the support to attach mediation policies to API resources
- Related Issue: https://github.com/wso2/apk/issues/788

## Goals
- Mediation policies given under operations section of the payload should be attached to the relevant resource API
- Mediation policies given under apiPolicies section of the payload should be attached to all the resources of the API
- Validate the name and parameters of the given mediation policies
- Validate the presence of resource level and API level mediation policies in the request payload. Such a payload is not allowed

## Payload
- Operation policy payload will take the following format
```json
{
    "request": [
        "policyName": "addHeader",
        "parameters": [
            {
                "headerName": "Custom",
                "headerValue": "CustomValue"
            }
        ]
    ],
    "response": [
        "policyName": "removeHeader",
        "parameters": [
            {
                "headerName": "Content-Length"
            }
        ]
    ]
}
```
