### PR TITLE
[Runtime DS] Fix Resources used for OpenAPI Definition Validation

### DIFF
--- a/runtime/runtime-domain-service/ballerina/api_service.bal
+++ b/runtime/runtime-domain-service/ballerina/api_service.bal
@@ -73,7 +73,7 @@ http:Service runtimeService = service object {
         commons:Organization organization = authenticatedUserContext.organization;
         return apiService.importDefinition(message, organization);
     }
-    isolated resource function post apis/'validate\-definition(http:RequestContext requestContext, http:Request message, boolean returnContent = false) returns APIDefinitionValidationResponse|BadRequestError|NotFoundError|InternalServerErrorError|commons:APKError {
+    isolated resource function post apis/'validate\-definition(http:RequestContext requestContext, http:Request message, boolean returnContent = false) returns http:Ok|BadRequestError|NotFoundError|InternalServerErrorError|commons:APKError {
         final APIClient apiService = new ();
         return apiService.validateDefinition(message, returnContent);
     }

--- a/runtime/runtime-domain-service/ballerina/resources/runtime-api.yaml
+++ b/runtime/runtime-domain-service/ballerina/resources/runtime-api.yaml
@@ -432,8 +432,6 @@ paths:
                 $ref: "#/components/schemas/APIDefinitionValidationResponse"
         "400":
           $ref: "#/components/responses/BadRequest"
-        "404":
-          $ref: "#/components/responses/NotFound"
         "500":
           $ref: "#/components/responses/InternalServerError"
   /apis/validate:
@@ -1843,7 +1841,8 @@ components:
           format: binary
         type:
           type: string
-          description: API definition type - OpenAPI/AsyncAPI/GraphQL
+          description: API definition type - REST/ASYNC/GRAPHQL
+          default: REST
         inlineAPIDefinition:
           type: string
           description: Inline content of the API definition


### PR DESCRIPTION
## Purpose
- Fix https://github.com/wso2/apk/issues/969

## Approach
- Fix status code for successful response
- Utilise `returnContent` query parameter for URL type API definitions
- Update error messages for `BadRequestError`
- Update `runtime/runtime-domain-service/ballerina/resources/runtime-api.yaml`