### PR TITLE
Interceptor api support for setting custom metadata

### DIFF
--- a/developer/resources/interceptor-service-open-api-v1.yaml
+++ b/developer/resources/interceptor-service-open-api-v1.yaml
@@ -1,0 +1,287 @@
+# Copyright (c) 2023, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+openapi: 3.0.0
+servers:
+  - url: "{interceptor_service_url}/api/v1"
+    variables:
+      interceptor_service_url:
+        default: https://interceptor-service:8443
+        description: interceptor_host assigned by the service provider
+info:
+  title: Choreo-Connect Interceptor Service
+  description: Interceptor Service
+  version: v1
+  contact:
+    name: WSO2
+    url: http://wso2.com/products/api-manager/
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+tags:
+  - name: interceptor
+    description: Interceptor
+paths:
+  "/handle-request":
+    post:
+      tags:
+        - Request
+      summary: Handle Request
+      operationId: handleRequest
+      requestBody:
+        description: |
+          Content of the request
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RequestHandlerRequestBody"
+      responses:
+        200:
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RequestHandlerResponseBody"
+
+  "/handle-response":
+    post:
+      tags:
+        - Response
+      summary: Handle Response
+      operationId: handleResponse
+      requestBody:
+        description: |
+          Content of the request
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ResponseHandlerRequestBody"
+      responses:
+        200:
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseHandlerResponseBody"
+
+components:
+  schemas:
+    RequestHandlerRequestBody:
+      title: Request body of Request handler
+      type: object
+      properties:
+        requestHeaders:
+          $ref: "#/components/schemas/Headers"
+        requestTrailers:
+          $ref: "#/components/schemas/Trailers"
+        requestBody:
+          $ref: "#/components/schemas/Body"
+        invocationContext:
+          $ref: "#/components/schemas/InvocationContext"
+    RequestHandlerResponseBody:
+      title: Response body of Request handler
+      type: object
+      properties:
+        directRespond:
+          type: boolean
+          example: false
+        responseCode:
+          type: integer
+          example: 200
+        dynamicEndpoint:
+          $ref: "#/components/schemas/DynamicEndpoint"
+        headersToAdd:
+          $ref: "#/components/schemas/Headers"
+        headersToReplace:
+          $ref: "#/components/schemas/Headers"
+        headersToRemove:
+          $ref: "#/components/schemas/HeaderKeys"
+        trailersToAdd:
+          $ref: "#/components/schemas/Trailers"
+        trailersToReplace:
+          $ref: "#/components/schemas/Trailers"
+        trailersToRemove:
+          $ref: "#/components/schemas/HeaderKeys"
+        body:
+          $ref: "#/components/schemas/Body"
+        interceptorContext:
+          $ref: "#/components/schemas/InterceptorContext"
+        properties:
+          $ref: "#/components/schemas/Properties"
+    ResponseHandlerRequestBody:
+      title: Request body of Response handler
+      type: object
+      properties:
+        responseCode:
+          type: integer
+          example: 200
+        requestHeaders:
+          $ref: "#/components/schemas/Headers"
+        requestTrailers:
+          $ref: "#/components/schemas/Trailers"
+        requestBody:
+          $ref: "#/components/schemas/Body"
+        responseHeaders:
+          $ref: "#/components/schemas/Headers"
+        responseTrailers:
+          $ref: "#/components/schemas/Trailers"
+        responseBody:
+          $ref: "#/components/schemas/Body"
+        invocationContext:
+          $ref: "#/components/schemas/InvocationContext"
+        interceptorContext:
+          $ref: "#/components/schemas/InterceptorContext"
+      required:
+        - responseCode
+    ResponseHandlerResponseBody:
+      title: Response Body
+      type: object
+      properties:
+        responseCode:
+          type: integer
+          example: 200
+        headersToAdd:
+          $ref: "#/components/schemas/Headers"
+        headersToReplace:
+          $ref: "#/components/schemas/Headers"
+        headersToRemove:
+          $ref: "#/components/schemas/HeaderKeys"
+        trailersToAdd:
+          $ref: "#/components/schemas/Trailers"
+        trailersToReplace:
+          $ref: "#/components/schemas/Trailers"
+        trailersToRemove:
+          $ref: "#/components/schemas/HeaderKeys"
+        body:
+          $ref: "#/components/schemas/Body"
+        properties:
+          $ref: "#/components/schemas/Properties"
+    InvocationContext:
+      title: Invocation context
+      type: object
+      properties:
+        requestId:
+          type: string
+          example: 75269e44-f797-4432-9906-cf39e68d6ab8
+        protocol:
+          type: string
+          example: HTTP/1.1
+        scheme:
+          type: string
+          example: https
+        apiName:
+          type: string
+          example: PetStore
+        apiVersion:
+          type: string
+          example: v1.0.0
+        vhost:
+          type: string
+          example: localhost
+        supportedMethods:
+          type: string
+          example: GET POST
+        method:
+          type: string
+          example: POST
+        basePath:
+          type: string
+          example: /petstore
+        path:
+          type: string
+          example: /petstore/pet/1
+        pathTemplate:
+          type: string
+          example: /pet/{petID}
+        source:
+          type: string
+          example: 192.168.8.332:8080
+        prodClusterName:
+          type: string
+          example: carbon.super_clusterProd_localhost_Online-Storev1.0.0
+        sandClusterName:
+          type: string
+          example: ""
+        authenticationContext:
+          type: object
+          properties:
+            tokenType:
+              type: string
+              example: JWT
+            token:
+              type: string
+              example: xxxxxx-xxxx-xxxxxx-xxxx
+            keyType:
+              type: string
+              example: PRODUCTION
+    InterceptorContext:
+      title: Interceptor Context
+      type: object
+      additionalProperties:
+        type: string
+      description: |
+        Map (string-to-string dictionary) of key value pairs
+      example:
+        key1: value1
+        key2: value2
+    DynamicEndpoint:
+      title: Dynamic endpoint
+      type: object
+      properties:
+        endpointName:
+          type: string
+          example: my-dynamic-endpoint
+    Headers:
+      title: Headers
+      type: object
+      additionalProperties:
+        type: string
+      description: |
+        Map (string-to-string dictionary) of key value pairs of headers
+      example:
+        content-type: application/xml
+        content-length: "40"
+    Trailers:
+      title: Trailers
+      type: object
+      additionalProperties:
+        type: string
+      description: |
+        Map (string-to-string dictionary) of key value pairs of trailers
+      example:
+        trailer1-key: value
+    HeaderKeys:
+      title: HeaderKeys
+      type: array
+      items:
+        type: string
+      description: |
+        Array of header keys
+      example:
+        - key1
+        - key2
+    Body:
+      type: string
+      description: |
+        Base64 encoded body
+      example: PGhlbGxvPndvcmxkPC9oZWxsbz4K
+    Properties:
+      title: Properties
+      type: object
+      additionalProperties:
+        type: string
+      description: |
+        Map (string-to-string dictionary) of key value pairs of properties
+      example:
+        property-1-key: property-1-value

