### PR TITLE
Add OPA policy support

### DIFF
--- a/adapter/internal/oasparser/constants/constants.go
+++ b/adapter/internal/oasparser/constants/constants.go
@@ -87,9 +87,11 @@ const (
 	ActionRewriteMethod      string = "REWRITE_RESOURCE_METHOD"
 	ActionInterceptorService string = "CALL_INTERCEPTOR_SERVICE"
 	ActionRewritePath        string = "REWRITE_RESOURCE_PATH"
+	ActionOPA                string = "OPA"
 
 	PolicyRequestInterceptor  string = "PolicyRequestInterceptor"
 	PolicyResponseInterceptor string = "PolicyResponseInterceptor"
+	PolicyOPA                 string = "PolicyOPA"
 
 	RewritePathResourcePath    string = "resourcePath"
 	RewritePathType            string = "rewritePathType"
@@ -101,6 +103,15 @@ const (
 	HeaderValue                string = "headerValue"
 	CurrentMethod              string = "currentMethod"
 	UpdatedMethod              string = "updatedMethod"
+
+	ServerURL            string = "serverURL"
+	Policy               string = "policy"
+	Rule                 string = "rule"
+	AccessToken          string = "accessToken"
+	SendAccessToken      string = "sendAccessToken"
+	AdditionalProperties string = "additionalProperties"
+	MaxOpenConnections   string = "maxOpenConnections"
+	ConnectionTimeout    string = "connectionTimeout"
 )
 
 // API Type Constants

--- a/adapter/internal/oasparser/model/policy_layout.go
+++ b/adapter/internal/oasparser/model/policy_layout.go
@@ -50,11 +50,8 @@ var supportedPoliciesMap = map[string]policyLayout{
 		RequiredParams:   []string{constants.RewritePathResourcePath, constants.IncludeQueryParams},
 		IsPassToEnforcer: true,
 	},
-	"OPA": {
-		// Following parameters are not required (optional)
-		// "rule", token", "additionalProperties", "sendAccessToken", "maxOpenConnections", "maxPerRoute"
-		// "connectionTimeout", "requestGenerator"
-		RequiredParams:   []string{"serverURL", "policy"},
+	constants.ActionOPA: {
+		RequiredParams:   []string{constants.ServerURL, constants.Policy},
 		IsPassToEnforcer: true,
 	},
 }

--- a/adapter/internal/operator/apis/dp/v1alpha1/apipolicy_types.go
+++ b/adapter/internal/operator/apis/dp/v1alpha1/apipolicy_types.go
@@ -82,6 +82,7 @@ type CORSPolicy struct {
 // OPAPolicy holds OPA policy information
 type OPAPolicy struct {
 	// ServerURL is the URL of the OPA server
+	// +kubebuilder:validation:Pattern=`/^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$/`
 	ServerURL string `json:"serverURL,omitempty"`
 
 	// Policy is the policy name of the OPA policy

--- a/adapter/internal/operator/apis/dp/v1alpha1/apipolicy_types.go
+++ b/adapter/internal/operator/apis/dp/v1alpha1/apipolicy_types.go
@@ -82,7 +82,7 @@ type CORSPolicy struct {
 // OPAPolicy holds OPA policy information
 type OPAPolicy struct {
 	// ServerURL is the URL of the OPA server
-	// +kubebuilder:validation:Pattern=`/^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$/`
+	// +kubebuilder:validation:Pattern=`(https?://)([^:^/]*)(:\\d*)?(.*)?`
 	ServerURL string `json:"serverURL,omitempty"`
 
 	// Policy is the policy name of the OPA policy

--- a/adapter/internal/operator/apis/dp/v1alpha1/apipolicy_types.go
+++ b/adapter/internal/operator/apis/dp/v1alpha1/apipolicy_types.go
@@ -43,6 +43,7 @@ type PolicySpec struct {
 	ResponseInterceptors []InterceptorReference `json:"responseInterceptors,omitempty"`
 	BackendJWTToken      *BackendJWTToken       `json:"backendJwtToken,omitempty"`
 	CORSPolicy           *CORSPolicy            `json:"cORSPolicy,omitempty"`
+	OPAPolicy            *OPAPolicy             `json:"oPAPolicy,omitempty"`
 }
 
 // BackendJWTToken holds backend JWT token information
@@ -76,6 +77,33 @@ type CORSPolicy struct {
 	AccessControlAllowMethods     []string `json:"accessControlAllowMethods,omitempty"`
 	AccessControlAllowOrigins     []string `json:"accessControlAllowOrigins,omitempty"`
 	AccessControlExposeHeaders    []string `json:"accessControlExposeHeaders,omitempty"`
+}
+
+// OPAPolicy holds OPA policy information
+type OPAPolicy struct {
+	// ServerURL is the URL of the OPA server
+	ServerURL string `json:"serverURL,omitempty"`
+
+	// Policy is the policy name of the OPA policy
+	Policy string `json:"policy,omitempty"`
+
+	// +optional
+	Rule string `json:"rule,omitempty"`
+
+	// +optional
+	AccessToken string `json:"accessToken,omitempty"`
+
+	// +optional
+	SendAccessToken bool `json:"sendAccessToken,omitempty"`
+
+	// +optional
+	AdditionalProperties []string `json:"additionalProperties,omitempty"`
+
+	// +optional
+	MaxOpenConnections int `json:"maxOpenConnections,omitempty"`
+
+	// +optional
+	ConnectionTimeout int `json:"connectionTimeout,omitempty"`
 }
 
 // InterceptorReference holds InterceptorService reference using name and namespace

--- a/adapter/internal/operator/config/crd/bases/dp.wso2.com_apipolicies.yaml
+++ b/adapter/internal/operator/config/crd/bases/dp.wso2.com_apipolicies.yaml
@@ -108,6 +108,7 @@ spec:
                         type: boolean
                       serverURL:
                         description: ServerURL is the URL of the OPA server
+                        pattern: /^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$/
                         type: string
                     type: object
                   requestInterceptors:
@@ -256,6 +257,7 @@ spec:
                         type: boolean
                       serverURL:
                         description: ServerURL is the URL of the OPA server
+                        pattern: /^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$/
                         type: string
                     type: object
                   requestInterceptors:

--- a/adapter/internal/operator/config/crd/bases/dp.wso2.com_apipolicies.yaml
+++ b/adapter/internal/operator/config/crd/bases/dp.wso2.com_apipolicies.yaml
@@ -86,6 +86,30 @@ spec:
                       enabled:
                         type: boolean
                     type: object
+                  oPAPolicy:
+                    description: OPAPolicy holds OPA policy information
+                    properties:
+                      accessToken:
+                        type: string
+                      additionalProperties:
+                        items:
+                          type: string
+                        type: array
+                      connectionTimeout:
+                        type: integer
+                      maxOpenConnections:
+                        type: integer
+                      policy:
+                        description: Policy is the policy name of the OPA policy
+                        type: string
+                      rule:
+                        type: string
+                      sendAccessToken:
+                        type: boolean
+                      serverURL:
+                        description: ServerURL is the URL of the OPA server
+                        type: string
+                    type: object
                   requestInterceptors:
                     items:
                       description: InterceptorReference holds InterceptorService reference
@@ -209,6 +233,30 @@ spec:
                         type: array
                       enabled:
                         type: boolean
+                    type: object
+                  oPAPolicy:
+                    description: OPAPolicy holds OPA policy information
+                    properties:
+                      accessToken:
+                        type: string
+                      additionalProperties:
+                        items:
+                          type: string
+                        type: array
+                      connectionTimeout:
+                        type: integer
+                      maxOpenConnections:
+                        type: integer
+                      policy:
+                        description: Policy is the policy name of the OPA policy
+                        type: string
+                      rule:
+                        type: string
+                      sendAccessToken:
+                        type: boolean
+                      serverURL:
+                        description: ServerURL is the URL of the OPA server
+                        type: string
                     type: object
                   requestInterceptors:
                     items:

--- a/adapter/internal/operator/config/crd/bases/dp.wso2.com_apipolicies.yaml
+++ b/adapter/internal/operator/config/crd/bases/dp.wso2.com_apipolicies.yaml
@@ -108,7 +108,7 @@ spec:
                         type: boolean
                       serverURL:
                         description: ServerURL is the URL of the OPA server
-                        pattern: /^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$/
+                        pattern: (https?://)([^:^/]*)(:\\d*)?(.*)?
                         type: string
                     type: object
                   requestInterceptors:
@@ -257,7 +257,7 @@ spec:
                         type: boolean
                       serverURL:
                         description: ServerURL is the URL of the OPA server
-                        pattern: /^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$/
+                        pattern: (https?://)([^:^/]*)(:\\d*)?(.*)?
                         type: string
                     type: object
                   requestInterceptors:

--- a/gateway/enforcer/org.wso2.apk.enforcer.commons/src/main/java/org/wso2/apk/enforcer/commons/opa/OPAConstants.java
+++ b/gateway/enforcer/org.wso2.apk.enforcer.commons/src/main/java/org/wso2/apk/enforcer/commons/opa/OPAConstants.java
@@ -29,4 +29,8 @@ public class OPAConstants {
         public static final String ADDITIONAL_PROPERTIES = "additionalProperties";
         public static final String SEND_ACCESS_TOKEN = "sendAccessToken";
     }
+
+    public static final String EMPTY_OPA_RESPONSE = "{}";
+    public static final String OPA_RESPONSE_RESULT_KEY = "result";
+    public static final String OPA_RESPONSE_DEFAULT_RULE = "allow";
 }

--- a/gateway/enforcer/org.wso2.apk.enforcer/src/main/java/org/wso2/apk/enforcer/interceptor/opa/OPAClient.java
+++ b/gateway/enforcer/org.wso2.apk.enforcer/src/main/java/org/wso2/apk/enforcer/interceptor/opa/OPAClient.java
@@ -154,7 +154,9 @@ public class OPAClient {
                     if (statusCode == 200) {
                         HttpEntity entity = response.getEntity();
                         try (InputStream content = entity.getContent()) {
-                            return IOUtils.toString(content, String.valueOf(Charset.defaultCharset()));
+                            String stringContent = IOUtils.toString(content, String.valueOf(Charset.defaultCharset()));
+                            log.debug("Response from the OPA server: " + stringContent);
+                            return stringContent.strip();
                         }
                     } else {
                         log.error("Unexpected HTTP response code responded by the OPA server, HTTP code: {} {}",

--- a/gateway/enforcer/org.wso2.apk.enforcer/src/main/java/org/wso2/apk/enforcer/interceptor/opa/OPADefaultRequestGenerator.java
+++ b/gateway/enforcer/org.wso2.apk.enforcer/src/main/java/org/wso2/apk/enforcer/interceptor/opa/OPADefaultRequestGenerator.java
@@ -108,9 +108,8 @@ public class OPADefaultRequestGenerator implements OPARequestGenerator {
                 if (rule.isEmpty()) {
                     JSONObject result = (JSONObject) response.get(OPAConstants.OPA_RESPONSE_RESULT_KEY);
                     return result.getBoolean(OPAConstants.OPA_RESPONSE_DEFAULT_RULE);
-                } else {
-                    return response.getBoolean(OPAConstants.OPA_RESPONSE_RESULT_KEY);
                 }
+                return response.getBoolean(OPAConstants.OPA_RESPONSE_RESULT_KEY);
             } catch (JSONException e) {
                 log.error("Error parsing OPA JSON response, the field \"result\" not found or rule is not a " +
                                 "Boolean, response: {} {} {}", opaResponse,

--- a/helm-charts/crds/dp.wso2.com_apipolicies.yaml
+++ b/helm-charts/crds/dp.wso2.com_apipolicies.yaml
@@ -124,6 +124,7 @@ spec:
                         type: boolean
                       serverURL:
                         description: ServerURL is the URL of the OPA server
+                        pattern: /^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$/
                         type: string
                     type: object
                   requestInterceptors:
@@ -272,6 +273,7 @@ spec:
                         type: boolean
                       serverURL:
                         description: ServerURL is the URL of the OPA server
+                        pattern: /^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$/
                         type: string
                     type: object
                   requestInterceptors:

--- a/helm-charts/crds/dp.wso2.com_apipolicies.yaml
+++ b/helm-charts/crds/dp.wso2.com_apipolicies.yaml
@@ -102,6 +102,30 @@ spec:
                       enabled:
                         type: boolean
                     type: object
+                  oPAPolicy:
+                    description: OPAPolicy holds OPA policy information
+                    properties:
+                      accessToken:
+                        type: string
+                      additionalProperties:
+                        items:
+                          type: string
+                        type: array
+                      connectionTimeout:
+                        type: integer
+                      maxOpenConnections:
+                        type: integer
+                      policy:
+                        description: Policy is the policy name of the OPA policy
+                        type: string
+                      rule:
+                        type: string
+                      sendAccessToken:
+                        type: boolean
+                      serverURL:
+                        description: ServerURL is the URL of the OPA server
+                        type: string
+                    type: object
                   requestInterceptors:
                     items:
                       description: InterceptorReference holds InterceptorService reference
@@ -225,6 +249,30 @@ spec:
                         type: array
                       enabled:
                         type: boolean
+                    type: object
+                  oPAPolicy:
+                    description: OPAPolicy holds OPA policy information
+                    properties:
+                      accessToken:
+                        type: string
+                      additionalProperties:
+                        items:
+                          type: string
+                        type: array
+                      connectionTimeout:
+                        type: integer
+                      maxOpenConnections:
+                        type: integer
+                      policy:
+                        description: Policy is the policy name of the OPA policy
+                        type: string
+                      rule:
+                        type: string
+                      sendAccessToken:
+                        type: boolean
+                      serverURL:
+                        description: ServerURL is the URL of the OPA server
+                        type: string
                     type: object
                   requestInterceptors:
                     items:

--- a/helm-charts/crds/dp.wso2.com_apipolicies.yaml
+++ b/helm-charts/crds/dp.wso2.com_apipolicies.yaml
@@ -124,7 +124,7 @@ spec:
                         type: boolean
                       serverURL:
                         description: ServerURL is the URL of the OPA server
-                        pattern: /^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$/
+                        pattern: (https?://)([^:^/]*)(:\\d*)?(.*)?
                         type: string
                     type: object
                   requestInterceptors:
@@ -273,7 +273,7 @@ spec:
                         type: boolean
                       serverURL:
                         description: ServerURL is the URL of the OPA server
-                        pattern: /^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$/
+                        pattern: (https?://)([^:^/]*)(:\\d*)?(.*)?
                         type: string
                     type: object
                   requestInterceptors:

--- a/test/integration/integration/tests/api-with-opa-policy.go
+++ b/test/integration/integration/tests/api-with-opa-policy.go
@@ -1,0 +1,80 @@
+/*
+ *  Copyright (c) 2023, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package tests
+
+import (
+	"testing"
+
+	"github.com/wso2/apk/test/integration/integration/utils/http"
+	"github.com/wso2/apk/test/integration/integration/utils/suite"
+)
+
+func init() {
+	IntegrationTests = append(IntegrationTests, APIWithOPAPolicy)
+}
+
+// APIWithOPAPolicy test
+var APIWithOPAPolicy = suite.IntegrationTest{
+	ShortName:   "APIWithOPAPolicy",
+	Description: "Tests API with OPA policy",
+	Manifests:   []string{"tests/api-with-opa-policy.yaml"},
+	Test: func(t *testing.T, suite *suite.IntegrationTestSuite) {
+		ns := "gateway-integration-test-infra"
+		gwAddr := "opa-policy.test.gw.wso2.com:9095"
+		token := http.GetTestToken(t)
+
+		testCases := []http.ExpectedResponse{
+			{
+				Request: http.Request{
+					Host:   "opa-policy.test.gw.wso2.com",
+					Path:   "/opa-policy-api/1.0.0/test",
+					Method: "GET",
+				},
+				ExpectedRequest: &http.ExpectedRequest{
+					Request: http.Request{
+						Method: "GET",
+						Path: "/v2/echo-full",
+					},
+				},
+				Response: http.Response{
+					StatusCode: 200,
+				},
+				Backend:   "infra-backend-v1",
+				Namespace: ns,
+			},
+			{
+				Request: http.Request{
+					Host:   "opa-policy.test.gw.wso2.com",
+					Path:   "/opa-policy-api/1.0.0/test",
+					Method: "POST",
+				},
+				Response: http.Response{
+					StatusCode: 403,
+				},
+			},
+		}
+		for i := range testCases {
+			tc := testCases[i]
+			tc.Request.Headers = http.AddBearerTokenToHeader(token, tc.Request.Headers)
+			t.Run(tc.GetTestCaseName(i), func(t *testing.T) {
+				t.Parallel()
+				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, tc)
+			})
+		}
+	},
+}

--- a/test/integration/integration/tests/resources/base/manifests.yaml
+++ b/test/integration/integration/tests/resources/base/manifests.yaml
@@ -322,7 +322,6 @@ spec:
 #     - host: interceptor-backend-v1.apk
 #       port: 9081
 # ---
----
 apiVersion: dp.wso2.com/v1alpha1
 kind: JWTIssuer
 metadata:
@@ -343,4 +342,81 @@ spec:
     group: gateway.networking.k8s.io
     kind: Gateway
     name: default
-
+---
+apiVersion: dp.wso2.com/v1alpha1
+kind: Backend
+metadata:
+  name: opa-backend
+  namespace: gateway-integration-test-infra
+spec:
+  services:
+  - host: opa-svc.gateway-integration-test-infra
+    port: 8181
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: opa-svc
+  namespace: gateway-integration-test-infra
+spec:
+  type: NodePort
+  selector:
+    app: opa-server
+  ports:
+    - protocol: TCP
+      port: 8181
+      targetPort: 8181
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: opa-server
+  namespace: gateway-integration-test-infra
+  labels:
+    app: opa-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: opa-server
+  template:
+    metadata:
+      labels:
+        app: opa-server
+    spec:
+      containers:
+      - name: opa-container
+        image: openpolicyagent/opa:0.52.0
+        ports:
+        - name: http
+          containerPort: 8181
+        args:
+        - "run"
+        - "--ignore=.*"
+        - "--server"
+        - "/policies"
+        volumeMounts:
+        - readOnly: true
+          mountPath: /policies
+          name: opa-volume
+      volumes:
+      - name: opa-volume
+        configMap:
+          name: opa-configmap
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: opa-configmap
+  namespace: gateway-integration-test-infra
+data:
+  policy.rego: |
+    package opa.test
+    import future.keywords.if
+    default allow := false
+    allow if {
+        is_get
+    }
+    is_get if {
+        input.method == "GET"
+    }

--- a/test/integration/integration/tests/resources/tests/api-with-opa-policy.yaml
+++ b/test/integration/integration/tests/resources/tests/api-with-opa-policy.yaml
@@ -1,0 +1,77 @@
+# Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+apiVersion: dp.wso2.com/v1alpha1
+kind: API
+metadata:
+  name: opa-policy-api
+  namespace: gateway-integration-test-infra
+spec:
+  apiDisplayName: API with OPA Policy
+  apiType: REST
+  apiVersion: 1.0.0
+  context: /opa-policy-api/1.0.0
+  definitionFileRef: definition-file
+  production:
+    - httpRouteRefs:
+      - opa-policy-httproute
+  organization: wso2-org
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: opa-policy-httproute
+  namespace: gateway-integration-test-infra
+spec:
+  hostnames:
+  - opa-policy.test.gw.wso2.com
+  parentRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: default
+    namespace: apk-integration-test
+    sectionName: httpslistener
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /opa-policy-api/1.0.0/test
+    filters:
+    - type: URLRewrite
+      urlRewrite:
+        path:
+          type: ReplacePrefixMatch
+          replacePrefixMatch: /v2/echo-full
+    backendRefs:
+    - group: dp.wso2.com
+      kind: Backend
+      name: infra-backend-v1
+---
+apiVersion: dp.wso2.com/v1alpha1
+kind: APIPolicy
+metadata:
+  name: opa-policy
+  namespace: gateway-integration-test-infra
+spec:
+  override:
+    oPAPolicy:
+      serverURL: http://opa-svc.gateway-integration-test-infra:8181/v1/data
+      policy: opa/test
+      rule: allow
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: API
+    name: opa-policy-api

--- a/test/integration/integration/utils/kubernetes/apply.go
+++ b/test/integration/integration/utils/kubernetes/apply.go
@@ -217,7 +217,7 @@ func (a Applier) MustApplyWithCleanup(t *testing.T, c client.Client, timeoutConf
 			for err != nil {
 				if rounds > 0 {
 					err = c.Create(ctx, uObj)
-					t.Logf("Waitning to create resource")
+					t.Logf("Waiting to create resource")
 					time.Sleep(15 * time.Second)
 					rounds--
 				} else {

--- a/test/integration/scripts/run-tests.sh
+++ b/test/integration/scripts/run-tests.sh
@@ -64,6 +64,7 @@ sudo echo "$IP trailing-slash.test.gw.wso2.com" | sudo tee -a /etc/hosts
 sudo echo "$IP interceptor-api.test.gw.wso2.com" | sudo tee -a /etc/hosts
 sudo echo "$IP interceptor-resource.test.gw.wso2.com" | sudo tee -a /etc/hosts
 sudo echo "$IP cors-policy.test.gw.wso2.com" | sudo tee -a /etc/hosts
+sudo echo "$IP opa-policy.test.gw.wso2.com" | sudo tee -a /etc/hosts
 sudo echo "255.255.255.255 broadcasthost" | sudo tee -a /etc/hosts
 sudo echo "::1 localhost" | sudo tee -a /etc/hosts
 


### PR DESCRIPTION
## Purpose
This PR resolves https://github.com/wso2/apk/issues/1164 by adding OPA policy config for API Policies. An OPA policy can be added by defining `oPAPolicy` property in APIPolicy kind. Following is an sample APIPolicy kind which includes a OPA policy.

```yaml
apiVersion: dp.wso2.com/v1alpha1
kind: APIPolicy
metadata:
  name: sample-api-policy
  namespace: apk
spec:
  override:
    oPAPolicy:
      serverURL: http://opa-svc.apk:8181/v1/data
      policy: opa/test
      rule: allow
  targetRef:
    group: dp.wso2.com
    kind: API
    name: http-bin-api
    namespace: apk
```