### PR TITLE
BackendJwt config support from Runtime DS

### DIFF
--- a/runtime/config-deployer-service/ballerina/APIClient.bal
+++ b/runtime/config-deployer-service/ballerina/APIClient.bal
@@ -553,12 +553,14 @@ public class APIClient {
     private isolated function generateAPIPolicyAndBackendCR(model:APIArtifact apiArtifact, APKConf apkConf, APKOperations? operations, APIOperationPolicies? policies, string organization, string targetRefName) returns model:APIPolicy? {
         model:APIPolicyData defaultSpecData = {};
         APKOperationPolicy[]? request = policies?.request;
-        model:InterceptorReference? requestInterceptor = self.retrieveAPIPolicyDetails(apiArtifact, apkConf, operations, organization, request, "request");
-        if requestInterceptor is model:InterceptorReference {
-            defaultSpecData.requestInterceptors = [requestInterceptor];
+        model:InterceptorReference?|model:BackendJwtPolicy? requestPolicy = self.retrieveAPIPolicyDetails(apiArtifact, apkConf, operations, organization, request, "request");
+        if requestPolicy is model:InterceptorReference {
+            defaultSpecData.requestInterceptors = [requestPolicy];
+        } else if requestPolicy is model:BackendJwtPolicy {
+            defaultSpecData.backendJwtToken = requestPolicy;
         }
         APKOperationPolicy[]? response = policies?.response;
-        model:InterceptorReference? responseInterceptor = self.retrieveAPIPolicyDetails(apiArtifact, apkConf, operations, organization, response, "response");
+        model:InterceptorReference?|model:BackendJwtPolicy? responseInterceptor = self.retrieveAPIPolicyDetails(apiArtifact, apkConf, operations, organization, response, "response");
         if responseInterceptor is model:InterceptorReference {
             defaultSpecData.responseInterceptors = [responseInterceptor];
         }
@@ -1029,7 +1031,7 @@ public class APIClient {
         return apiPolicyCR;
     }
 
-    isolated function retrieveAPIPolicyDetails(model:APIArtifact apiArtifact, APKConf apkConf, APKOperations? operations, string organization, APKOperationPolicy[]? policies, string flow) returns model:InterceptorReference? {
+    isolated function retrieveAPIPolicyDetails(model:APIArtifact apiArtifact, APKConf apkConf, APKOperations? operations, string organization, APKOperationPolicy[]? policies, string flow) returns model:InterceptorReference?|model:BackendJwtPolicy? {
         if policies is APKOperationPolicy[] {
             foreach APKOperationPolicy policy in policies {
                 string policyName = policy.policyName;
@@ -1053,7 +1055,28 @@ public class APIClient {
                             };
                         }
                         return interceptorReference;
-                    }
+                    } else if (policyName == "BackendJwt") {
+                        model:BackendJwtPolicy backendJwt = {};
+                        if policyParameters["enabled"] is boolean {
+                            backendJwt.enabled = <boolean>policyParameters["enabled"];
+                        }
+                        if policyParameters["encoding"] is string {
+                            backendJwt.encoding = <string>policyParameters["encoding"];
+                        }
+                        if policyParameters["signingAlgorithm"] is string {
+                            backendJwt.signingAlgorithm = <string>policyParameters["signingAlgorithm"];
+                        }
+                        if policyParameters["header"] is string {
+                            backendJwt.header = <string>policyParameters["header"];
+                        }
+                        if policyParameters["tokenTTL"] is int {
+                            backendJwt.tokenTTL = <int>policyParameters["tokenTTL"];
+                        }
+                        if policyParameters["customClaims"] is model:BackendJwtCustomClaim[] {
+                            backendJwt.customClaims = <model:BackendJwtCustomClaim[]>policyParameters["customClaims"];
+                        }
+                        return backendJwt;
+                    } 
                 }
             }
         }

--- a/runtime/config-deployer-service/ballerina/MediationPolicyList.bal
+++ b/runtime/config-deployer-service/ballerina/MediationPolicyList.bal
@@ -144,6 +144,53 @@ final MediationPolicy[] & readonly avilableMediationPolicyList = [
                 validationRegex: "^([a-zA-Z_][a-zA-Z\\d_\\-\\ ]*)$"
             }
         ]