--- a/gateway/router/resources/interceptor/lib/consts.lua
+++ b/gateway/router/resources/interceptor/lib/consts.lua
@@ -74,7 +74,8 @@ RESPONSE = {
     TRAILERS_TO_REPLACE = "trailersToReplace",
     TRAILERS_TO_REMOVE = "trailersToRemove",
     INTCPT_CONTEXT = "interceptorContext",
-    DYNAMIC_ENDPOINT = "dynamicEndpoint"
+    DYNAMIC_ENDPOINT = "dynamicEndpoint",
+    DYNAMIC_METADATA = "properties",
 }
 
 DYNAMIC_ENDPOINT = {
@@ -96,3 +97,4 @@ STATUS = ":status"
 LUA_FILTER_NAME = "envoy.filters.http.lua"
 EXT_AUTHZ_FILTER = "envoy.filters.http.ext_authz"
 SHARED_INFO_META_KEY = "shared.info"
+CUSTOM_METADATA_KEY = "apk.custom.metadata"

--- a/gateway/router/resources/interceptor/lib/interceptor.lua
+++ b/gateway/router/resources/interceptor/lib/interceptor.lua
@@ -82,6 +82,16 @@ local function handle_dynamic_endpoint(handle, interceptor_response_body, inv_co
     end
 end
 
+local function set_dynamic_metadata(handle, interceptor_response_body)
+    if interceptor_response_body[RESPONSE.DYNAMIC_METADATA] then
+        handle:logDebug("Response body has dynamic metadata. Setting dynamic metadata...")
+        for metadata_key, metadata_velue in pairs(interceptor_response_body[RESPONSE.DYNAMIC_METADATA]) do
+            handle:streamInfo():dynamicMetadata():set(CUSTOM_METADATA_KEY, metadata_key, metadata_velue)
+            handle:logDebug("set metadata <key: "..metadata_key..", value: "..metadata_velue..">")
+        end
+    end
+end
+
 --- modify body
 ---@param handle table
 ---@param interceptor_response_body table
@@ -387,6 +397,7 @@ function interceptor.handle_request_interceptor(request_handle, intercept_servic
     end
 
     request_handle:streamInfo():dynamicMetadata():set(LUA_FILTER_NAME, SHARED_INFO_META_KEY, shared_info)
+    set_dynamic_metadata(request_handle, interceptor_response_body)
 end
 
 ---interceptor handler for response flow
@@ -496,6 +507,8 @@ function interceptor.handle_response_interceptor(response_handle, intercept_serv
     --#endregion
 
     utils.wire_log_trailers(response_handle, " >> response trailers >> ", wire_log_config.log_trailers_enabled)
+    
+    set_dynamic_metadata(response_handle, interceptor_response_body)
 end
 
 return interceptor


### PR DESCRIPTION
## Purpose
$subject

## Interceptor sample response in request path
```
{
  "headersToAdd": {
    "x-user": "admin"
  },
  "headersToReplace": {
    "content-type": "application/xml"
  },
  "body": "PG5hbWU+VGhlIFByaXNvbmVyPC9uYW1lPg==",
  "properties": {
    "hello": "world",
    "hi": "hey"
  }
}
```
This will set metadata as:
```
apk.custom.metadata["hello"] = "world"
apk.custom.metadata["hi"] = "hey"
```
