### PR TITLE
[Adaptor] Enable operator HA

### DIFF
--- a/adapter/internal/operator/operator.go
+++ b/adapter/internal/operator/operator.go
@@ -31,6 +31,7 @@ import (
 	dpcontrollers "github.com/wso2/apk/adapter/internal/operator/controllers/dp"
 	"github.com/wso2/apk/adapter/internal/operator/status"
 	"github.com/wso2/apk/adapter/internal/operator/synchronizer"
+	"github.com/wso2/apk/adapter/internal/operator/utils"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
@@ -84,12 +85,13 @@ func InitOperator() {
 	operatorDataStore := synchronizer.CreateNewOperatorDataStore()
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
-		Scheme:                 scheme,
-		MetricsBindAddress:     metricsAddr,
-		Port:                   9443,
-		HealthProbeBindAddress: probeAddr,
-		LeaderElection:         enableLeaderElection,
-		LeaderElectionID:       "73c5c496.wso2.com",
+		Scheme:                  scheme,
+		MetricsBindAddress:      metricsAddr,
+		Port:                    9443,
+		HealthProbeBindAddress:  probeAddr,
+		LeaderElection:          true,
+		LeaderElectionID:        "operator-lease.apk.wso2.com",
+		LeaderElectionNamespace: utils.GetOperatorPodNamespace(),
 		// LeaderElectionReleaseOnCancel defines if the leader should step down voluntarily
 		// when the Manager ends. This requires the binary to immediately end when the
 		// Manager is stopped, otherwise, this setting is unsafe. Setting this significantly

--- a/helm-charts/templates/data-plane/gateway-components/adapter/adapter-deployment.yaml
+++ b/helm-charts/templates/data-plane/gateway-components/adapter/adapter-deployment.yaml
@@ -33,16 +33,6 @@ spec:
 {{ include "apk-helm.pod.selectorLabels" (dict "root" . "app" "adapter" ) | indent 8}}
     spec:
       serviceAccountName: {{ .Values.wso2.apk.auth.serviceAccountName }}
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: app.kubernetes.io/app
-                operator: In
-                values:
-                - adapter
-            topologyKey: "kubernetes.io/hostname"
       containers:
         - name: adapter
           image: {{ .Values.wso2.apk.dp.adapter.deployment.image }}

--- a/helm-charts/templates/data-plane/gateway-components/adapter/adapter-deployment.yaml
+++ b/helm-charts/templates/data-plane/gateway-components/adapter/adapter-deployment.yaml
@@ -33,6 +33,16 @@ spec:
 {{ include "apk-helm.pod.selectorLabels" (dict "root" . "app" "adapter" ) | indent 8}}
     spec:
       serviceAccountName: {{ .Values.wso2.apk.auth.serviceAccountName }}
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app.kubernetes.io/app
+                operator: In
+                values:
+                - adapter
+            topologyKey: "kubernetes.io/hostname"
       containers:
         - name: adapter
           image: {{ .Values.wso2.apk.dp.adapter.deployment.image }}

--- a/helm-charts/templates/serviceAccount/apk-cluster-role.yaml
+++ b/helm-charts/templates/serviceAccount/apk-cluster-role.yaml
@@ -101,4 +101,7 @@ rules:
   - apiGroups: [ "dp.wso2.com" ]
     resources: [ "ratelimitpolicies/status" ]
     verbs: [ "get","patch","update" ]
+  - apiGroups: [ "coordination.k8s.io" ]
+    resources: [ "leases" ]
+    verbs: [ "get","list","watch","update","patch","create","delete" ]
 {{- end -}}


### PR DESCRIPTION
## Purpose
This is to enable high availability for adaptor operator. Configured using controller manager config which enable a k8s lease.  Kept the pod count as 1 since no need to enable for development.

## Tested
Tested with two nodes in a kind cluster with adaptor deployment replica count set to 2. 