### PR TITLE
Add: HealthChecks in upstream level

### DIFF
--- a/adapter/config/default_config.go
+++ b/adapter/config/default_config.go
@@ -64,12 +64,6 @@ var defaultConfig = &Config{
 				VerifyHostName:         true,
 				DisableSslVerification: false,
 			},
-			Health: upstreamHealth{
-				Timeout:            1,
-				Interval:           10,
-				UnhealthyThreshold: 2,
-				HealthyThreshold:   2,
-			},
 			Retry: upstreamRetry{
 				StatusCodes: []uint32{504},
 			},

--- a/adapter/config/types.go
+++ b/adapter/config/types.go
@@ -186,11 +186,10 @@ type payloadPassingToEnforcer struct {
 // Envoy Upstream Related Configurations
 type envoyUpstream struct {
 	// UpstreamTLS related Configuration
-	TLS    upstreamTLS
-	Health upstreamHealth
-	DNS    upstreamDNS
-	Retry  upstreamRetry
-	HTTP2  upstreamHTTP2Options
+	TLS   upstreamTLS
+	DNS   upstreamDNS
+	Retry upstreamRetry
+	HTTP2 upstreamHTTP2Options
 }
 
 // Envoy Downstream Related Configurations
@@ -211,13 +210,6 @@ type upstreamTLS struct {
 	TrustedCertPath        string
 	VerifyHostName         bool
 	DisableSslVerification bool
-}
-
-type upstreamHealth struct {
-	Timeout            int32
-	Interval           int32
-	UnhealthyThreshold int32
-	HealthyThreshold   int32
 }
 
 type upstreamDNS struct {

--- a/adapter/internal/oasparser/envoyconf/routes_with_clusters.go
+++ b/adapter/internal/oasparser/envoyconf/routes_with_clusters.go
@@ -490,8 +490,8 @@ func processEndpoints(clusterName string, clusterDetails *model.EndpointCluster,
 		},
 	}
 
-	if len(clusterDetails.Endpoints) > 1 {
-		cluster.HealthChecks = createHealthCheck()
+	if len(clusterDetails.Endpoints) > 0 && clusterDetails.HealthCheck != nil {
+		cluster.HealthChecks = createHealthCheck(clusterDetails.HealthCheck)
 	}
 
 	if clusterDetails.Config != nil && clusterDetails.Config.CircuitBreakers != nil {
@@ -522,14 +522,13 @@ func processEndpoints(clusterName string, clusterDetails *model.EndpointCluster,
 	return &cluster, addresses, nil
 }
 
-func createHealthCheck() []*corev3.HealthCheck {
-	conf := config.ReadConfigs()
+func createHealthCheck(healthCheck *model.HealthCheck) []*corev3.HealthCheck {
 	return []*corev3.HealthCheck{
 		{
-			Timeout:            durationpb.New(time.Duration(conf.Envoy.Upstream.Health.Timeout) * time.Second),
-			Interval:           durationpb.New(time.Duration(conf.Envoy.Upstream.Health.Interval) * time.Second),
-			UnhealthyThreshold: wrapperspb.UInt32(uint32(conf.Envoy.Upstream.Health.UnhealthyThreshold)),
-			HealthyThreshold:   wrapperspb.UInt32(uint32(conf.Envoy.Upstream.Health.HealthyThreshold)),
+			Timeout:            durationpb.New(time.Duration(healthCheck.Timeout) * time.Second),
+			Interval:           durationpb.New(time.Duration(healthCheck.Interval) * time.Second),
+			UnhealthyThreshold: wrapperspb.UInt32(uint32(healthCheck.UnhealthyThreshold)),
+			HealthyThreshold:   wrapperspb.UInt32(uint32(healthCheck.HealthyThreshold)),
 			// we only support tcp default healthcheck
 			HealthChecker: &corev3.HealthCheck_TcpHealthCheck_{},
 		},

--- a/adapter/internal/oasparser/model/adapter_internal_api.go
+++ b/adapter/internal/oasparser/model/adapter_internal_api.go
@@ -152,7 +152,7 @@ type EndpointConfig struct {
 // HealthCheck holds the parameters for health check done by apk to the EndpointCluster
 type HealthCheck struct {
 	Timeout            int32 `mapstructure:"timeout"`
-	Interval           int32 `json:"mapstructure"`
+	Interval           int32 `mapstructure:"interval"`
 	UnhealthyThreshold int32 `mapstructure:"unhealthyThreshold"`
 	HealthyThreshold   int32 `mapstructure:"healthyThreshold"`
 }
@@ -333,7 +333,7 @@ func (swagger *AdapterInternalAPI) SetVersion(version string) {
 
 // SetIsDefaultVersion sets whether this API is the default
 func (swagger *AdapterInternalAPI) SetIsDefaultVersion(isDefaultVersion bool) {
-	swagger.IsDefaultVersion = isDefaultVersion;
+	swagger.IsDefaultVersion = isDefaultVersion
 }
 
 // SetXWso2AuthHeader sets the authHeader of the API

--- a/adapter/internal/oasparser/model/adapter_internal_api.go
+++ b/adapter/internal/oasparser/model/adapter_internal_api.go
@@ -101,6 +101,7 @@ type EndpointCluster struct {
 	// EndpointType enum {failover, loadbalance}. if any other value provided, consider as the default value; which is loadbalance
 	EndpointType string
 	Config       *EndpointConfig
+	HealthCheck  *HealthCheck
 	// Is http2 protocol enabled
 	HTTP2BackendEnabled bool
 }
@@ -146,6 +147,14 @@ type EndpointConfig struct {
 	TimeoutInMillis      uint32           `mapstructure:"timeoutInMillis"`
 	IdleTimeoutInSeconds uint32           `mapstructure:"idleTimeoutInSeconds"`
 	CircuitBreakers      *CircuitBreakers `mapstructure:"circuitBreakers"`
+}
+
+// HealthCheck holds the parameters for health check done by apk to the EndpointCluster
+type HealthCheck struct {
+	Timeout            int32 `mapstructure:"timeout"`
+	Interval           int32 `json:"mapstructure"`
+	UnhealthyThreshold int32 `mapstructure:"unhealthyThreshold"`
+	HealthyThreshold   int32 `mapstructure:"healthyThreshold"`
 }
 
 // RetryConfig holds the parameters for retries done by apk to the EndpointCluster

--- a/adapter/internal/oasparser/model/http_route.go
+++ b/adapter/internal/oasparser/model/http_route.go
@@ -127,6 +127,14 @@ func (swagger *AdapterInternalAPI) SetInfoHTTPRouteCR(httpRoute *gwapiv1b1.HTTPR
 						statusCodes = resolvedBackend.Retry.StatusCodes
 					}
 				}
+				if resolvedBackend.HealthCheck != nil {
+					healthCheck = &dpv1alpha1.HealthCheck{
+						Interval:           resolvedBackend.HealthCheck.Interval,
+						Timeout:            resolvedBackend.HealthCheck.Timeout,
+						UnhealthyThreshold: resolvedBackend.HealthCheck.UnhealthyThreshold,
+						HealthyThreshold:   resolvedBackend.HealthCheck.HealthyThreshold,
+					}
+				}
 				endPoints = append(endPoints, GetEndpoints(backendName, httpRouteParams.BackendMapping)...)
 				backendBasePath = GetBackendBasePath(backendName, httpRouteParams.BackendMapping)
 				for _, security := range resolvedBackend.Security {

--- a/adapter/internal/operator/apis/dp/v1alpha1/backend_types.go
+++ b/adapter/internal/operator/apis/dp/v1alpha1/backend_types.go
@@ -70,9 +70,24 @@ type BackendSpec struct {
 
 	// +optional
 	Retry *RetryConfig `json:"retry,omitempty"`
-	
+
 	// +optional
 	BasePath string `json:"basePath"`
+
+	// +optional
+	HealthCheck *HealthCheck `json:"healthCheck,omitempty"`
+}
+
+// HealthCheck defines the health check configurations
+type HealthCheck struct {
+	// +kubebuilder:default=1
+	Timeout int32 `json:"timeout,omitempty"`
+	// +kubebuilder:default=10
+	Interval int32 `json:"interval,omitempty"`
+	// +kubebuilder:default=2
+	UnhealthyThreshold int32 `json:"unhealthyThreshold,omitempty"`
+	// +kubebuilder:default=2
+	HealthyThreshold int32 `json:"healthyThreshold,omitempty"`
 }
 
 // Timeout defines the timeout configurations

--- a/adapter/internal/operator/apis/dp/v1alpha1/backend_webhook.go
+++ b/adapter/internal/operator/apis/dp/v1alpha1/backend_webhook.go
@@ -102,6 +102,25 @@ func (r *Backend) validateBackendSpec() error {
 			}
 		}
 	}
+	healthCheck := r.Spec.HealthCheck
+	if healthCheck != nil {
+		if healthCheck.Timeout < 0 {
+			allErrs = append(allErrs, field.Invalid(field.NewPath("spec").Child("healthCheck").Child("timeoutInMillis"),
+				healthCheck.Timeout, "timeout should be greater than or equal to 0"))
+		}
+		if healthCheck.Interval < 0 {
+			allErrs = append(allErrs, field.Invalid(field.NewPath("spec").Child("healthCheck").Child("intervalInMillis"),
+				healthCheck.Interval, "interval should be greater than or equal to 0"))
+		}
+		if healthCheck.UnhealthyThreshold < 0 {
+			allErrs = append(allErrs, field.Invalid(field.NewPath("spec").Child("healthCheck").Child("unhealthyThreshold"),
+				healthCheck.UnhealthyThreshold, "unhealthyThreshold should be greater than or equal to 0"))
+		}
+		if healthCheck.HealthyThreshold < 0 {
+			allErrs = append(allErrs, field.Invalid(field.NewPath("spec").Child("healthCheck").Child("healthyThreshold"),
+				healthCheck.HealthyThreshold, "healthyThreshold should be greater than or equal to 0"))
+		}
+	}
 	if len(allErrs) > 0 {
 		return apierrors.NewInvalid(
 			schema.GroupKind{Group: "dp.wso2.com", Kind: "Backend"},

--- a/adapter/internal/operator/apis/dp/v1alpha1/resolvedbackend.go
+++ b/adapter/internal/operator/apis/dp/v1alpha1/resolvedbackend.go
@@ -31,7 +31,8 @@ type ResolvedBackend struct {
 	CircuitBreaker *CircuitBreaker
 	Timeout        *Timeout
 	Retry          *RetryConfig
-	BasePath string `json:"basePath"`
+	BasePath       string `json:"basePath"`
+	HealthCheck    *HealthCheck
 }
 
 // ResolvedTLSConfig defines enpoint TLS configurations

--- a/adapter/internal/operator/config/crd/bases/dp.wso2.com_backends.yaml
+++ b/adapter/internal/operator/config/crd/bases/dp.wso2.com_backends.yaml
@@ -65,6 +65,26 @@ spec:
                 - maxRequests
                 - maxRetries
                 type: object
+              healthCheck:
+                description: HealthCheck defines the health check configurations
+                properties:
+                  healthyThreshold:
+                    default: 2
+                    format: int32
+                    type: integer
+                  interval:
+                    default: 10
+                    format: int32
+                    type: integer
+                  timeout:
+                    default: 1
+                    format: int32
+                    type: integer
+                  unhealthyThreshold:
+                    default: 2
+                    format: int32
+                    type: integer
+                type: object
               protocol:
                 default: http
                 description: BackendProtocolType defines the backend protocol type.

--- a/adapter/internal/operator/utils/utils.go
+++ b/adapter/internal/operator/utils/utils.go
@@ -332,6 +332,14 @@ func GetResolvedBackend(ctx context.Context, client k8client.Client,
 			StatusCodes:        backend.Spec.Retry.StatusCodes,
 		}
 	}
+	if backend.Spec.HealthCheck != nil {
+		resolvedBackend.HealthCheck = &dpv1alpha1.HealthCheck{
+			Timeout:            backend.Spec.HealthCheck.Timeout,
+			Interval:           backend.Spec.HealthCheck.Interval,
+			UnhealthyThreshold: backend.Spec.HealthCheck.UnhealthyThreshold,
+			HealthyThreshold:   backend.Spec.HealthCheck.HealthyThreshold,
+		}
+	}
 	if backend.Spec.TLS != nil {
 		resolvedTLSConfig.ResolvedCertificate, err = ResolveCertificate(ctx, client,
 			backend.Namespace, backend.Spec.TLS.CertificateInline, backend.Spec.TLS.ConfigMapRef, backend.Spec.TLS.SecretRef)

--- a/developer/tryout/samples/sample-backend.yaml
+++ b/developer/tryout/samples/sample-backend.yaml
@@ -41,6 +41,8 @@ spec:
     maxRouteTimeoutSeconds: 60
     routeIdleTimeoutSeconds: 10
     routeTimeoutSeconds: 40
+  healthCheck:
+    timeout: 5
   retry:
     count: 4
     baseIntervalMillis: 2000

--- a/helm-charts/crds/dp.wso2.com_backends.yaml
+++ b/helm-charts/crds/dp.wso2.com_backends.yaml
@@ -83,6 +83,26 @@ spec:
                 - maxRequests
                 - maxRetries
                 type: object
+              healthCheck:
+                description: HealthCheck defines the health check configurations
+                properties:
+                  healthyThreshold:
+                    default: 2
+                    format: int32
+                    type: integer
+                  interval:
+                    default: 10
+                    format: int32
+                    type: integer
+                  timeout:
+                    default: 1
+                    format: int32
+                    type: integer
+                  unhealthyThreshold:
+                    default: 2
+                    format: int32
+                    type: integer
+                type: object
               protocol:
                 default: http
                 description: BackendProtocolType defines the backend protocol type.
@@ -224,4 +244,3 @@ spec:
     storage: true
     subresources:
       status: {}
-


### PR DESCRIPTION
## Purpose
Add `healthCheck` configuration in Backend CRD.

## Approach
- Introduced a new struct for health check configurations in `backend_types.go`.
- Added the validations for the properties in `backend_webhook.go`.
- Updated the backend CR in helm chart to support the configurations.
- Backend CR looks as follows
```
apiVersion: dp.wso2.com/v1alpha1
kind: Backend
metadata:
  name: test-backend
spec:
  healthCheck:
    timeout: 5
  services:
  - host: test-backend-svc
    port: 3000
```

- Route config looks as follows.
```
          "cluster": {
            "@type": "type.googleapis.com/envoy.config.cluster.v3.Cluster",
            "name": "a3b58ccf-6ecc-4557-b5bb-0a35cce38256__prod.gw.wso2.com_http-bin-api1.0.8_3b4f1dbd-a23b-4ef4-9c18-240f3dd758d40",
            "type": "STRICT_DNS",
            "connect_timeout": "20s",
            "health_checks": [
              {
                "timeout": "5s",
                "interval": "10s",
                "unhealthy_threshold": 2,
                "healthy_threshold": 2,
                "tcp_health_check": {}
              }
            ],
            "dns_refresh_rate": "5s",
            "dns_lookup_family": "V4_ONLY",
            "load_assignment": {
              "cluster_name": "a3b58ccf-6ecc-4557-b5bb-0a35cce38256__prod.gw.wso2.com_http-bin-api1.0.8_3b4f1dbd-a23b-4ef4-9c18-240f3dd758d40",
              "endpoints": [
                {
                  "lb_endpoints": [
                    {
                      "endpoint": {
                        "address": {
                          "socket_address": {
                            "address": "test-backend-svc",
                            "port_value": 3000
                          }
                        }
                      }
                    }
                  ]
                }
              ]
            },
```
### Related Issues
- Fixes: https://github.com/wso2/apk/issues/1338