### PR TITLE
Improve workflow trigger conditions

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -3,6 +3,7 @@ on:
   workflow_dispatch:
   pull_request_target:
     types: [opened, synchronize, reopened]
+    paths-ignore: ['.gitignore/**', 'developer/**', 'log/**', 'samples/**', '.checkov.yaml', '.gitignore', '.gitmodules', 'db_recreate_steps.md', 'issue_template.md', 'LICENSE', 'pull_request_template.md', 'README.md']
 concurrency: 
   group: integration-test-${{ github.event.number || github.run_id }}
 env:
@@ -144,7 +145,7 @@ jobs:
       AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
 
   runs_integration_tests_on_pull_request_target:
-    if: github.event_name == 'pull_request_target' && github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.action == 'reopened'
+    if: github.event_name == 'pull_request_target' && !contains(github.event.pull_request.title, '[IGNORE_AKS]') && github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.action == 'reopened'
     needs: [build_adapter, build_enforcer, build_runtime,build_management_server,build_admin,build_backoffice,build_devportal, build_idpds, build_idpui,build_config]
     runs-on: ubuntu-latest
     steps:
@@ -257,7 +258,7 @@ jobs:
        fail_on_test_failures: true
 
   runs_go_integration_tests_on_pull_request_target:
-    if: github.event_name == 'pull_request_target' && github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.action == 'reopened'
+    if: github.event_name == 'pull_request_target' && !contains(github.event.pull_request.title, '[IGNORE_AKS]') && github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.action == 'reopened'
     needs: [build_adapter, build_enforcer]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -145,7 +145,7 @@ jobs:
       AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
 
   runs_integration_tests_on_pull_request_target:
-    if: github.event_name == 'pull_request_target' && !contains(github.event.pull_request.title, '[IGNORE_AKS]') && github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.action == 'reopened'
+    if: github.event_name == 'pull_request_target' && !contains(github.event.pull_request.labels.*.name, 'IGNORE_AKS') && github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.action == 'reopened'
     needs: [build_adapter, build_enforcer, build_runtime,build_management_server,build_admin,build_backoffice,build_devportal, build_idpds, build_idpui,build_config]
     runs-on: ubuntu-latest
     steps:
@@ -258,7 +258,7 @@ jobs:
        fail_on_test_failures: true
 
   runs_go_integration_tests_on_pull_request_target:
-    if: github.event_name == 'pull_request_target' && !contains(github.event.pull_request.title, '[IGNORE_AKS]') && github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.action == 'reopened'
+    if: github.event_name == 'pull_request_target' && !contains(github.event.pull_request.labels.*.name, 'IGNORE_AKS') && github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.action == 'reopened'
     needs: [build_adapter, build_enforcer]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Purpose
> We are using AKS to run the integration tests. Now git action triggered for files changes that actually do not need a integration test. In addition to the paths-ignore improvement, I have added logic to check if the title of the PR contains [IGNORE_AKS] to ignore integration tests on AKS. If the developer is creating draft PR that does not need an integration test they can add this string to the PR title and skip the testing. 