### PR TITLE
Add: Backend Retry Configuration in CR

### DIFF
--- a/adapter/internal/oasparser/envoyconf/routes_with_clusters.go
+++ b/adapter/internal/oasparser/envoyconf/routes_with_clusters.go
@@ -167,8 +167,17 @@ func CreateRoutesWithClusters(adapterInternalAPI model.AdapterInternalAPI, inter
 			interceptorCerts, vHost, organizationID, apiRequestInterceptor, apiResponseInterceptor, resource)
 		clusters = append(clusters, clustersI...)
 		endpoints = append(endpoints, endpointsI...)
-		routeP, err := createRoutes(genRouteCreateParams(&adapterInternalAPI, resource, vHost, basePath, clusterName, *operationalReqInterceptors, *operationalRespInterceptorVal, organizationID,
-			false))
+		routeParams := genRouteCreateParams(&adapterInternalAPI, resource, vHost, basePath, clusterName, *operationalReqInterceptors, *operationalRespInterceptorVal, organizationID,
+			false)
+
+		// set retry count if endpoint retry config is available
+		if endpoint.Config != nil && endpoint.Config.RetryConfig != nil {
+			routeParams.routeConfig.RetryConfig = &model.RetryConfig{
+				Count: endpoint.Config.RetryConfig.Count,
+			}
+		}
+
+		routeP, err := createRoutes(routeParams)
 		if err != nil {
 			logger.LoggerXds.ErrorC(logging.GetErrorByCode(2231, adapterInternalAPI.GetTitle(), adapterInternalAPI.GetVersion(), resource.GetPath(), err.Error()))
 			return nil, nil, nil, fmt.Errorf("error while creating routes. %v", err)

--- a/adapter/internal/oasparser/model/http_route.go
+++ b/adapter/internal/oasparser/model/http_route.go
@@ -71,27 +71,7 @@ func (swagger *AdapterInternalAPI) SetInfoHTTPRouteCR(httpRoute *gwapiv1b1.HTTPR
 	if outputRatelimitPolicy != nil {
 		ratelimitPolicy = concatRateLimitPolicies(*outputRatelimitPolicy, nil)
 	}
-
-	// var endpoints []Endpoint
-	// endpoint := &Endpoint{
-	// 	Host:    "localhost",
-	// 	Port:    8084,
-	// 	URLType: "https",
-	// }
-	// path := swagger.xWso2Basepath + "/swagger.json"
-	// endpoints = append(endpoints, *endpoint)
-	// swaggerResource := &Resource{
-	// 	path: path,
-	// 	methods: []*Operation{{iD: uuid.New().String(), method: string(gwapiv1b1.HTTPMethodGet),
-	// 		disableSecurity: true, security: nil, RateLimitPolicy: nil}},
-	// 	pathMatchType: gwapiv1b1.PathMatchExact,
-	// 	iD:            uuid.New().String(),
-	// 	endpoints: &EndpointCluster{
-	// 		Endpoints: endpoints,
-	// 	},
-	// }
-	// resources = append(resources, swaggerResource)
-	// fmt.Println("swaggerResource", swaggerResource)
+	var backendRetry int32
 
 	for _, rule := range httpRoute.Spec.Rules {
 		var endPoints []Endpoint
@@ -250,6 +230,7 @@ func (swagger *AdapterInternalAPI) SetInfoHTTPRouteCR(httpRoute *gwapiv1b1.HTTPR
 			}
 			resolvedBackend, ok := httpRouteParams.BackendMapping[backendName]
 			if ok {
+				backendRetry = resolvedBackend.Retry
 				endPoints = append(endPoints, GetEndpoints(backendName, httpRouteParams.BackendMapping)...)
 				for _, security := range resolvedBackend.Security {
 					switch security.Type {
@@ -275,8 +256,19 @@ func (swagger *AdapterInternalAPI) SetInfoHTTPRouteCR(httpRoute *gwapiv1b1.HTTPR
 				hasPolicies:   hasPolicies,
 				iD:            uuid.New().String(),
 			}
-			resource.endpoints = &EndpointCluster{
-				Endpoints: endPoints,
+			if backendRetry > 0 {
+				resource.endpoints = &EndpointCluster{
+					Endpoints: endPoints,
+					Config: &EndpointConfig{
+						RetryConfig: &RetryConfig{
+							Count: backendRetry,
+						},
+					},
+				}
+			} else {
+				resource.endpoints = &EndpointCluster{
+					Endpoints: endPoints,
+				}
 			}
 			resource.endpointSecurity = utils.GetPtrSlice(securityConfig)
 			resources = append(resources, resource)

--- a/adapter/internal/operator/apis/dp/v1alpha1/backend_types.go
+++ b/adapter/internal/operator/apis/dp/v1alpha1/backend_types.go
@@ -61,6 +61,7 @@ type BackendSpec struct {
 
 	// +optional
 	Security []SecurityConfig `json:"security,omitempty"`
+	Retry    int32            `json:"retry,omitempty"`
 }
 
 // Service holds host and port information for the service

--- a/adapter/internal/operator/apis/dp/v1alpha1/resolvedbackend.go
+++ b/adapter/internal/operator/apis/dp/v1alpha1/resolvedbackend.go
@@ -28,6 +28,7 @@ type ResolvedBackend struct {
 	Protocol BackendProtocolType
 	TLS      ResolvedTLSConfig
 	Security []ResolvedSecurityConfig
+	Retry    int32
 }
 
 // ResolvedTLSConfig defines enpoint TLS configurations

--- a/adapter/internal/operator/config/crd/bases/dp.wso2.com_backends.yaml
+++ b/adapter/internal/operator/config/crd/bases/dp.wso2.com_backends.yaml
@@ -44,6 +44,9 @@ spec:
                 - ws
                 - wss
                 type: string
+              retry:
+                format: int32
+                type: integer
               security:
                 items:
                   description: SecurityConfig defines enpoint security configurations

--- a/helm-charts/crds/dp.wso2.com_backends.yaml
+++ b/helm-charts/crds/dp.wso2.com_backends.yaml
@@ -60,6 +60,9 @@ spec:
                 - ws
                 - wss
                 type: string
+              retry:
+                format: int32
+                type: integer
               security:
                 items:
                   description: SecurityConfig defines enpoint security configurations


### PR DESCRIPTION
## Purpose
Override the `retryCount` per backend.

## Goals
Configure different retry counts for different backends.

## Approach
Add new property `retryCount` in Backend CR which is getting overridden when creating the routes with actions.