+    },
+    {
+        id: "6",
+        'type: POLICY_TYPE_BACKEND_JWT,
+        name: POLICY_TYPE_BACKEND_JWT,
+        displayName: "BackendJwt",
+        description: "This policy allows you to add backend JWT",
+        applicableFlows: [MEDIATION_POLICY_FLOW_REQUEST],
+        supportedApiTypes: [API_TYPE_REST],
+        policyAttributes: [
+            {
+                name: "enabled",
+                description: "enabled holds the status of the policy",
+                'type: "boolean",
+                required: true
+            },
+            {
+                name: "encoding",
+                description: "Encoding holds the encoding type",
+                'type: "String",
+                required: false
+            },
+            {
+                name: "signingAlgorithm",
+                description: "signingAlgorithm holds the signing algorithm",
+                'type: "String",
+                required: false
+            },
+            {
+                name: "header",
+                description: "Header holds the header name",
+                'type: "String",
+                required: false
+            },
+            {
+                name: "tokenTTL",
+                description: "TokenTTL holds the token time to live in seconds",
+                'type: "int",
+                required: false
+            },
+            {
+                name: "customClaims",
+                description: "CustomClaim holds custom claim information",
+                'type: "array",
+                required: false
+            }
+        ]
     }
 ];
 

--- a/runtime/config-deployer-service/ballerina/constants.bal
+++ b/runtime/config-deployer-service/ballerina/constants.bal
@@ -55,6 +55,7 @@ isolated string[] ALLOWED_API_TYPES = [API_TYPE_REST];
 const string MEDIATION_POLICY_TYPE_REQUEST_HEADER_MODIFIER = "RequestHeaderModifier";
 const string MEDIATION_POLICY_TYPE_RESPONSE_HEADER_MODIFIER = "ResponseHeaderModifier";
 const string MEDIATION_POLICY_TYPE_INTERCEPTOR = "Interceptor";
+const string POLICY_TYPE_BACKEND_JWT = "BackendJwt";
 const string MEDIATION_POLICY_NAME_ADD_HEADER = "addHeader";
 const string MEDIATION_POLICY_NAME_REMOVE_HEADER = "removeHeader";
 const string MEDIATION_POLICY_TYPE_URL_REWRITE = "URLRewrite";

