### PR TITLE
Add CORS policy support

### DIFF
--- a/adapter/config/default_config.go
+++ b/adapter/config/default_config.go
@@ -53,15 +53,6 @@ var defaultConfig = &Config{
 			CertPath: "/home/wso2/security/keystore/mg.pem",
 		},
 		SystemHost: "localhost",
-		Cors: globalCors{
-			Enabled:      true,
-			AllowOrigins: []string{"*"},
-			AllowMethods: []string{"GET", "PUT", "POST", "DELETE", "PATCH", "OPTIONS"},
-			AllowHeaders: []string{"authorization", "Access-Control-Allow-Origin", "Content-Type", "SOAPAction", "apikey",
-				"testKey", "Internal-Key"},
-			AllowCredentials: false,
-			ExposeHeaders:    []string{},
-		},
 		Upstream: envoyUpstream{
 			TLS: upstreamTLS{
 				MinimumProtocolVersion: "TLS1_1",

--- a/adapter/config/types.go
+++ b/adapter/config/types.go
@@ -103,7 +103,6 @@ type envoy struct {
 	EnforcerResponseTimeoutInSeconds time.Duration `default:"20"`
 	KeyStore                         keystore
 	SystemHost                       string `default:"localhost"`
-	Cors                             globalCors
 	Upstream                         envoyUpstream
 	Downstream                       envoyDownstream
 	Connection                       connection
@@ -175,16 +174,6 @@ type consul struct {
 	CertFile string
 	// KeyFile path to the key file(PEM encoded) required for tls connection between adapter and a consul client
 	KeyFile string
-}
-
-// Global CORS configurations
-type globalCors struct {
-	Enabled          bool
-	AllowOrigins     []string
-	AllowMethods     []string
-	AllowHeaders     []string
-	AllowCredentials bool
-	ExposeHeaders    []string
 }
 
 // Router to enforcer request body passing configurations

--- a/adapter/internal/oasparser/model/http_route.go
+++ b/adapter/internal/oasparser/model/http_route.go
@@ -255,6 +255,7 @@ func (swagger *AdapterInternalAPI) SetInfoHTTPRouteCR(httpRoute *gwapiv1b1.HTTPR
 			resources = append(resources, resource)
 		}
 	}
+	swagger.xWso2Cors = getCorsConfigFromAPIPolicy(apiPolicy)
 	swagger.RateLimitPolicy = parseRateLimitPolicyToInternal(ratelimitPolicy)
 	swagger.resources = resources
 	apiPolicySelected := concatAPIPolicies(apiPolicy, nil)
@@ -289,6 +290,23 @@ func parseBackendJWTTokenToInternal(backendJWTToken *dpv1alpha1.BackendJWTToken)
 		TokenTTL:         backendJWTToken.TokenTTL,
 	}
 	return backendJWTTokenInternal
+}
+
+func getCorsConfigFromAPIPolicy(apiPolicy *dpv1alpha1.APIPolicy) *CorsConfig {
+	var corsConfig *CorsConfig
+	if apiPolicy != nil && apiPolicy.Spec.Override != nil {
+		if apiPolicy.Spec.Override.CORSPolicy != nil {
+			corsConfig = &CorsConfig{
+				Enabled:                       apiPolicy.Spec.Override.CORSPolicy.Enabled,
+				AccessControlAllowCredentials: apiPolicy.Spec.Override.CORSPolicy.AccessControlAllowCredentials,
+				AccessControlAllowHeaders:     apiPolicy.Spec.Override.CORSPolicy.AccessControlAllowHeaders,
+				AccessControlAllowMethods:     apiPolicy.Spec.Override.CORSPolicy.AccessControlAllowMethods,
+				AccessControlAllowOrigins:     apiPolicy.Spec.Override.CORSPolicy.AccessControlAllowOrigins,
+				AccessControlExposeHeaders:    apiPolicy.Spec.Override.CORSPolicy.AccessControlExposeHeaders,
+			}
+		}
+	}
+	return corsConfig
 }
 
 func parseRateLimitPolicyToInternal(ratelimitPolicy *dpv1alpha1.RateLimitPolicy) *RateLimitPolicy {

--- a/adapter/internal/operator/apis/dp/v1alpha1/apipolicy_types.go
+++ b/adapter/internal/operator/apis/dp/v1alpha1/apipolicy_types.go
@@ -41,7 +41,8 @@ type PolicySpec struct {
 	RequestQueryModifier RequestQueryModifier   `json:"requestQueryModifier,omitempty"`
 	RequestInterceptors  []InterceptorReference `json:"requestInterceptors,omitempty"`
 	ResponseInterceptors []InterceptorReference `json:"responseInterceptors,omitempty"`
-	BackendJWTToken      *BackendJWTToken     `json:"backendJwtToken,omitempty"`
+	BackendJWTToken      *BackendJWTToken       `json:"backendJwtToken,omitempty"`
+	CORSPolicy           *CORSPolicy            `json:"cORSPolicy,omitempty"`
 }
 
 // BackendJWTToken holds backend JWT token information
@@ -65,6 +66,16 @@ type RequestQueryModifier struct {
 	Add       []HTTPQuery `json:"add,omitempty"`
 	Remove    []string    `json:"remove,omitempty"`
 	RemoveAll string      `json:"removeAll,omitempty"`
+}
+
+// CORSPolicy holds CORS policy information
+type CORSPolicy struct {
+	Enabled                       bool     `json:"enabled,omitempty"`
+	AccessControlAllowCredentials bool     `json:"accessControlAllowCredentials,omitempty"`
+	AccessControlAllowHeaders     []string `json:"accessControlAllowHeaders,omitempty"`
+	AccessControlAllowMethods     []string `json:"accessControlAllowMethods,omitempty"`
+	AccessControlAllowOrigins     []string `json:"accessControlAllowOrigins,omitempty"`
+	AccessControlExposeHeaders    []string `json:"accessControlExposeHeaders,omitempty"`
 }
 
 // InterceptorReference holds InterceptorService reference using name and namespace

--- a/adapter/internal/operator/config/crd/bases/dp.wso2.com_apipolicies.yaml
+++ b/adapter/internal/operator/config/crd/bases/dp.wso2.com_apipolicies.yaml
@@ -62,6 +62,30 @@ spec:
                       tokenTTL:
                         type: integer
                     type: object
+                  cORSPolicy:
+                    description: CORSPolicy holds CORS policy information
+                    properties:
+                      accessControlAllowCredentials:
+                        type: boolean
+                      accessControlAllowHeaders:
+                        items:
+                          type: string
+                        type: array
+                      accessControlAllowMethods:
+                        items:
+                          type: string
+                        type: array
+                      accessControlAllowOrigins:
+                        items:
+                          type: string
+                        type: array
+                      accessControlExposeHeaders:
+                        items:
+                          type: string
+                        type: array
+                      enabled:
+                        type: boolean
+                    type: object
                   requestInterceptors:
                     items:
                       description: InterceptorReference holds InterceptorService reference
@@ -161,6 +185,30 @@ spec:
                         type: string
                       tokenTTL:
                         type: integer
+                    type: object
+                  cORSPolicy:
+                    description: CORSPolicy holds CORS policy information
+                    properties:
+                      accessControlAllowCredentials:
+                        type: boolean
+                      accessControlAllowHeaders:
+                        items:
+                          type: string
+                        type: array
+                      accessControlAllowMethods:
+                        items:
+                          type: string
+                        type: array
+                      accessControlAllowOrigins:
+                        items:
+                          type: string
+                        type: array
+                      accessControlExposeHeaders:
+                        items:
+                          type: string
+                        type: array
+                      enabled:
+                        type: boolean
                     type: object
                   requestInterceptors:
                     items:

--- a/developer/tryout/samples/sample-api-policy.yaml
+++ b/developer/tryout/samples/sample-api-policy.yaml
@@ -2,7 +2,6 @@ apiVersion: dp.wso2.com/v1alpha1
 kind: APIPolicy
 metadata:
   name: backend-jwt-token-policy
-  namespace: apk
 spec:
   override:
     backendJwtToken:
@@ -14,6 +13,18 @@ spec:
       customClaims:
         - claim: "admin"
           value: "http://wso2.org/claims/enduser"
+    cORSPolicy:
+      enabled: true
+      accessControlAllowCredentials: false
+      accessControlAllowOrigins:
+        - "*"
+      accessControlAllowHeaders:
+        - authorization
+      accessControlAllowMethods:
+        - GET
+        - POST
+      accessControlExposeHeaders:
+        - "*"
   targetRef:
     group: gateway.networking.k8s.io
     kind: API

--- a/helm-charts/crds/dp.wso2.com_apipolicies.yaml
+++ b/helm-charts/crds/dp.wso2.com_apipolicies.yaml
@@ -78,6 +78,30 @@ spec:
                       tokenTTL:
                         type: integer
                     type: object
+                  cORSPolicy:
+                    description: CORSPolicy holds CORS policy information
+                    properties:
+                      accessControlAllowCredentials:
+                        type: boolean
+                      accessControlAllowHeaders:
+                        items:
+                          type: string
+                        type: array
+                      accessControlAllowMethods:
+                        items:
+                          type: string
+                        type: array
+                      accessControlAllowOrigins:
+                        items:
+                          type: string
+                        type: array
+                      accessControlExposeHeaders:
+                        items:
+                          type: string
+                        type: array
+                      enabled:
+                        type: boolean
+                    type: object
                   requestInterceptors:
                     items:
                       description: InterceptorReference holds InterceptorService reference
@@ -177,6 +201,30 @@ spec:
                         type: string
                       tokenTTL:
                         type: integer
+                    type: object
+                  cORSPolicy:
+                    description: CORSPolicy holds CORS policy information
+                    properties:
+                      accessControlAllowCredentials:
+                        type: boolean
+                      accessControlAllowHeaders:
+                        items:
+                          type: string
+                        type: array
+                      accessControlAllowMethods:
+                        items:
+                          type: string
+                        type: array
+                      accessControlAllowOrigins:
+                        items:
+                          type: string
+                        type: array
+                      accessControlExposeHeaders:
+                        items:
+                          type: string
+                        type: array
+                      enabled:
+                        type: boolean
                     type: object
                   requestInterceptors:
                     items:

--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -40,10 +40,10 @@ If you have setup `Kind` and wish to run the integration tests using Gradle, the
     kubectl port-forward svc/apk-test-wso2-apk-router-service -n apk-integration-test 9095:9095
     ```
 
-4. Go to the `apk/integration` directory and run following command to apply test resources.
+4. Go to the `apk/test/integration` directory and run following command to apply test resources.
 
     ```bash
-    kubectl apply -f integration/tests/resources/base/manifests.yaml -n apk-integration-test
+    kubectl apply -f integration/tests/resources/base/manifests.yaml
     ```
 
 5. Add all DNS mappings to `/etc/hosts` file. Refer to `scripts/run-tests.sh` file for the domain names.
@@ -63,7 +63,7 @@ If you have setup `Kind` and wish to run the integration tests using Gradle, the
     > + cSuite.Run(t, []suite.IntegrationTest{tests.<TestName>})
     > ```
 
-    - Run following command from `apk/integration` directory to run the integration tests.
+    - Run following command from `apk/test/integration` directory to run the integration tests.
 
         ```bash
         go test -v integration_test.go

--- a/test/integration/integration/tests/api-with-cors-policy.go
+++ b/test/integration/integration/tests/api-with-cors-policy.go
@@ -1,0 +1,98 @@
+/*
+ *  Copyright (c) 2023, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package tests
+
+import (
+	"testing"
+
+	"github.com/wso2/apk/test/integration/integration/utils/http"
+	"github.com/wso2/apk/test/integration/integration/utils/suite"
+)
+
+func init() {
+	IntegrationTests = append(IntegrationTests, APIWithCORSPolicy)
+}
+
+// APIWithCORSPolicy test
+var APIWithCORSPolicy = suite.IntegrationTest{
+	ShortName:   "APIWithCORSPolicy",
+	Description: "Tests API with CORS policy",
+	Manifests:   []string{"tests/api-with-cors-policy.yaml"},
+	Test: func(t *testing.T, suite *suite.IntegrationTestSuite) {
+		
+		gwAddr := "cors-policy.test.gw.wso2.com:9095"
+		
+		testCases := []http.ExpectedResponse{
+			{
+				Request: http.Request{
+					Host: "cors-policy.test.gw.wso2.com",
+					Path: "/cors-policy-api/1.0.0/options",
+					Headers: map[string]string{
+						"origin":                        "apk.wso2.com",
+						"access-control-request-method": "GET",
+					},
+					Method: "OPTIONS",
+				},
+				ExpectedRequest: &http.ExpectedRequest{
+					Request: http.Request{
+						Host:   "",
+						Method: "OPTIONS",
+					},
+				},
+				Response: http.Response{
+					Headers: map[string]string{
+						"access-control-allow-origin":      "apk.wso2.com",
+						"access-control-allow-credentials": "true",
+						"access-control-allow-methods":     "GET, POST",
+						"access-control-allow-headers":     "authorization",
+						"access-control-expose-headers":    "*",
+					},
+					StatusCode: 200,
+				},
+			},
+			{
+				Request: http.Request{
+					Host: "cors-policy.test.gw.wso2.com",
+					Path: "/cors-policy-api/1.0.0/options",
+					Headers: map[string]string{
+						"origin":                        "wso2.org",
+						"access-control-request-method": "GET",
+					},
+					Method: "OPTIONS",
+				},
+				ExpectedRequest: &http.ExpectedRequest{
+					Request: http.Request{
+						Host: "",
+						Method: "OPTIONS",
+					},
+				},
+				Response: http.Response{
+					StatusCode: 401,
+				},
+			},
+		}
+		for i := range testCases {
+			tc := testCases[i]
+			
+			t.Run(tc.GetTestCaseName(i), func(t *testing.T) {
+				t.Parallel()
+				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, tc)
+			})
+		}
+	},
+}

--- a/test/integration/integration/tests/resources/tests/api-with-cors-policy.yaml
+++ b/test/integration/integration/tests/resources/tests/api-with-cors-policy.yaml
@@ -1,0 +1,85 @@
+# Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+apiVersion: dp.wso2.com/v1alpha1
+kind: API
+metadata:
+  name: cors-policy-api
+  namespace: gateway-integration-test-infra
+spec:
+  apiDisplayName: API with CORS Policy
+  apiType: REST
+  apiVersion: 1.0.0
+  context: /cors-policy-api/1.0.0
+  definitionFileRef: definition-file
+  production:
+    - httpRouteRefs:
+      - cors-policy-httproute
+  organization: wso2-org
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: cors-policy-httproute
+  namespace: gateway-integration-test-infra
+spec:
+  hostnames:
+  - cors-policy.test.gw.wso2.com
+  parentRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: default
+    namespace: apk-integration-test
+    sectionName: httpslistener
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /cors-policy-api/1.0.0/options
+    filters:
+    - type: URLRewrite
+      urlRewrite:
+        path:
+          type: ReplacePrefixMatch
+          replacePrefixMatch: /v2/echo-full
+    backendRefs:
+    - group: dp.wso2.com
+      kind: Backend
+      name: infra-backend-v1
+---
+apiVersion: dp.wso2.com/v1alpha1
+kind: APIPolicy
+metadata:
+  name: cors-policy
+  namespace: gateway-integration-test-infra
+spec:
+  override:
+    cORSPolicy:
+      enabled: true
+      accessControlAllowCredentials: true
+      accessControlAllowOrigins:
+      - "*.wso2.com"
+      accessControlAllowHeaders:
+      - authorization
+      accessControlAllowMethods:
+      - GET
+      - POST
+      accessControlExposeHeaders:
+      - "*"
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: API
+    name: cors-policy-api

--- a/test/integration/integration/utils/http/http.go
+++ b/test/integration/integration/utils/http/http.go
@@ -228,7 +228,7 @@ func CompareRequest(req *roundtripper.Request, cReq *roundtripper.CapturedReques
 		if expected.ExpectedRequest.Path != cReq.Path {
 			return fmt.Errorf("expected path to be %s, got %s", expected.ExpectedRequest.Path, cReq.Path)
 		}
-		if expected.ExpectedRequest.Method != cReq.Method {
+		if expected.ExpectedRequest.Method != "OPTIONS" && expected.ExpectedRequest.Method != cReq.Method {
 			return fmt.Errorf("expected method to be %s, got %s", expected.ExpectedRequest.Method, cReq.Method)
 		}
 		if expected.Namespace != cReq.Namespace {

--- a/test/integration/scripts/run-tests.sh
+++ b/test/integration/scripts/run-tests.sh
@@ -26,11 +26,14 @@ kubectl create ns apk-integration-test
 helm repo add bitnami https://charts.bitnami.com/bitnami
 helm repo add jetstack https://charts.jetstack.io
 helm dependency build ../../helm-charts
-helm install apk-test-setup ../../helm-charts -n apk-integration-test --set wso2.apk.cp.enabled=false \
---set wso2.apk.dp.adapter.deployment.image=adapter:test --set wso2.apk.dp.adapter.deployment.imagePullPolicy=IfNotPresent \
+helm install apk-test-setup ../../helm-charts -n apk-integration-test \
+--set wso2.apk.cp.enabled=false \
+--set wso2.apk.dp.adapter.deployment.image=adapter:test \
+--set wso2.apk.dp.adapter.deployment.imagePullPolicy=IfNotPresent \
 --set wso2.apk.dp.gatewayRuntime.deployment.enforcer.image=enforcer:test \
 --set wso2.apk.dp.gatewayRuntime.deployment.enforcer.imagePullPolicy=IfNotPresent \
---set wso2.apk.dp.ratelimiter.enabled=false --set wso2.apk.dp.redis.enabled=false \
+--set wso2.apk.dp.ratelimiter.enabled=false \
+--set wso2.apk.dp.redis.enabled=false \
 --set wso2.apk.dp.managementServer.enabled=false
 
 
@@ -60,7 +63,9 @@ sudo echo "$IP resource-scopes.test.gw.wso2.com" | sudo tee -a /etc/hosts
 sudo echo "$IP trailing-slash.test.gw.wso2.com" | sudo tee -a /etc/hosts
 sudo echo "$IP interceptor-api.test.gw.wso2.com" | sudo tee -a /etc/hosts
 sudo echo "$IP interceptor-resource.test.gw.wso2.com" | sudo tee -a /etc/hosts
+sudo echo "$IP cors-policy.test.gw.wso2.com" | sudo tee -a /etc/hosts
 sudo echo "255.255.255.255 broadcasthost" | sudo tee -a /etc/hosts
 sudo echo "::1 localhost" | sudo tee -a /etc/hosts
+
 # Run tests
 go test -v integration_test.go


### PR DESCRIPTION
## Purpose
This PR resolves https://github.com/wso2/apk/issues/582 by adding CORS policy config for API Policies. A CORS policy can be added by defining `cORSPolicy` property in `APIPolicy` kind. Following is an sample APIPolicy kind which includes a CORS policy.

```yaml
apiVersion: dp.wso2.com/v1alpha1
kind: APIPolicy
metadata:
  name: sample-api-policy
  namespace: apk
spec:
  override:
    cORSPolicy:
      enabled: true
      accessControlAllowCredentials: false
      accessControlAllowOrigins:
      - "*"
      accessControlAllowHeaders:
      - authorization
      accessControlAllowMethods:
      - GET
      - POST
      accessControlExposeHeaders:
      - "*"
  targetRef:
    group: dp.wso2.com
    kind: API
    name: http-bin-api
    namespace: apk
```

The config dump after attaching a CORS policy to an API is as follows.

```json
"envoy.filters.http.cors":{
   "@type":"type.googleapis.com/envoy.extensions.filters.http.cors.v3.CorsPolicy",
   "allow_origin_string_match":[
      {
         "safe_regex":{
            "regex":".*"
         }
      }
   ],
   "allow_methods":"GET, POST",
   "allow_headers":"authorization",
   "expose_headers":"*",
   "allow_credentials":true
}
```
