### PR TITLE
Fix enforcer pod cashing issue when adapter is not available 

### DIFF
--- a/helm-charts/templates/data-plane/gateway-components/gateway-runtime/gateway-runtime-deployment.yaml
+++ b/helm-charts/templates/data-plane/gateway-components/gateway-runtime/gateway-runtime-deployment.yaml
@@ -33,6 +33,15 @@ spec:
         networkPolicyId: {{ .Values.wso2.apk.dp.gatewayRuntime.deployment.enforcer.npi }}
 {{ include "apk-helm.pod.selectorLabels" (dict "root" . "app" .Values.wso2.apk.dp.gatewayRuntime.appName ) | indent 8}}
     spec:
+      initContainers:
+        - name: check-adapter
+          image: busybox:1.32
+          env:
+            - name: ADAPTER_HOST
+              value: {{ template "apk-helm.resource.prefix" . }}-adapter-service.{{ .Release.Namespace }}.svc
+            - name: ADAPTER_XDS_PORT
+              value : "18000"  
+          command: ['sh', '-c', 'echo -e "Checking for the availability of Adapter deployment"; while ! nc -z $ADAPTER_HOST $ADAPTER_XDS_PORT; do sleep 1; printf "-"; done; echo -e "  >> Adapter has started";']
       containers:
         - name: enforcer
           image: {{ .Values.wso2.apk.dp.gatewayRuntime.deployment.enforcer.image }}


### PR DESCRIPTION
## Purpose
This will fix the enforcer pod crashing issue if the adapter is not available at the beginning. From this the gateway will wait until the adapter is up and running

## Fixes
- https://github.com/wso2/apk/issues/578

