### PR TITLE
Add analytics support for fluent bit

### DIFF
--- a/helm-charts/templates/data-plane/gateway-components/gateway-runtime/enforcer-analytics-logs-volume-pvc.yaml
+++ b/helm-charts/templates/data-plane/gateway-components/gateway-runtime/enforcer-analytics-logs-volume-pvc.yaml
@@ -22,7 +22,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: enforcer-analytics-logs-volume-pvc
 spec:
-  storageClassName: standard
+  storageClassName: {{ .Values.wso2.apk.dp.gatewayRuntime.analytics.storageClassName | default "standard" }}
   accessModes:
     - ReadWriteOnce
   resources:

--- a/helm-charts/templates/data-plane/gateway-components/gateway-runtime/enforcer-analytics-logs-volume-pvc.yaml
+++ b/helm-charts/templates/data-plane/gateway-components/gateway-runtime/enforcer-analytics-logs-volume-pvc.yaml
@@ -1,0 +1,33 @@
+# --------------------------------------------------------------------
+# Copyright (c) 2023, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -----------------------------------------------------------------------
+
+{{- if and .Values.wso2.apk.dp.gatewayRuntime.analytics .Values.wso2.apk.dp.gatewayRuntime.analytics.enabled .Values.wso2.apk.dp.gatewayRuntime.analytics.type }}
+{{- if eq .Values.wso2.apk.dp.gatewayRuntime.analytics.enabled true }}
+{{- if eq .Values.wso2.apk.dp.gatewayRuntime.analytics.type "File" }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: enforcer-analytics-logs-volume-pvc
+spec:
+  storageClassName: standard
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+{{- end }}
+{{- end }}
+{{- end }}

--- a/helm-charts/templates/data-plane/gateway-components/gateway-runtime/gateway-runtime-deployment.yaml
+++ b/helm-charts/templates/data-plane/gateway-components/gateway-runtime/gateway-runtime-deployment.yaml
@@ -151,6 +151,14 @@ spec:
               mountPath: /home/wso2/security/truststore/idp-tls.pem
               subPath: {{ .Values.wso2.apk.idp.tls.fileName }}
             {{ end }}
+            {{- if and .Values.wso2.apk.dp.gatewayRuntime.analytics .Values.wso2.apk.dp.gatewayRuntime.analytics.enabled .Values.wso2.apk.dp.gatewayRuntime.analytics.type }}
+            {{- if eq .Values.wso2.apk.dp.gatewayRuntime.analytics.enabled true }}
+            {{- if eq .Values.wso2.apk.dp.gatewayRuntime.analytics.type "File" }}
+            - name: enforcer-analytics-logs-volume
+              mountPath: /home/wso2/logs
+            {{- end }}
+            {{- end }}
+            {{- end }}
           readinessProbe:
             exec:
               command: [ "sh", "check_health.sh" ]
@@ -335,3 +343,12 @@ spec:
             secretName: {{ .Values.wso2.apk.idp.tls.secretName }}
           {{ end }}
           {{end}}
+        {{- if and .Values.wso2.apk.dp.gatewayRuntime.analytics .Values.wso2.apk.dp.gatewayRuntime.analytics.enabled .Values.wso2.apk.dp.gatewayRuntime.analytics.type }}
+        {{- if eq .Values.wso2.apk.dp.gatewayRuntime.analytics.enabled true }}
+        {{- if eq .Values.wso2.apk.dp.gatewayRuntime.analytics.type "File" }}
+        - name: enforcer-analytics-logs-volume
+          persistentVolumeClaim:
+            claimName: enforcer-analytics-logs-volume-pvc
+        {{- end }}
+        {{- end }}
+        {{- end }}

--- a/helm-charts/templates/data-plane/gateway-components/log-conf.yaml
+++ b/helm-charts/templates/data-plane/gateway-components/log-conf.yaml
@@ -114,7 +114,7 @@ data:
     [analytics]
       enabled = {{ .Values.wso2.apk.dp.gatewayRuntime.analytics.enabled | default false }}
     {{- if .Values.wso2.apk.dp.gatewayRuntime.analytics.type }}
-      {{- if eq .Values.wso2.apk.dp.gatewayRuntime.analytics.type "ELK" }}
+      {{- if eq .Values.wso2.apk.dp.gatewayRuntime.analytics.type "File" }}
       type = "ELK"
       {{- end }}
 


### PR DESCRIPTION
## Purpose
This PR introduces `enforcer-analytics-logs-volume-pvc` PersistentVolumeClaim to store enforcer analytics log files, which can be later read by other services such as [Filebeat](https://www.elastic.co/beats/filebeat) and [FluentBit](https://fluentbit.io/). To enable PVC and writing logs to the file user has to add following config to the `values.yaml` under `wso2.apk.dp.gatewayRuntime` section.

```yaml
analytics:
  enabled: true
  type: "File"
```