--- a/runtime/config-deployer-service/ballerina/modules/model/APIPolicy.bal
+++ b/runtime/config-deployer-service/ballerina/modules/model/APIPolicy.bal
@@ -31,11 +31,27 @@ public type APIPolicySpec record {|
 public type APIPolicyData record {
     InterceptorReference[] requestInterceptors?;
     InterceptorReference[] responseInterceptors?;
+    BackendJwtPolicy backendJwtToken?;
 };
 
 public type InterceptorReference record {
     string name;
     string namespace?;
+};
+
+public type BackendJwtPolicy record {
+    boolean enabled = false;
+    string encoding?;
+    string signingAlgorithm?;
+    string header?;
+    int tokenTTL?;
+    BackendJwtCustomClaim[] customClaims?;
+
+};
+
+public type BackendJwtCustomClaim record {
+    string claim?;
+    string value?;
 };
 
 public type APIPolicyList record {

--- a/runtime/runtime-domain-service/ballerina/APIClient.bal
+++ b/runtime/runtime-domain-service/ballerina/APIClient.bal
@@ -1743,12 +1743,14 @@ public class APIClient {
     private isolated function generateAPIPolicyAndBackendCR(model:APIArtifact apiArtifact, API api, APIOperations? operations, APIOperationPolicies? policies, commons:Organization organization, string targetRefName) returns model:APIPolicy? {
         model:APIPolicyData defaultSpecData = {};
         OperationPolicy[]? request = policies?.request;
-        model:InterceptorReference? requestInterceptor = self.retrieveAPIPolicyDetails(apiArtifact, api, operations, organization, request, "request");
-        if requestInterceptor is model:InterceptorReference {
-            defaultSpecData.requestInterceptors = [requestInterceptor];
+        model:InterceptorReference?|model:BackendJwtPolicy? requestPolicy = self.retrieveAPIPolicyDetails(apiArtifact, api, operations, organization, request, "request");
+        if requestPolicy is model:InterceptorReference {
+            defaultSpecData.requestInterceptors = [requestPolicy];
+        } else if requestPolicy is model:BackendJwtPolicy {
+            defaultSpecData.backendJwtToken = requestPolicy;
         }
         OperationPolicy[]? response = policies?.response;
-        model:InterceptorReference? responseInterceptor = self.retrieveAPIPolicyDetails(apiArtifact, api, operations, organization, response, "response");
+        model:InterceptorReference?|model:BackendJwtPolicy? responseInterceptor = self.retrieveAPIPolicyDetails(apiArtifact, api, operations, organization, response, "response");
         if responseInterceptor is model:InterceptorReference {
             defaultSpecData.responseInterceptors = [responseInterceptor];
         }
@@ -2476,7 +2478,7 @@ public class APIClient {
         return apiPolicyCR;
     }
 
-    isolated function retrieveAPIPolicyDetails(model:APIArtifact apiArtifact, API api, APIOperations? operations, commons:Organization organization, OperationPolicy[]? policies, string flow) returns model:InterceptorReference? {
+    isolated function retrieveAPIPolicyDetails(model:APIArtifact apiArtifact, API api, APIOperations? operations, commons:Organization organization, OperationPolicy[]? policies, string flow) returns model:InterceptorReference?|model:BackendJwtPolicy? {
         if policies is OperationPolicy[] {
             foreach OperationPolicy policy in policies {
                 string policyName = policy.policyName;
@@ -2501,7 +2503,29 @@ public class APIClient {
                             };
                         }
                         return interceptorReference;
-                    }
+                    } else if (policyName == "BackendJwt") {
+                        model:BackendJwtPolicy backendJwt = {};
+                        if policyParameters["enabled"] is boolean {
+                            backendJwt.enabled = <boolean>policyParameters["enabled"];
+                        }
+                        if policyParameters["encoding"] is string {
+                            backendJwt.encoding = <string>policyParameters["encoding"];
+                        }
+                        if policyParameters["signingAlgorithm"] is string {
+                            backendJwt.signingAlgorithm = <string>policyParameters["signingAlgorithm"];
+                        }
+                        if policyParameters["header"] is string {
+                            backendJwt.header = <string>policyParameters["header"];
+                        }
+                        if policyParameters["tokenTTL"] is int {
+                            backendJwt.tokenTTL = <int>policyParameters["tokenTTL"];
+                        }
+                        if policyParameters["customClaims"] is model:BackendJwtCustomClaim[] {
+                            backendJwt.customClaims = <model:BackendJwtCustomClaim[]>policyParameters["customClaims"];
+                        }
+                        return backendJwt;
+                    } 
+
                 }
             }
         }

--- a/runtime/runtime-domain-service/ballerina/MediationPolicyList.bal
+++ b/runtime/runtime-domain-service/ballerina/MediationPolicyList.bal
@@ -146,6 +146,53 @@ isolated final model:MediationPolicy[] avilableMediationPolicyList = [
                 validationRegex: "^([a-zA-Z_][a-zA-Z\\d_\\-\\ ]*)$"
             }
         ]
+    },
+    {
+        id: "6",
+        'type: POLICY_TYPE_BACKEND_JWT,
+        name: POLICY_TYPE_BACKEND_JWT,
+        displayName: "BackendJwt",
+        description: "This policy allows you to add backend JWT",
+        applicableFlows: [MEDIATION_POLICY_FLOW_REQUEST],
+        supportedApiTypes: [API_TYPE_REST],
+        policyAttributes: [
+            {
+                name: "enabled",
+                description: "enabled holds the status of the policy",
+                'type: "boolean",
+                required: true
+            },
+            {
+                name: "encoding",
+                description: "Encoding holds the encoding type",
+                'type: "String",
+                required: false
+            },
+            {
+                name: "signingAlgorithm",
+                description: "signingAlgorithm holds the signing algorithm",
+                'type: "String",
+                required: false
+            },
+            {
+                name: "header",
+                description: "Header holds the header name",
+                'type: "String",
+                required: false
+            },
+            {
+                name: "tokenTTL",
+                description: "TokenTTL holds the token time to live in seconds",
+                'type: "int",
+                required: false
+            },
+            {
+                name: "customClaims",
+                description: "CustomClaim holds custom claim information",
+                'type: "array",
+                required: false
+            }
+        ]
     }
 ];
 

