### PR TITLE
[Runtime DS] Fix multiple issues related to Endpoint Certificate resources

### DIFF
--- a/runtime/runtime-domain-service/ballerina/CertUtils.bal
+++ b/runtime/runtime-domain-service/ballerina/CertUtils.bal
@@ -123,7 +123,7 @@ isolated function convertConfigMapToCertificate(model:ConfigMap configMap) retur
     boolean active = false;
     [int, decimal] currentTime = time:utcNow();
     if currentTime[0] >= check int:fromString(notBefore) && currentTime[0] <= check int:fromString(notAfter) {
-        active = false;
+        active = true;
     }
     return {
         'version: certificateVersion,

--- a/runtime/runtime-domain-service/ballerina/api_service.bal
+++ b/runtime/runtime-domain-service/ballerina/api_service.bal
@@ -163,7 +163,7 @@ http:Service runtimeService = service object {
         commons:Organization organization = authenticatedUserContext.organization;
         return apiService.getEndpointCertificateByID(apiId,certificateId, organization);
     }
-    resource function put apis/[string apiId]/'endpoint\-certificates/[string certificateId](http:RequestContext requestContext,http:Request request) returns CertMetadata|BadRequestError|NotFoundError|InternalServerErrorError|commons:APKError {
+    resource function put apis/[string apiId]/'endpoint\-certificates/[string certificateId](http:RequestContext requestContext,http:Request request) returns OkCertMetadata|BadRequestError|NotFoundError|InternalServerErrorError|commons:APKError {
         final APIClient apiService = new ();
         commons:UserContext authenticatedUserContext = check commons:getAuthenticatedUserContext(requestContext);
         commons:Organization organization = authenticatedUserContext.organization;

--- a/runtime/runtime-domain-service/ballerina/resources/runtime-api.yaml
+++ b/runtime/runtime-domain-service/ballerina/resources/runtime-api.yaml
@@ -663,9 +663,9 @@ paths:
                   type: string
                   description: The certificate that needs to be uploaded.
                   format: binary
-                endpoint:
+                host:
                   type: string
-                  description: Endpoint to which the certificate should be applied.
+                  description: Host of the endpoint to which the certificate should be applied.
         required: true
       responses:
         200:


### PR DESCRIPTION
## Purpose
- Fix https://github.com/wso2/apk/issues/1048

## Approach
- Add `next`, `previous` fields in the pagination when retrieving endpoint certificates
```
"pagination": {
        "offset": 1,
        "limit": 2,
        "total": 4,
        "next": "/apis/e9fe9b98-99ce-4630-8369-b8f7ff74ae4b/endpoint-certificates?limit=2&offset=3&endpoint=",
        "previous": "/apis/e9fe9b98-99ce-4630-8369-b8f7ff74ae4b/endpoint-certificates?limit=2&offset=0&endpoint="
    }
 ```
- Add location header to the response when adding and updating endpoint certificates.
<img width="1156" alt="Screenshot 2023-04-18 at 16 25 30" src="https://user-images.githubusercontent.com/55122994/232756454-4220fa6e-b553-45e7-8138-7339bfdef319.png">

- Fix an internal server error while retrieving endpoint certificate information.
   - Remove `utcToCivil` conversion and directly convert it to RFC 3339 timestamp from the UTC timestamp.

- Update `runtime-api.yaml`.