### PR TITLE
[Migration] Add migration flag and authentication CR for runtime

### DIFF
--- a/common-bal-libs/apk-common-lib/JWTValidationInterceptor.bal
+++ b/common-bal-libs/apk-common-lib/JWTValidationInterceptor.bal
@@ -42,7 +42,7 @@ public service class JWTValidationInterceptor {
                         userContext.claims = self.extractCustomClaims(validatedJWT);
                         return userContext;
                     } else {
-                        APKError apkError = error("inactive organization", code = 900951, description = "organization is enactive", statusCode = 401, message = "organization is enactive");
+                        APKError apkError = error("Inactive Organization", code = 900951, description = "Organization is inactive", statusCode = 401, message = "Organization is inactive");
                         return apkError;
                     }
                 } else {

--- a/helm-charts/templates/data-plane/runtime-ds/runtime-ds-authentication.yaml
+++ b/helm-charts/templates/data-plane/runtime-ds/runtime-ds-authentication.yaml
@@ -1,0 +1,36 @@
+# Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+{{- if .Values.wso2.apk.migration.enabled }}
+apiVersion: "dp.wso2.com/v1alpha1"
+kind: "Authentication"
+metadata:
+  name: {{ template "apk-helm.resource.prefix" . }}-runtime-ds-authentication
+  namespace: {{ .Release.Namespace }}
+  labels:
+    api-name: "runtime-domain-service"
+    api-version: "1.0.0"
+spec:
+  override:
+    ext:
+      disabled: true
+    type: "ext"
+  targetRef:
+    group: ""
+    kind: "HTTPRoute"
+    name: {{ template "apk-helm.resource.prefix" . }}-runtime-ds-httproute
+    namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/helm-charts/values.yaml
+++ b/helm-charts/values.yaml
@@ -403,6 +403,10 @@ wso2:
             #       properties:
             #         - name: filterConfig1
             #           value: filterConfig1
+    migration:
+    # This flag should be enabled only in a migration scenario.
+    # It is not recommended to run a production deployment with this flag enabled.
+      enabled: false        
 certmanager:
   enabled: true
   enableClusterIssuer: true


### PR DESCRIPTION
## Purpose
This PR adds a new migration flag and an Authentication CR for the Runtime DS to be used in a migration scenario

## Approach
Enabling the migration flag will change the authentication mechanism for the Runtime DS allowing the migration client (Loader) to import the runtime APIs.


Related issue: https://github.com/wso2/apk/issues/787