### PR TITLE
Add API properties to an API

### DIFF
--- a/adapter/internal/interceptor/interceptor.go
+++ b/adapter/internal/interceptor/interceptor.go
@@ -70,6 +70,7 @@ type InvocationContext struct {
 	PathTemplate     string
 	Vhost            string
 	ClusterName      string
+	APIProperty      string
 }
 
 var (
@@ -93,6 +94,7 @@ var (
 	 pathTemplate = "{{.Context.PathTemplate}}",
 	 vhost = "{{.Context.Vhost}}",
 	 clusterName = "{{.Context.ClusterName}}",
+	 apiProperty = "{{.Context.APIProperty}}",
  }
  local wire_log_config = {
 	 log_body_enabled = {{ .LogConfig.LogBodyEnabled }},

--- a/adapter/internal/interceptor/interceptor.go
+++ b/adapter/internal/interceptor/interceptor.go
@@ -70,7 +70,7 @@ type InvocationContext struct {
 	PathTemplate     string
 	Vhost            string
 	ClusterName      string
-	APIProperties      string
+	APIProperties    string
 }
 
 var (

--- a/adapter/internal/interceptor/interceptor.go
+++ b/adapter/internal/interceptor/interceptor.go
@@ -70,7 +70,7 @@ type InvocationContext struct {
 	PathTemplate     string
 	Vhost            string
 	ClusterName      string
-	APIProperty      string
+	APIProperties      string
 }
 
 var (
@@ -94,7 +94,7 @@ var (
 	 pathTemplate = "{{.Context.PathTemplate}}",
 	 vhost = "{{.Context.Vhost}}",
 	 clusterName = "{{.Context.ClusterName}}",
-	 apiProperty = "{{.Context.APIProperty}}",
+	 apiProperties = "{{.Context.APIProperties}}",
  }
  local wire_log_config = {
 	 log_body_enabled = {{ .LogConfig.LogBodyEnabled }},

--- a/adapter/internal/oasparser/envoyconf/internal_dtos.go
+++ b/adapter/internal/oasparser/envoyconf/internal_dtos.go
@@ -41,7 +41,7 @@ type routeCreateParams struct {
 	passRequestPayloadToEnforcer bool
 	isDefaultVersion             bool
 	apiLevelRateLimitPolicy      *model.RateLimitPolicy
-	apiProperty	                 []dpv1alpha1.Property
+	apiProperties	             []dpv1alpha1.Property
 }
 
 // RatelimitCriteria criterias of rate limiting

--- a/adapter/internal/oasparser/envoyconf/internal_dtos.go
+++ b/adapter/internal/oasparser/envoyconf/internal_dtos.go
@@ -19,6 +19,7 @@ package envoyconf
 
 import (
 	"github.com/wso2/apk/adapter/internal/oasparser/model"
+	dpv1alpha1 "github.com/wso2/apk/adapter/internal/operator/apis/dp/v1alpha1"
 )
 
 // routeCreateParams is the DTO used to provide information to the envoy route create function
@@ -40,6 +41,7 @@ type routeCreateParams struct {
 	passRequestPayloadToEnforcer bool
 	isDefaultVersion             bool
 	apiLevelRateLimitPolicy      *model.RateLimitPolicy
+	apiProperty	                 []dpv1alpha1.Property
 }
 
 // RatelimitCriteria criterias of rate limiting

--- a/adapter/internal/oasparser/envoyconf/routes_with_clusters.go
+++ b/adapter/internal/oasparser/envoyconf/routes_with_clusters.go
@@ -1476,7 +1476,7 @@ func genRouteCreateParams(swagger *model.AdapterInternalAPI, resource *model.Res
 		passRequestPayloadToEnforcer: swagger.GetXWso2RequestBodyPass(),
 		isDefaultVersion:             swagger.IsDefaultVersion,
 		apiLevelRateLimitPolicy:      swagger.RateLimitPolicy,
-		apiProperties:                  swagger.APIProperties,
+		apiProperties:                swagger.APIProperties,
 	}
 	return params
 }

--- a/adapter/internal/oasparser/envoyconf/routes_with_clusters.go
+++ b/adapter/internal/oasparser/envoyconf/routes_with_clusters.go
@@ -767,7 +767,7 @@ func createRoutes(params *routeCreateParams) (routes []*routev3.Route, err error
 			PathTemplate:     contextExtensions[pathContextExtension],
 			Vhost:            contextExtensions[vHostContextExtension],
 			ClusterName:      contextExtensions[clusterNameContextExtension],
-			APIProperty:	  getAPIProperties(params.apiProperty),
+			APIProperties:	  getAPIProperties(params.apiProperties),
 		}
 		luaPerFilterConfig = lua.LuaPerRoute{
 			Override: &lua.LuaPerRoute_SourceCode{
@@ -1476,7 +1476,7 @@ func genRouteCreateParams(swagger *model.AdapterInternalAPI, resource *model.Res
 		passRequestPayloadToEnforcer: swagger.GetXWso2RequestBodyPass(),
 		isDefaultVersion:             swagger.IsDefaultVersion,
 		apiLevelRateLimitPolicy:      swagger.RateLimitPolicy,
-		apiProperty:                  swagger.APIProperty,
+		apiProperties:                  swagger.APIProperties,
 	}
 	return params
 }

--- a/adapter/internal/oasparser/envoyconf/routes_with_clusters.go
+++ b/adapter/internal/oasparser/envoyconf/routes_with_clusters.go
@@ -26,6 +26,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"encoding/json"
 
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -58,6 +59,7 @@ import (
 	"github.com/golang/protobuf/ptypes/any"
 	"github.com/golang/protobuf/ptypes/wrappers"
 	gwapiv1b1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+	dpv1alpha1 "github.com/wso2/apk/adapter/internal/operator/apis/dp/v1alpha1"
 )
 
 // WireLogValues holds debug logging related template values
@@ -765,6 +767,7 @@ func createRoutes(params *routeCreateParams) (routes []*routev3.Route, err error
 			PathTemplate:     contextExtensions[pathContextExtension],
 			Vhost:            contextExtensions[vHostContextExtension],
 			ClusterName:      contextExtensions[clusterNameContextExtension],
+			APIProperty:	  getAPIProperties(params.apiProperty),
 		}
 		luaPerFilterConfig = lua.LuaPerRoute{
 			Override: &lua.LuaPerRoute_SourceCode{
@@ -1399,6 +1402,15 @@ func getUpgradeConfig(apiType string) []*routev3.RouteAction_UpgradeConfig {
 	return upgradeConfig
 }
 
+func getAPIProperties(apiPropertiesConfig []dpv1alpha1.Property) string {
+	var apiProperties = make(map[string]string)
+	for _, val := range apiPropertiesConfig {
+		apiProperties[val.Name] = val.Value
+	}
+	apiPropertiesJSON, _ := json.Marshal(apiProperties)
+	return strings.Replace(string(apiPropertiesJSON), `"`, `'`, -1)
+}
+
 func getCorsPolicy(corsConfig *model.CorsConfig) *cors_filter_v3.CorsPolicy {
 
 	if corsConfig == nil || !corsConfig.Enabled {
@@ -1464,6 +1476,7 @@ func genRouteCreateParams(swagger *model.AdapterInternalAPI, resource *model.Res
 		passRequestPayloadToEnforcer: swagger.GetXWso2RequestBodyPass(),
 		isDefaultVersion:             swagger.IsDefaultVersion,
 		apiLevelRateLimitPolicy:      swagger.RateLimitPolicy,
+		apiProperty:                  swagger.APIProperty,
 	}
 	return params
 }

--- a/adapter/internal/oasparser/model/adapter_internal_api.go
+++ b/adapter/internal/oasparser/model/adapter_internal_api.go
@@ -64,7 +64,7 @@ type AdapterInternalAPI struct {
 	EnvType                  string
 	backendJWTTokenInfo      *BackendJWTTokenInfo
 	apiDefinitionFile        []byte
-	APIProperty	             []dpv1alpha1.Property
+	APIProperties	         []dpv1alpha1.Property
 	// GraphQLSchema              string
 	// GraphQLComplexities        GraphQLComplexityYaml
 	IsSystemAPI     bool

--- a/adapter/internal/oasparser/model/adapter_internal_api.go
+++ b/adapter/internal/oasparser/model/adapter_internal_api.go
@@ -64,6 +64,7 @@ type AdapterInternalAPI struct {
 	EnvType                  string
 	backendJWTTokenInfo      *BackendJWTTokenInfo
 	apiDefinitionFile        []byte
+	APIProperty	             []dpv1alpha1.Property
 	// GraphQLSchema              string
 	// GraphQLComplexities        GraphQLComplexityYaml
 	IsSystemAPI     bool

--- a/adapter/internal/oasparser/model/http_route.go
+++ b/adapter/internal/oasparser/model/http_route.go
@@ -521,4 +521,5 @@ func (swagger *AdapterInternalAPI) SetInfoAPICR(api dpv1alpha1.API) {
 	swagger.xWso2Basepath = api.Spec.Context
 	swagger.OrganizationID = api.Spec.Organization
 	swagger.IsSystemAPI = api.Spec.SystemAPI
+	swagger.APIProperty = api.Spec.APIProperty
 }

--- a/adapter/internal/oasparser/model/http_route.go
+++ b/adapter/internal/oasparser/model/http_route.go
@@ -521,5 +521,5 @@ func (swagger *AdapterInternalAPI) SetInfoAPICR(api dpv1alpha1.API) {
 	swagger.xWso2Basepath = api.Spec.Context
 	swagger.OrganizationID = api.Spec.Organization
 	swagger.IsSystemAPI = api.Spec.SystemAPI
-	swagger.APIProperty = api.Spec.APIProperty
+	swagger.APIProperties = api.Spec.APIProperties
 }

--- a/adapter/internal/operator/apis/dp/v1alpha1/api_types.go
+++ b/adapter/internal/operator/apis/dp/v1alpha1/api_types.go
@@ -90,7 +90,7 @@ type APISpec struct {
 	// +optional
 	SystemAPI bool `json:"systemAPI"`
 
-	APIProperty []Property `json:"apiProperties,omitempty"`
+	APIProperties []Property `json:"apiProperties,omitempty"`
 }
 
 // Property holds key value pair of APIProperties

--- a/adapter/internal/operator/apis/dp/v1alpha1/api_types.go
+++ b/adapter/internal/operator/apis/dp/v1alpha1/api_types.go
@@ -89,6 +89,14 @@ type APISpec struct {
 	//
 	// +optional
 	SystemAPI bool `json:"systemAPI"`
+
+	APIProperty []Property `json:"apiProperties,omitempty"`
+}
+
+// Property holds key value pair of APIProperties
+type Property struct {
+	Name  string `json:"name,omitempty"`
+	Value string `json:"value,omitempty"`
 }
 
 // EnvConfig contains the environment specific configuration

--- a/adapter/internal/operator/config/crd/bases/dp.wso2.com_apis.yaml
+++ b/adapter/internal/operator/config/crd/bases/dp.wso2.com_apis.yaml
@@ -56,6 +56,16 @@ spec:
                   defined. "Namespace/APIDisplayName" can be used to uniquely identify
                   an API.
                 type: string
+              apiProperties:
+                items:
+                  description: Property holds key value pair of APIProperties
+                  properties:
+                    name:
+                      type: string
+                    value:
+                      type: string
+                  type: object
+                type: array
               apiProvider:
                 description: APIProvider denotes the provider of the API.
                 type: string

--- a/adapter/internal/operator/synchronizer/gateway_synchronizer.go
+++ b/adapter/internal/operator/synchronizer/gateway_synchronizer.go
@@ -169,6 +169,7 @@ func getGlobalInterceptorScript(gatewayAPIPolicies map[string]v1alpha1.APIPolicy
 		PathTemplate:     "",
 		Vhost:            "",
 		ClusterName:      "",
+		APIProperty:      "",
 	}
 	reqI, resI := createInterceptors(gatewayAPIPolicies, gatewayInterceptorServiceMapping, gatewayBackendMapping)
 	if len(reqI) > 0 || len(resI) > 0 {

--- a/adapter/internal/operator/synchronizer/gateway_synchronizer.go
+++ b/adapter/internal/operator/synchronizer/gateway_synchronizer.go
@@ -169,7 +169,7 @@ func getGlobalInterceptorScript(gatewayAPIPolicies map[string]v1alpha1.APIPolicy
 		PathTemplate:     "",
 		Vhost:            "",
 		ClusterName:      "",
-		APIProperty:      "",
+		APIProperties:      "",
 	}
 	reqI, resI := createInterceptors(gatewayAPIPolicies, gatewayInterceptorServiceMapping, gatewayBackendMapping)
 	if len(reqI) > 0 || len(resI) > 0 {

--- a/developer/resources/interceptor-service-open-api-v1.yaml
+++ b/developer/resources/interceptor-service-open-api-v1.yaml
@@ -215,6 +215,9 @@ components:
         sandClusterName:
           type: string
           example: ""
+        apiProperties:
+          type: string
+          example: {'propertyName1':'propertyValue1','propertyName2':'propertyValue2'}
         authenticationContext:
           type: object
           properties:

--- a/helm-charts/crds/dp.wso2.com_apis.yaml
+++ b/helm-charts/crds/dp.wso2.com_apis.yaml
@@ -71,6 +71,16 @@ spec:
                   defined. "Namespace/APIDisplayName" can be used to uniquely identify
                   an API.
                 type: string
+              apiProperties:
+                items:
+                  description: Property holds key value pair of APIProperties
+                  properties:
+                    name:
+                      type: string
+                    value:
+                      type: string
+                  type: object
+                type: array
               apiProvider:
                 description: APIProvider denotes the provider of the API.
                 type: string

--- a/samples/request-response-mediation-interceptors/k8s-resources/api.yaml
+++ b/samples/request-response-mediation-interceptors/k8s-resources/api.yaml
@@ -24,6 +24,11 @@ spec:
   apiType: REST
   apiVersion: 1.0.0
   context: /interceptor/1.0.0
+  apiProperties:
+    - name: propertyName1
+      value: "propertyValue1"
+    - name: propertyName2
+      value: "propertyValue2"
   production:
     - httpRouteRefs:
       - interceptor-route

--- a/test/integration/integration/tests/resources/tests/interceptors-api-level.yaml
+++ b/test/integration/integration/tests/resources/tests/interceptors-api-level.yaml
@@ -29,6 +29,11 @@ spec:
     - httpRouteRefs:
       - api-interceptor-route
   organization: wso2-org
+  apiProperties:
+    - name: propertyName1
+      value: "propertyValue1"
+    - name: propertyName2
+      value: "propertyValue2"
 ---
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute


### PR DESCRIPTION
$subject
Related PR https://github.com/wso2/apk/pull/1251

**Config for Adding APIProperties to an API**
```
spec:
  apiProperties:
    - name: propertyName1
      value: "propertyValue1"
    - name: propertyName2
      value: "propertyValue2"
```

**Added APIProperties can be accessed inside interceptor services in both Request and Response paths**
```
invocationContext: {
   apiProperty: "{'propertyName1':'propertyValue1','propertyName2':'propertyValue2'}"
}
```