--- a/runtime/runtime-domain-service/ballerina/constants.bal
+++ b/runtime/runtime-domain-service/ballerina/constants.bal
@@ -50,6 +50,7 @@ isolated string[] ALLOWED_API_TYPES = [API_TYPE_REST];
 const string MEDIATION_POLICY_TYPE_REQUEST_HEADER_MODIFIER = "RequestHeaderModifier";
 const string MEDIATION_POLICY_TYPE_RESPONSE_HEADER_MODIFIER = "ResponseHeaderModifier";
 const string MEDIATION_POLICY_TYPE_INTERCEPTOR = "Interceptor";
+const string POLICY_TYPE_BACKEND_JWT = "BackendJwt";
 const string MEDIATION_POLICY_NAME_ADD_HEADER = "addHeader";
 const string MEDIATION_POLICY_NAME_REMOVE_HEADER = "removeHeader";
 const string MEDIATION_POLICY_TYPE_URL_REWRITE = "URLRewrite";

--- a/runtime/runtime-domain-service/ballerina/modules/model/APIPolicy.bal
+++ b/runtime/runtime-domain-service/ballerina/modules/model/APIPolicy.bal
@@ -31,11 +31,28 @@ public type APIPolicySpec record {|
 public type APIPolicyData record {
     InterceptorReference[] requestInterceptors?;
     InterceptorReference[] responseInterceptors?;
+    BackendJwtPolicy backendJwtToken?;
+    
 };
 
 public type InterceptorReference record {
     string name;
     string namespace;
+};
+
+public type BackendJwtPolicy record {
+    boolean enabled = false;
+    string encoding?;
+    string signingAlgorithm?;
+    string header?;
+    int tokenTTL?;
+    BackendJwtCustomClaim[] customClaims?;
+
+};
+
+public type BackendJwtCustomClaim record {
+    string claim?;
+    string value?;
 };
 
 public type APIPolicyList record {

--- a/runtime/runtime-domain-service/ballerina/tests/APIClientTest.bal
+++ b/runtime/runtime-domain-service/ballerina/tests/APIClientTest.bal
@@ -2480,8 +2480,8 @@ function createApiFromServiceDataProvider() returns map<[string, string, [model:
         services.push([interceptorBackendService2, interceptorBackendServiceResponse2]);
 
         [model:InterceptorService, any][] interceptorServices = [];
-        string interceptorBackendUrl1 =  "http://interceptor-backend1.interceptor:9082";
-        string interceptorBackendUrl2 =  "http://interceptor-backend2.interceptor:9083";
+        string interceptorBackendUrl1 = "http://interceptor-backend1.interceptor:9082";
+        string interceptorBackendUrl2 = "http://interceptor-backend2.interceptor:9083";
         string[] requestIncludes = ["request_headers", "invocation_context"];
         string[] responseIncludes = ["response_body", "invocation_context"];
         model:InterceptorService requestInterceptorService = getMockInterceptorService(check apiWithAPILevelInterceptorPolicy.cloneWithType(API), organiztion1, apiUUID, "request", requestIncludes, interceptorBackendUrl1);
@@ -4351,10 +4351,10 @@ function createAPIWithOperationPolicyProvider() returns map<[string, string, API
         services.push([interceptorBackendService2, interceptorBackendServiceResponse2]);
         [model:Backend, any][] servicesError = [];
         servicesError.push([backendService, backendServiceErrorResponse]);
-        
+
         [model:InterceptorService, any][] interceptorServices = [];
-        string interceptorBackendUrl1 =  "http://interceptor-backend1.interceptor:9082";
-        string interceptorBackendUrl2 =  "http://interceptor-backend2.interceptor:9083";
+        string interceptorBackendUrl1 = "http://interceptor-backend1.interceptor:9082";
+        string interceptorBackendUrl2 = "http://interceptor-backend2.interceptor:9083";
         string[] requestIncludes = ["request_headers", "invocation_context"];
         string[] responseIncludes = ["response_body", "invocation_context"];
         model:InterceptorService requestInterceptorService = getMockInterceptorService(check apiWithAPILevelInterceptorPolicy.cloneWithType(API), organiztion1, apiUUID, "request", requestIncludes, interceptorBackendUrl1);
@@ -5628,15 +5628,15 @@ function getMockResourceLevelPolicy(API api, commons:Organization organiztion, s
         "metadata": {"name": "api-policy-ref-name", "namespace": "apk-platform", "labels": getLabels(api, organiztion)},
         "spec": {
             "default": {
-               "requestInterceptors": [
+                "requestInterceptors": [
                     {
                         "name": getInterceptorServiceUid(api, organiztion, "request", 0),
                         "namespace": "apk-platform"
                     }
-                    
+
                 ],
                 "responseInterceptors": [
-                   {
+                    {
                         "name": getInterceptorServiceUid(api, organiztion, "response", 0),
                         "namespace": "apk-platform"
                     }
@@ -5664,10 +5664,10 @@ function getMockAPILevelPolicy(API api, commons:Organization organiztion, string
                         "name": getInterceptorServiceUid(api, organiztion, "request", 0),
                         "namespace": "apk-platform"
                     }
-                    
+
                 ],
                 "responseInterceptors": [
-                   {
+                    {
                         "name": getInterceptorServiceUid(api, organiztion, "response", 0),
                         "namespace": "apk-platform"
                     }
@@ -5693,17 +5693,17 @@ function getMockAPIPolicyResponse(model:APIPolicy request) returns http:Response
 
 function getMockInterceptorService(API api, commons:Organization organiztion, string apiUUID, string flow, string[] includes, string backendUrl) returns model:InterceptorService {
     return {
-            "apiVersion": "dp.wso2.com/v1alpha1",
-            "kind": "InterceptorService",
-            "metadata": {"name": getInterceptorServiceUid(api, organiztion, flow, 0), "namespace": "apk-platform", "labels": getLabels(api, organiztion)},
-            "spec": {
-                "backendRef": {
-                    "name": getInterceptorBackendUid(api, INTERCEPTOR_TYPE, organiztion, backendUrl),
-                    "namespace": "apk-platform"
-                },
-                "includes": includes
-            }
-        };
+        "apiVersion": "dp.wso2.com/v1alpha1",
+        "kind": "InterceptorService",
+        "metadata": {"name": getInterceptorServiceUid(api, organiztion, flow, 0), "namespace": "apk-platform", "labels": getLabels(api, organiztion)},
+        "spec": {
+            "backendRef": {
+                "name": getInterceptorBackendUid(api, INTERCEPTOR_TYPE, organiztion, backendUrl),
+                "namespace": "apk-platform"
+            },
+            "includes": includes
+        }
+    };
 }
 
 function getMockInterceptorServiceResponse(model:InterceptorService request) returns http:Response {
@@ -6167,15 +6167,15 @@ public function mediationPolicyByIdDataProvider() returns map<[string, commons:O
             }
         ]
     };
-    commons:APKError notfound = error commons:APKError("6 not found",
+    commons:APKError notfound = error commons:APKError("7 not found",
         code = 909001,
-        message = "6 not found",
+        message = "7 not found",
         statusCode = 404,
-        description = "6 not found"
+        description = "7 not found"
     );
     map<[string, commons:Organization, anydata]> dataset = {
         "1": ["1", organiztion1, mediationPolicy1.toBalString()],
-        "2": ["6", organiztion1, notfound.toBalString()]
+        "2": ["7", organiztion1, notfound.toBalString()]
     };
     return dataset;
 }
@@ -6212,8 +6212,59 @@ function getMediationPolicyListDataProvider() returns map<[string?, int, int, st
             SORT_BY_POLICY_NAME,
             SORT_ORDER_ASC,
             {
-                "count": 5,
+                "count": 6,
                 "list": [
+                    {
+                        "id": "6",
+                        "type": "BackendJwt",
+                        "name": "BackendJwt",
+                        "displayName": "BackendJwt",
+                        "description": "This policy allows you to add backend JWT",
+                        "applicableFlows": [
+                            "request"
+                        ],
+                        "supportedApiTypes": [
+                            "REST"
+                        ],
+                        "policyAttributes": [
+                            {
+                                "name": "enabled",
+                                "description": "enabled holds the status of the policy",
+                                "required": true,
+                                "type": "boolean"
+                            },
+                            {
+                                "name": "encoding",
+                                "description": "Encoding holds the encoding type",
+                                "required": false,
+                                "type": "String"
+                            },
+                            {
+                                "name": "signingAlgorithm",
+                                "description": "signingAlgorithm holds the signing algorithm",
+                                "required": false,
+                                "type": "String"
+                            },
+                            {
+                                "name": "header",
+                                "description": "Header holds the header name",
+                                "required": false,
+                                "type": "String"
+                            },
+                            {
+                                "name": "tokenTTL",
+                                "description": "TokenTTL holds the token time to live in seconds",
+                                "required": false,
+                                "type": "int"
+                            },
+                            {
+                                "name": "customClaims",
+                                "description": "CustomClaim holds custom claim information",
+                                "required": false,
+                                "type": "array"
+                            }
+                        ]
+                    },
                     {
                         "id": "5",
                         "type": "Interceptor",
@@ -6367,7 +6418,7 @@ function getMediationPolicyListDataProvider() returns map<[string?, int, int, st
                 "pagination": {
                     "offset": 0,
                     "limit": 10,
-                    "total": 5,
+                    "total": 6,
                     "next": "",
                     "previous": ""
                 }
@@ -6380,7 +6431,7 @@ function getMediationPolicyListDataProvider() returns map<[string?, int, int, st
             SORT_BY_POLICY_NAME,
             SORT_ORDER_DESC,
             {
-                "count": 5,
+                "count": 6,
                 "list": [
                     {
                         "id": "2",
@@ -6530,12 +6581,63 @@ function getMediationPolicyListDataProvider() returns map<[string?, int, int, st
                                 "type": "String"
                             }
                         ]
+                    },
+                    {
+                        "id": "6",
+                        "type": "BackendJwt",
+                        "name": "BackendJwt",
+                        "displayName": "BackendJwt",
+                        "description": "This policy allows you to add backend JWT",
+                        "applicableFlows": [
+                            "request"
+                        ],
+                        "supportedApiTypes": [
+                            "REST"
+                        ],
+                        "policyAttributes": [
+                            {
+                                "name": "enabled",
+                                "description": "enabled holds the status of the policy",
+                                "required": true,
+                                "type": "boolean"
+                            },
+                            {
+                                "name": "encoding",
+                                "description": "Encoding holds the encoding type",
+                                "required": false,
+                                "type": "String"
+                            },
+                            {
+                                "name": "signingAlgorithm",
+                                "description": "signingAlgorithm holds the signing algorithm",
+                                "required": false,
+                                "type": "String"
+                            },
+                            {
+                                "name": "header",
+                                "description": "Header holds the header name",
+                                "required": false,
+                                "type": "String"
+                            },
+                            {
+                                "name": "tokenTTL",
+                                "description": "TokenTTL holds the token time to live in seconds",
+                                "required": false,
+                                "type": "int"
+                            },
+                            {
+                                "name": "customClaims",
+                                "description": "CustomClaim holds custom claim information",
+                                "required": false,
+                                "type": "array"
+                            }
+                        ]
                     }
                 ],
                 "pagination": {
                     "offset": 0,
                     "limit": 10,
-                    "total": 5,
+                    "total": 6,
                     "next": "",
                     "previous": ""
                 }
@@ -6548,7 +6650,7 @@ function getMediationPolicyListDataProvider() returns map<[string?, int, int, st
             SORT_BY_ID,
             SORT_ORDER_ASC,
             {
-                "count": 5,
+                "count": 6,
                 "list": [
                     {
                         "id": "1",
@@ -6698,12 +6800,63 @@ function getMediationPolicyListDataProvider() returns map<[string?, int, int, st
                                 "type": "String"
                             }
                         ]
+                    },
+                    {
+                        "id": "6",
+                        "type": "BackendJwt",
+                        "name": "BackendJwt",
+                        "displayName": "BackendJwt",
+                        "description": "This policy allows you to add backend JWT",
+                        "applicableFlows": [
+                            "request"
+                        ],
+                        "supportedApiTypes": [
+                            "REST"
+                        ],
+                        "policyAttributes": [
+                            {
+                                "name": "enabled",
+                                "description": "enabled holds the status of the policy",
+                                "required": true,
+                                "type": "boolean"
+                            },
+                            {
+                                "name": "encoding",
+                                "description": "Encoding holds the encoding type",
+                                "required": false,
+                                "type": "String"
+                            },
+                            {
+                                "name": "signingAlgorithm",
+                                "description": "signingAlgorithm holds the signing algorithm",
+                                "required": false,
+                                "type": "String"
+                            },
+                            {
+                                "name": "header",
+                                "description": "Header holds the header name",
+                                "required": false,
+                                "type": "String"
+                            },
+                            {
+                                "name": "tokenTTL",
+                                "description": "TokenTTL holds the token time to live in seconds",
+                                "required": false,
+                                "type": "int"
+                            },
+                            {
+                                "name": "customClaims",
+                                "description": "CustomClaim holds custom claim information",
+                                "required": false,
+                                "type": "array"
+                            }
+                        ]
                     }
                 ],
                 "pagination": {
                     "offset": 0,
                     "limit": 10,
-                    "total": 5,
+                    "total": 6,
                     "next": "",
                     "previous": ""
                 }
@@ -6716,8 +6869,59 @@ function getMediationPolicyListDataProvider() returns map<[string?, int, int, st
             SORT_BY_ID,
             SORT_ORDER_DESC,
             {
-                "count": 5,
+                "count": 6,
                 "list": [
+                    {
+                        "id": "6",
+                        "type": "BackendJwt",
+                        "name": "BackendJwt",
+                        "displayName": "BackendJwt",
+                        "description": "This policy allows you to add backend JWT",
+                        "applicableFlows": [
+                            "request"
+                        ],
+                        "supportedApiTypes": [
+                            "REST"
+                        ],
+                        "policyAttributes": [
+                            {
+                                "name": "enabled",
+                                "description": "enabled holds the status of the policy",
+                                "required": true,
+                                "type": "boolean"
+                            },
+                            {
+                                "name": "encoding",
+                                "description": "Encoding holds the encoding type",
+                                "required": false,
+                                "type": "String"
+                            },
+                            {
+                                "name": "signingAlgorithm",
+                                "description": "signingAlgorithm holds the signing algorithm",
+                                "required": false,
+                                "type": "String"
+                            },
+                            {
+                                "name": "header",
+                                "description": "Header holds the header name",
+                                "required": false,
+                                "type": "String"
+                            },
+                            {
+                                "name": "tokenTTL",
+                                "description": "TokenTTL holds the token time to live in seconds",
+                                "required": false,
+                                "type": "int"
+                            },
+                            {
+                                "name": "customClaims",
+                                "description": "CustomClaim holds custom claim information",
+                                "required": false,
+                                "type": "array"
+                            }
+                        ]
+                    },
                     {
                         "id": "5",
                         "type": "Interceptor",
@@ -6871,7 +7075,7 @@ function getMediationPolicyListDataProvider() returns map<[string?, int, int, st
                 "pagination": {
                     "offset": 0,
                     "limit": 10,
-                    "total": 5,
+                    "total": 6,
                     "next": "",
                     "previous": ""
                 }
@@ -6888,6 +7092,57 @@ function getMediationPolicyListDataProvider() returns map<[string?, int, int, st
                 "count": 2,
                 "list": [
                     {
+                        "id": "6",
+                        "type": "BackendJwt",
+                        "name": "BackendJwt",
+                        "displayName": "BackendJwt",
+                        "description": "This policy allows you to add backend JWT",
+                        "applicableFlows": [
+                            "request"
+                        ],
+                        "supportedApiTypes": [
+                            "REST"
+                        ],
+                        "policyAttributes": [
+                            {
+                                "name": "enabled",
+                                "description": "enabled holds the status of the policy",
+                                "required": true,
+                                "type": "boolean"
+                            },
+                            {
+                                "name": "encoding",
+                                "description": "Encoding holds the encoding type",
+                                "required": false,
+                                "type": "String"
+                            },
+                            {
+                                "name": "signingAlgorithm",
+                                "description": "signingAlgorithm holds the signing algorithm",
+                                "required": false,
+                                "type": "String"
+                            },
+                            {
+                                "name": "header",
+                                "description": "Header holds the header name",
+                                "required": false,
+                                "type": "String"
+                            },
+                            {
+                                "name": "tokenTTL",
+                                "description": "TokenTTL holds the token time to live in seconds",
+                                "required": false,
+                                "type": "int"
+                            },
+                            {
+                                "name": "customClaims",
+                                "description": "CustomClaim holds custom claim information",
+                                "required": false,
+                                "type": "array"
+                            }
+                        ]
+                    },
+                    {
                         "id": "5",
                         "type": "Interceptor",
                         "name": "Interceptor",
@@ -6933,41 +7188,12 @@ function getMediationPolicyListDataProvider() returns map<[string?, int, int, st
                                 "type": "String"
                             }
                         ]
-                    },
-                    {
-                        "id": "1",
-                        "type": "RequestHeaderModifier",
-                        "name": "addHeader",
-                        "displayName": "Add Header",
-                        "description": "This policy allows you to add a new header to the request",
-                        "applicableFlows": [
-                            "request"
-                        ],
-                        "supportedApiTypes": [
-                            "REST"
-                        ],
-                        "policyAttributes": [
-                            {
-                                "name": "headerName",
-                                "description": "Name of the header to be added",
-                                "required": true,
-                                "validationRegex": "^([a-zA-Z_][a-zA-Z\\d_\\-\\ ]*)$",
-                                "type": "String"
-                            },
-                            {
-                                "name": "headerValue",
-                                "description": "Value of the header",
-                                "required": true,
-                                "validationRegex": "^([a-zA-Z_][a-zA-Z\\d_\\-\\ ]*)$",
-                                "type": "String"
-                            }
-                        ]
                     }
                 ],
                 "pagination": {
                     "offset": 0,
                     "limit": 2,
-                    "total": 5,
+                    "total": 6,
                     "next": "/policies?limit=2&offset=2&sortBy=policyName&sortOrder=asc&query=",
                     "previous": ""
                 }
@@ -7044,7 +7270,7 @@ function getMediationPolicyListDataProvider() returns map<[string?, int, int, st
                 "pagination": {
                     "offset": 2,
                     "limit": 2,
-                    "total": 5,
+                    "total": 6,
                     "next": "/policies?limit=2&offset=4&sortBy=policyName&sortOrder=desc&query=",
                     "previous": "/policies?limit=2&offset=0&sortBy=policyName&sortOrder=desc&query="
                 }
@@ -7053,16 +7279,16 @@ function getMediationPolicyListDataProvider() returns map<[string?, int, int, st
         "8": [
             (),
             3,
-            6,
+            7,
             SORT_BY_POLICY_NAME,
             SORT_ORDER_ASC,
             {
                 "count": 0,
                 "list": [],
                 "pagination": {
-                    "offset": 6,
+                    "offset": 7,
                     "limit": 3,
-                    "total": 5,
+                    "total": 6,
                     "next": "",
                     "previous": ""
                 }


### PR DESCRIPTION
## Purpose
This will add backendJwt config support from Runtime Ds.

This config can be added API level and Resource level

Example:

```
                        "request": [
                            {
                                "policyName": "BackendJwt",
                                "parameters":
                                {
                                      "enabled": true,
                                      "encoding": "base64",
                                      "signingAlgorithm": "SHA256withRSA",
                                      "header": "X-JWT-Assertion",
                                      "tokenTTL": 3600,
                                      "customClaims": [
                                          {
                                              "claim": "claim1",
                                              "value": "value1"
                                          }
                                      ]
                                }
                        ],


```

### Fixes
- https://github.com/wso2/apk/issues/1243