### PR TITLE
[Migration] Add authentication CR for Admin DS

### DIFF
--- a/helm-charts/templates/control-plane/admin-ds/admin-ds-authentication.yaml
+++ b/helm-charts/templates/control-plane/admin-ds/admin-ds-authentication.yaml
@@ -1,0 +1,36 @@
+# Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+{{- if .Values.wso2.apk.migration.enabled }}
+apiVersion: "dp.wso2.com/v1alpha1"
+kind: "Authentication"
+metadata:
+  name: {{ template "apk-helm.resource.prefix" . }}-admin-ds-authentication
+  namespace: {{ .Release.Namespace }}
+  labels:
+    api-name: "admin-domain-service"
+    api-version: "1.0.0"
+spec:
+  override:
+    ext:
+      disabled: true
+    type: "ext"
+  targetRef:
+    group: ""
+    kind: "HTTPRoute"
+    name: {{ template "apk-helm.resource.prefix" . }}-admin-ds-httproute
+    namespace: {{ .Release.Namespace }}
+{{- end -}}


### PR DESCRIPTION
## Purpose
This PR adds an Authentication CR for the Admin DS to be used in a migration scenario

Related issue: https://github.com/wso2/apk/issues/787

