### PR TITLE
Add: MTLS Support in API level

### DIFF
--- a/adapter/internal/oasparser/config_generator.go
+++ b/adapter/internal/oasparser/config_generator.go
@@ -207,7 +207,7 @@ func GetEnforcerAPI(adapterInternalAPI model.AdapterInternalAPI, vhost string) *
 		BackendJWTTokenInfo:    backendJWTTokenInfo,
 		// IsMockedApi:         isMockedAPI,
 		ClientCertificates:  clientCertificates,
-		MutualSSL:           adapterInternalAPI.GetXWSO2MutualSSL(),
+		MutualSSL:           adapterInternalAPI.GetMutualSSL(),
 		ApplicationSecurity: adapterInternalAPI.GetXWSO2ApplicationSecurity(),
 		// GraphQLSchema:         adapterInternalAPI.GraphQLSchema,
 		// GraphqlComplexityInfo: adapterInternalAPI.GraphQLComplexities.Data.List,

--- a/adapter/internal/oasparser/model/adapter_internal_api.go
+++ b/adapter/internal/oasparser/model/adapter_internal_api.go
@@ -60,7 +60,7 @@ type AdapterInternalAPI struct {
 	xWso2RequestBodyPass     bool
 	IsDefaultVersion         bool
 	clientCertificates       []Certificate
-	xWso2MutualSSL           string
+	mutualSSL                string
 	xWso2ApplicationSecurity bool
 	EnvType                  string
 	backendJWTTokenInfo      *BackendJWTTokenInfo
@@ -355,14 +355,14 @@ func (swagger *AdapterInternalAPI) GetXWSO2AuthHeader() string {
 	return swagger.xWso2AuthHeader
 }
 
-// SetXWSO2MutualSSL sets the optional or mandatory mTLS
-func (swagger *AdapterInternalAPI) SetXWSO2MutualSSL(mutualSSl string) {
-	swagger.xWso2MutualSSL = mutualSSl
+// SetMutualSSL sets the optional or mandatory mTLS
+func (swagger *AdapterInternalAPI) SetMutualSSL(mutualSSl string) {
+	swagger.mutualSSL = mutualSSl
 }
 
-// GetXWSO2MutualSSL returns the optional or mandatory mTLS
-func (swagger *AdapterInternalAPI) GetXWSO2MutualSSL() string {
-	return swagger.xWso2MutualSSL
+// GetMutualSSL returns the optional or mandatory mTLS
+func (swagger *AdapterInternalAPI) GetMutualSSL() string {
+	return swagger.mutualSSL
 }
 
 // SetXWSO2ApplicationSecurity sets the optional or mandatory application security

--- a/adapter/internal/oasparser/model/http_route.go
+++ b/adapter/internal/oasparser/model/http_route.go
@@ -68,7 +68,7 @@ func (swagger *AdapterInternalAPI) SetInfoHTTPRouteCR(httpRoute *gwapiv1b1.HTTPR
 		var mutualSSL string
 		if authScheme.Spec.Override != nil && authScheme.Spec.Default != nil && authScheme.Spec.Override.MutualSSL == "" {
 			mutualSSL = authScheme.Spec.Default.MutualSSL
-		} else {
+		} else if authScheme.Spec.Override != nil && authScheme.Spec.Override.MutualSSL != "" {
 			mutualSSL = authScheme.Spec.Override.MutualSSL
 		}
 		swagger.mutualSSL = mutualSSL

--- a/adapter/internal/oasparser/model/http_route.go
+++ b/adapter/internal/oasparser/model/http_route.go
@@ -65,6 +65,13 @@ func (swagger *AdapterInternalAPI) SetInfoHTTPRouteCR(httpRoute *gwapiv1b1.HTTPR
 		if authScheme.Spec.Override != nil && authScheme.Spec.Override.ExternalService.Disabled != nil {
 			disableAuthentications = *authScheme.Spec.Override.ExternalService.Disabled
 		}
+		var mutualSSL string
+		if authScheme.Spec.Override != nil && authScheme.Spec.Default != nil && authScheme.Spec.Override.MutualSSL == "" {
+			mutualSSL = authScheme.Spec.Default.MutualSSL
+		} else {
+			mutualSSL = authScheme.Spec.Override.MutualSSL
+		}
+		swagger.mutualSSL = mutualSSL
 	}
 	var apiPolicy *dpv1alpha1.APIPolicy
 	if outputAPIPolicy != nil {

--- a/adapter/internal/oasparser/model/http_route.go
+++ b/adapter/internal/oasparser/model/http_route.go
@@ -66,10 +66,10 @@ func (swagger *AdapterInternalAPI) SetInfoHTTPRouteCR(httpRoute *gwapiv1b1.HTTPR
 			disableAuthentications = *authScheme.Spec.Override.ExternalService.Disabled
 		}
 		var mutualSSL string
-		if authScheme.Spec.Override != nil && authScheme.Spec.Default != nil && authScheme.Spec.Override.MutualSSL == "" {
-			mutualSSL = authScheme.Spec.Default.MutualSSL
-		} else if authScheme.Spec.Override != nil && authScheme.Spec.Override.MutualSSL != "" {
-			mutualSSL = authScheme.Spec.Override.MutualSSL
+		if authScheme.Spec.Override != nil && authScheme.Spec.Default != nil && authScheme.Spec.Default.ExternalService.AuthTypes != nil && authScheme.Spec.Override.ExternalService.AuthTypes != nil && authScheme.Spec.Override.ExternalService.AuthTypes.MutualSSL == "" {
+			mutualSSL = authScheme.Spec.Default.ExternalService.AuthTypes.MutualSSL
+		} else if authScheme.Spec.Override != nil && authScheme.Spec.Override.ExternalService.AuthTypes != nil && authScheme.Spec.Override.ExternalService.AuthTypes.MutualSSL != "" {
+			mutualSSL = authScheme.Spec.Override.ExternalService.AuthTypes.MutualSSL
 		}
 		swagger.mutualSSL = mutualSSL
 	}

--- a/adapter/internal/operator/PROJECT
+++ b/adapter/internal/operator/PROJECT
@@ -40,6 +40,10 @@ resources:
   kind: Authentication
   path: github.com/wso2/apk/adapter/internal/operator/apis/dp/v1alpha1
   version: v1alpha1
+  webhooks:
+    defaulting: true
+    validation: true
+    webhookVersion: v1
 - api:
     crdVersion: v1
     namespaced: true

--- a/adapter/internal/operator/apis/dp/v1alpha1/authentication_types.go
+++ b/adapter/internal/operator/apis/dp/v1alpha1/authentication_types.go
@@ -35,8 +35,6 @@ type AuthenticationSpec struct {
 type AuthSpec struct {
 	AuthServerType  string         `json:"type,omitempty"`
 	ExternalService ExtAuthService `json:"ext,omitempty"`
-	// +optional
-	MutualSSL string `json:"mutualSSL,omitempty"`
 }
 
 // ExtAuthService external authentication related information
@@ -59,6 +57,9 @@ type ServiceRef struct {
 
 // APIAuth Authentication scheme type and details
 type APIAuth struct {
+	// +optional
+	// +kubebuilder:validation:Enum=mandatory;optional
+	MutualSSL      string             `json:"mutualSSL,omitempty"`
 	JWT            JWTAuth            `json:"jwt,omitempty"`
 	APIKey         []APIKeyAuth       `json:"apiKey,omitempty"`
 	TestConsoleKey TestConsoleKeyAuth `json:"testConsoleKey,omitempty"`

--- a/adapter/internal/operator/apis/dp/v1alpha1/authentication_types.go
+++ b/adapter/internal/operator/apis/dp/v1alpha1/authentication_types.go
@@ -35,6 +35,8 @@ type AuthenticationSpec struct {
 type AuthSpec struct {
 	AuthServerType  string         `json:"type,omitempty"`
 	ExternalService ExtAuthService `json:"ext,omitempty"`
+	// +optional
+	MutualSSL string `json:"mutualSSL,omitempty"`
 }
 
 // ExtAuthService external authentication related information

--- a/adapter/internal/operator/apis/dp/v1alpha1/authentication_webhook.go
+++ b/adapter/internal/operator/apis/dp/v1alpha1/authentication_webhook.go
@@ -1,0 +1,105 @@
+/*
+ *  Copyright (c) 2022, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package v1alpha1
+
+import (
+	"fmt"
+	"strings"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	ctrl "sigs.k8s.io/controller-runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+// log is for logging in this package.
+var authenticationlog = logf.Log.WithName("authentication-resource")
+
+// SetupWebhookWithManager sets up and registers the webhook with the manager.
+func (r *Authentication) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(r).
+		Complete()
+}
+
+// TODO(user): EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
+
+//+kubebuilder:webhook:path=/mutate-dp-wso2-com-v1alpha1-authentication,mutating=true,failurePolicy=fail,sideEffects=None,groups=dp.wso2.com,resources=authentications,verbs=create;update,versions=v1alpha1,name=mauthentication.kb.io,admissionReviewVersions=v1
+
+var _ webhook.Defaulter = &Authentication{}
+
+// Default implements webhook.Defaulter so a webhook will be registered for the type
+func (r *Authentication) Default() {
+	authenticationlog.Info("default", "name", r.Name)
+
+	// TODO(user): fill in your defaulting logic.
+}
+
+// TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
+//+kubebuilder:webhook:path=/validate-dp-wso2-com-v1alpha1-authentication,mutating=false,failurePolicy=fail,sideEffects=None,groups=dp.wso2.com,resources=authentications,verbs=create;update,versions=v1alpha1,name=vauthentication.kb.io,admissionReviewVersions=v1
+
+var _ webhook.Validator = &Authentication{}
+
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type
+func (r *Authentication) ValidateCreate() error {
+	fmt.Println("Auth validate create")
+	return r.validateAuthentication()
+}
+
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
+func (r *Authentication) ValidateUpdate(old runtime.Object) error {
+	return r.validateAuthentication()
+}
+
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type
+func (r *Authentication) ValidateDelete() error {
+	authenticationlog.Info("validate delete", "name", r.Name)
+
+	// TODO(user): fill in your validation logic upon object deletion.
+	return nil
+}
+
+func (r *Authentication) validateAuthentication() error {
+	var allErrs field.ErrorList
+	const mltsOptional = "optional"
+	const mltsMandatory = "mandatory"
+	mtlsOverride := r.Spec.Override.MutualSSL
+	mtlsDefault := r.Spec.Default.MutualSSL
+	fmt.Println("mtlsOverride", mtlsOverride)
+	if mtlsOverride != "" && mtlsDefault != "" {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("spec").Child("default").Child("mutualSSL"),
+			r.Spec.Default.MutualSSL, "mutualSSL cannot be empty in both default and override"))
+	}
+	if mtlsOverride != "" && (!strings.EqualFold(mtlsDefault, mltsMandatory) || !strings.EqualFold(mtlsDefault, mltsOptional)) {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("spec").Child("override").Child("mutualSSL"),
+			r.Spec.Override.MutualSSL, "invalid value for mutualSSL"))
+	}
+	if mtlsDefault != "" && (!strings.EqualFold(mtlsDefault, mltsMandatory) || !strings.EqualFold(mtlsDefault, mltsOptional)) {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("spec").Child("default").Child("mutualSSL"),
+			r.Spec.Default.MutualSSL, "invalid value for mutualSSL"))
+	}
+	if len(allErrs) > 0 {
+		return apierrors.NewInvalid(
+			schema.GroupKind{Group: "dp.wso2.com", Kind: "Authentication"},
+			r.Name, allErrs)
+	}
+	return nil
+}

--- a/adapter/internal/operator/apis/dp/v1alpha1/authentication_webhook.go
+++ b/adapter/internal/operator/apis/dp/v1alpha1/authentication_webhook.go
@@ -91,7 +91,7 @@ func (r *Authentication) validateAuthentication() error {
 		mtlsOverride = r.Spec.Override.ExternalService.AuthTypes.MutualSSL
 	}
 
-	if mtlsOverride == "" && !isMtlsDefault {
+	if r.Spec.Override != nil && r.Spec.Override.ExternalService.AuthTypes != nil && mtlsOverride == "" && !isMtlsDefault {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("spec").Child("override").Child("ext").Child("authTypes").Child("mutualSSL"),
 			r.Spec.Override.ExternalService.AuthTypes.MutualSSL, "mutualSSL is mandatory when default is not set"))
 	}

--- a/adapter/internal/operator/apis/dp/v1alpha1/authentication_webhook.go
+++ b/adapter/internal/operator/apis/dp/v1alpha1/authentication_webhook.go
@@ -83,16 +83,15 @@ func (r *Authentication) validateAuthentication() error {
 	const mltsMandatory = "mandatory"
 	mtlsOverride := r.Spec.Override.MutualSSL
 	mtlsDefault := r.Spec.Default.MutualSSL
-	fmt.Println("mtlsOverride", mtlsOverride)
-	if mtlsOverride != "" && mtlsDefault != "" {
+	if mtlsOverride == "" && mtlsDefault == "" {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("spec").Child("default").Child("mutualSSL"),
 			r.Spec.Default.MutualSSL, "mutualSSL cannot be empty in both default and override"))
 	}
-	if mtlsOverride != "" && (!strings.EqualFold(mtlsDefault, mltsMandatory) || !strings.EqualFold(mtlsDefault, mltsOptional)) {
+	if mtlsOverride != "" && (!strings.EqualFold(mtlsOverride, mltsMandatory) && !strings.EqualFold(mtlsOverride, mltsOptional)) {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("spec").Child("override").Child("mutualSSL"),
 			r.Spec.Override.MutualSSL, "invalid value for mutualSSL"))
 	}
-	if mtlsDefault != "" && (!strings.EqualFold(mtlsDefault, mltsMandatory) || !strings.EqualFold(mtlsDefault, mltsOptional)) {
+	if mtlsDefault != "" && (!strings.EqualFold(mtlsDefault, mltsMandatory) && !strings.EqualFold(mtlsDefault, mltsOptional)) {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("spec").Child("default").Child("mutualSSL"),
 			r.Spec.Default.MutualSSL, "invalid value for mutualSSL"))
 	}

--- a/adapter/internal/operator/apis/dp/v1alpha1/webhook_suite_test.go
+++ b/adapter/internal/operator/apis/dp/v1alpha1/webhook_suite_test.go
@@ -115,6 +115,9 @@ var _ = BeforeSuite(func() {
 	err = (&Backend{}).SetupWebhookWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred())
 
+	err = (&Authentication{}).SetupWebhookWithManager(mgr)
+	Expect(err).NotTo(HaveOccurred())
+
 	//+kubebuilder:scaffold:webhook
 
 	go func() {

--- a/adapter/internal/operator/config/crd/bases/dp.wso2.com_authentications.yaml
+++ b/adapter/internal/operator/config/crd/bases/dp.wso2.com_authentications.yaml
@@ -108,6 +108,8 @@ spec:
                             type: integer
                         type: object
                     type: object
+                  mutualSSL:
+                    type: string
                   type:
                     type: string
                 type: object
@@ -184,6 +186,8 @@ spec:
                             type: integer
                         type: object
                     type: object
+                  mutualSSL:
+                    type: string
                   type:
                     type: string
                 type: object

--- a/adapter/internal/operator/config/crd/bases/dp.wso2.com_authentications.yaml
+++ b/adapter/internal/operator/config/crd/bases/dp.wso2.com_authentications.yaml
@@ -77,6 +77,11 @@ spec:
                               sendTokenToUpstream:
                                 type: boolean
                             type: object
+                          mutualSSL:
+                            enum:
+                            - mandatory
+                            - optional
+                            type: string
                           testConsoleKey:
                             description: TestConsoleKeyAuth Test Console Key Authentication
                               scheme details
@@ -108,8 +113,6 @@ spec:
                             type: integer
                         type: object
                     type: object
-                  mutualSSL:
-                    type: string
                   type:
                     type: string
                 type: object
@@ -155,6 +158,11 @@ spec:
                               sendTokenToUpstream:
                                 type: boolean
                             type: object
+                          mutualSSL:
+                            enum:
+                            - mandatory
+                            - optional
+                            type: string
                           testConsoleKey:
                             description: TestConsoleKeyAuth Test Console Key Authentication
                               scheme details
@@ -186,8 +194,6 @@ spec:
                             type: integer
                         type: object
                     type: object
-                  mutualSSL:
-                    type: string
                   type:
                     type: string
                 type: object

--- a/adapter/internal/operator/config/webhook/manifests.yaml
+++ b/adapter/internal/operator/config/webhook/manifests.yaml
@@ -51,6 +51,26 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
+      path: /mutate-dp-wso2-com-v1alpha1-authentication
+  failurePolicy: Fail
+  name: mauthentication.kb.io
+  rules:
+  - apiGroups:
+    - dp.wso2.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - authentications
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
       path: /mutate-dp-wso2-com-v1alpha1-backend
   failurePolicy: Fail
   name: mbackend.kb.io
@@ -151,6 +171,26 @@ webhooks:
     - UPDATE
     resources:
     - apipolicies
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-dp-wso2-com-v1alpha1-authentication
+  failurePolicy: Fail
+  name: vauthentication.kb.io
+  rules:
+  - apiGroups:
+    - dp.wso2.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - authentications
   sideEffects: None
 - admissionReviewVersions:
   - v1

--- a/adapter/internal/operator/main.go
+++ b/adapter/internal/operator/main.go
@@ -134,8 +134,12 @@ func InitOperator() {
 		loggers.LoggerAPKOperator.ErrorC(logging.GetErrorByCode(2652, err))
 	}
 
+	if err = (&dpv1alpha1.Authentication{}).SetupWebhookWithManager(mgr); err != nil {
+		loggers.LoggerAPKOperator.ErrorC(logging.GetErrorByCode(2655, err))
+	}
+
 	if err = (&dpv1alpha1.Backend{}).SetupWebhookWithManager(mgr); err != nil {
-		loggers.LoggerAPKOperator.ErrorC(logging.GetErrorByCode(3115, err))
+		loggers.LoggerAPKOperator.ErrorC(logging.GetErrorByCode(2656, err))
 	}
 
 	if err := dpcontrollers.NewGatewayController(mgr, operatorDataStore, updateHandler, &gatewaych); err != nil {

--- a/adapter/internal/operator/synchronizer/synchronizer.go
+++ b/adapter/internal/operator/synchronizer/synchronizer.go
@@ -156,6 +156,7 @@ func GenerateAdapterInternalAPI(apiState APIState, httpRoute *HTTPRouteState, en
 		RateLimitPolicies:         httpRoute.RateLimitPolicies,
 		ResourceRateLimitPolicies: httpRoute.ResourceRateLimitPolicies,
 	}
+
 	if err := adapterInternalAPI.SetInfoHTTPRouteCR(httpRoute.HTTPRoute, httpRouteParams); err != nil {
 		loggers.LoggerAPKOperator.ErrorC(logging.GetErrorByCode(2631, err))
 		return nil, err

--- a/adapter/pkg/logging/logging_constant.go
+++ b/adapter/pkg/logging/logging_constant.go
@@ -74,6 +74,8 @@ const (
 	error2652 = 2652
 	error2653 = 2653
 	error2654 = 2654
+	error2655 = 2655
+	error2656 = 2656
 )
 
 // Error Log Pkg auth(3001-3099) Config Constants
@@ -377,6 +379,16 @@ var Mapper = map[int]ErrorDetails{
 	error2652: {
 		ErrorCode: error2652,
 		Message:   "Unable to create webhook for InterceptorService: %v",
+		Severity:  BLOCKER,
+	},
+	error2655: {
+		ErrorCode: error2655,
+		Message:   "Unable to create webhook for Authentication: %v",
+		Severity:  BLOCKER,
+	},
+	error2656: {
+		ErrorCode: error2656,
+		Message:   "Unable to create webhook for Backend: %v",
 		Severity:  BLOCKER,
 	},
 	error3001: {

--- a/developer/tryout/samples/sample-auth.yaml
+++ b/developer/tryout/samples/sample-auth.yaml
@@ -4,31 +4,33 @@ metadata:
   name: sand-http-bin-authentication
 spec:
   override:
+    mutualSSL: abc
     type: ext
     ext:
-      disabled: true
-      # serviceRef:
-      #   group: wso2/v1alpha2
-      #   kind: Backend
-      #   name: ext_authz-server
-      #   port: 1234
-      # authTypes:
-      #   apiKey:
-      #     - in: Header
-      #       name: x-api-key
-  # default:
-  #   type: ext
-  #   ext:
-  #     serviceRef: 
-  #       group: wso2/v1alpha2
-  #       kind: Backend
-  #       name: ext_authz-server
-  #       port: 1234
-  #     authTypes:
-  #       apiKey:
-  #         - in: Header
-  #           name: x-api-key
+      disabled: false
+      serviceRef:
+        group: wso2/v1alpha2
+        kind: Backend
+        name: ext_authz-server
+        port: 1234
+      authTypes:
+        apiKey:
+          - in: Header
+            name: x-api-key
+  default:
+    mutualSSL: optional
+    type: ext
+    ext:
+      serviceRef: 
+        group: wso2/v1alpha2
+        kind: Backend
+        name: ext_authz-server
+        port: 1234
+      authTypes:
+        apiKey:
+          - in: Header
+            name: x-api-key
   targetRef:
-    kind: Resource
-    name: http-bin-api #provide API ref name
-    group: gateway.networking.k8s.io
+    kind: API
+    name: http-bin-api1 #provide API ref name
+    group: ""

--- a/developer/tryout/samples/sample-auth.yaml
+++ b/developer/tryout/samples/sample-auth.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sand-http-bin-authentication
 spec:
   override:
-    mutualSSL: abc
+    mutualSSL: optional
     type: ext
     ext:
       disabled: false
@@ -18,7 +18,7 @@ spec:
           - in: Header
             name: x-api-key
   default:
-    mutualSSL: optional
+    mutualSSL: ""
     type: ext
     ext:
       serviceRef: 

--- a/gateway/enforcer/org.wso2.apk.enforcer/src/main/java/org/wso2/apk/enforcer/api/RestAPI.java
+++ b/gateway/enforcer/org.wso2.apk.enforcer/src/main/java/org/wso2/apk/enforcer/api/RestAPI.java
@@ -140,7 +140,7 @@ public class RestAPI implements API {
                 .disableScopes(api.getDisableScopes()).trustStore(trustStore).organizationId(api.getOrganizationId())
                 .mtlsCertificateTiers(mtlsCertificateTiers).mutualSSL(mutualSSL).systemAPI(api.getSystemAPI())
                 .applicationSecurity(applicationSecurity).jwtConfigurationDto(jwtConfigurationDto)
-                .apiDefinition(apiDefinition).build();
+                .apiDefinition(apiDefinition).mutualSSL(api.getMutualSSL()).build();
 
         initFilters();
         return basePath;

--- a/helm-charts/crds/dp.wso2.com_authentications.yaml
+++ b/helm-charts/crds/dp.wso2.com_authentications.yaml
@@ -93,6 +93,11 @@ spec:
                               sendTokenToUpstream:
                                 type: boolean
                             type: object
+                          mutualSSL:
+                            enum:
+                            - mandatory
+                            - optional
+                            type: string
                           testConsoleKey:
                             description: TestConsoleKeyAuth Test Console Key Authentication
                               scheme details
@@ -124,8 +129,6 @@ spec:
                             type: integer
                         type: object
                     type: object
-                  mutualSSL:
-                    type: string
                   type:
                     type: string
                 type: object
@@ -171,6 +174,11 @@ spec:
                               sendTokenToUpstream:
                                 type: boolean
                             type: object
+                          mutualSSL:
+                            enum:
+                            - mandatory
+                            - optional
+                            type: string
                           testConsoleKey:
                             description: TestConsoleKeyAuth Test Console Key Authentication
                               scheme details
@@ -202,8 +210,6 @@ spec:
                             type: integer
                         type: object
                     type: object
-                  mutualSSL:
-                    type: string
                   type:
                     type: string
                 type: object

--- a/helm-charts/crds/dp.wso2.com_authentications.yaml
+++ b/helm-charts/crds/dp.wso2.com_authentications.yaml
@@ -31,249 +31,253 @@ spec:
     singular: authentication
   scope: Namespaced
   versions:
-    - name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: Authentication is the Schema for the authentications API
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Authentication is the Schema for the authentications API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: AuthenticationSpec defines the desired state of Authentication
-              properties:
-                default:
-                  description: AuthSpec specification of the authentication service
-                  properties:
-                    ext:
-                      description: ExtAuthService external authentication related information
-                      properties:
-                        authTypes:
-                          description: APIAuth Authentication scheme type and details
-                          properties:
-                            apiKey:
-                              items:
-                                description: APIKeyAuth APIKey Authentication scheme
-                                  details
-                                properties:
-                                  in:
-                                    description: In is to specify how the APIKey is
-                                      passed to the request
-                                    enum:
-                                      - Header
-                                      - Query
-                                    minLength: 1
-                                    type: string
-                                  name:
-                                    description: Name is the name of the header or query
-                                      parameter to be used
-                                    minLength: 1
-                                    type: string
-                                  sendTokenToUpstream:
-                                    type: boolean
-                                type: object
-                              type: array
-                            jwt:
-                              description: JWTAuth JWT Authentication scheme details
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AuthenticationSpec defines the desired state of Authentication
+            properties:
+              default:
+                description: AuthSpec specification of the authentication service
+                properties:
+                  ext:
+                    description: ExtAuthService external authentication related information
+                    properties:
+                      authTypes:
+                        description: APIAuth Authentication scheme type and details
+                        properties:
+                          apiKey:
+                            items:
+                              description: APIKeyAuth APIKey Authentication scheme
+                                details
                               properties:
-                                header:
-                                  default: authorization
-                                  description: Header is the header name used to pass
-                                    the JWT token
+                                in:
+                                  description: In is to specify how the APIKey is
+                                    passed to the request
+                                  enum:
+                                  - Header
+                                  - Query
+                                  minLength: 1
+                                  type: string
+                                name:
+                                  description: Name is the name of the header or query
+                                    parameter to be used
+                                  minLength: 1
                                   type: string
                                 sendTokenToUpstream:
                                   type: boolean
                               type: object
-                            testConsoleKey:
-                              description: TestConsoleKeyAuth Test Console Key Authentication
-                                scheme details
-                              properties:
-                                header:
-                                  default: internal-key
-                                  description: Header is the header name used to pass
-                                    the Test Console Key
-                                  type: string
-                                sendTokenToUpstream:
-                                  type: boolean
-                              type: object
-                          type: object
-                        disabled:
-                          description: Disabled is to disable all authentications
-                          nullable: true
-                          type: boolean
-                        serviceRef:
-                          description: ServiceRef service using for Authentication
-                          properties:
-                            group:
-                              type: string
-                            kind:
-                              type: string
-                            name:
-                              type: string
-                            port:
-                              format: int32
-                              type: integer
-                          type: object
-                      type: object
-                    type:
-                      type: string
-                  type: object
-                override:
-                  description: AuthSpec specification of the authentication service
-                  properties:
-                    ext:
-                      description: ExtAuthService external authentication related information
-                      properties:
-                        authTypes:
-                          description: APIAuth Authentication scheme type and details
-                          properties:
-                            apiKey:
-                              items:
-                                description: APIKeyAuth APIKey Authentication scheme
-                                  details
-                                properties:
-                                  in:
-                                    description: In is to specify how the APIKey is
-                                      passed to the request
-                                    enum:
-                                      - Header
-                                      - Query
-                                    minLength: 1
-                                    type: string
-                                  name:
-                                    description: Name is the name of the header or query
-                                      parameter to be used
-                                    minLength: 1
-                                    type: string
-                                  sendTokenToUpstream:
-                                    type: boolean
-                                type: object
-                              type: array
-                            jwt:
-                              description: JWTAuth JWT Authentication scheme details
-                              properties:
-                                header:
-                                  default: authorization
-                                  description: Header is the header name used to pass
-                                    the JWT token
-                                  type: string
-                                sendTokenToUpstream:
-                                  type: boolean
-                              type: object
-                            testConsoleKey:
-                              description: TestConsoleKeyAuth Test Console Key Authentication
-                                scheme details
-                              properties:
-                                header:
-                                  default: internal-key
-                                  description: Header is the header name used to pass
-                                    the Test Console Key
-                                  type: string
-                                sendTokenToUpstream:
-                                  type: boolean
-                              type: object
-                          type: object
-                        disabled:
-                          description: Disabled is to disable all authentications
-                          nullable: true
-                          type: boolean
-                        serviceRef:
-                          description: ServiceRef service using for Authentication
-                          properties:
-                            group:
-                              type: string
-                            kind:
-                              type: string
-                            name:
-                              type: string
-                            port:
-                              format: int32
-                              type: integer
-                          type: object
-                      type: object
-                    type:
-                      type: string
-                  type: object
-                targetRef:
-                  description: PolicyTargetReference identifies an API object to apply
-                    policy to. This should be used as part of Policy resources that
-                    can target Gateway API resources. For more information on how this
-                    policy attachment model works, and a sample Policy resource, refer
-                    to the policy attachment documentation for Gateway API.
-                  properties:
-                    group:
-                      description: Group is the group of the target resource.
-                      maxLength: 253
-                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                      type: string
-                    kind:
-                      description: Kind is kind of the target resource.
-                      maxLength: 63
-                      minLength: 1
-                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
-                      type: string
-                    name:
-                      description: Name is the name of the target resource.
-                      maxLength: 253
-                      minLength: 1
-                      type: string
-                    namespace:
-                      description: Namespace is the namespace of the referent. When
-                        unspecified, the local namespace is inferred. Even when policy
-                        targets a resource in a different namespace, it MUST only apply
-                        to traffic originating from the same namespace as the policy.
-                      maxLength: 63
-                      minLength: 1
-                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
-                      type: string
-                  required:
-                    - group
-                    - kind
-                    - name
-                  type: object
-              type: object
-            status:
-              description: AuthenticationStatus defines the observed state of Authentication
-              properties:
-                accepted:
-                  description: Accepted represents whether the Authentication is accepted
-                    or not.
-                  type: boolean
-                events:
-                  description: Events contains a list of events related to the Authentication.
-                  items:
+                            type: array
+                          jwt:
+                            description: JWTAuth JWT Authentication scheme details
+                            properties:
+                              header:
+                                default: authorization
+                                description: Header is the header name used to pass
+                                  the JWT token
+                                type: string
+                              sendTokenToUpstream:
+                                type: boolean
+                            type: object
+                          testConsoleKey:
+                            description: TestConsoleKeyAuth Test Console Key Authentication
+                              scheme details
+                            properties:
+                              header:
+                                default: internal-key
+                                description: Header is the header name used to pass
+                                  the Test Console Key
+                                type: string
+                              sendTokenToUpstream:
+                                type: boolean
+                            type: object
+                        type: object
+                      disabled:
+                        description: Disabled is to disable all authentications
+                        nullable: true
+                        type: boolean
+                      serviceRef:
+                        description: ServiceRef service using for Authentication
+                        properties:
+                          group:
+                            type: string
+                          kind:
+                            type: string
+                          name:
+                            type: string
+                          port:
+                            format: int32
+                            type: integer
+                        type: object
+                    type: object
+                  mutualSSL:
                     type: string
-                  type: array
-                message:
-                  description: Message represents a user friendly message that explains
-                    the current state of the Authentication.
-                  minLength: 4
+                  type:
+                    type: string
+                type: object
+              override:
+                description: AuthSpec specification of the authentication service
+                properties:
+                  ext:
+                    description: ExtAuthService external authentication related information
+                    properties:
+                      authTypes:
+                        description: APIAuth Authentication scheme type and details
+                        properties:
+                          apiKey:
+                            items:
+                              description: APIKeyAuth APIKey Authentication scheme
+                                details
+                              properties:
+                                in:
+                                  description: In is to specify how the APIKey is
+                                    passed to the request
+                                  enum:
+                                  - Header
+                                  - Query
+                                  minLength: 1
+                                  type: string
+                                name:
+                                  description: Name is the name of the header or query
+                                    parameter to be used
+                                  minLength: 1
+                                  type: string
+                                sendTokenToUpstream:
+                                  type: boolean
+                              type: object
+                            type: array
+                          jwt:
+                            description: JWTAuth JWT Authentication scheme details
+                            properties:
+                              header:
+                                default: authorization
+                                description: Header is the header name used to pass
+                                  the JWT token
+                                type: string
+                              sendTokenToUpstream:
+                                type: boolean
+                            type: object
+                          testConsoleKey:
+                            description: TestConsoleKeyAuth Test Console Key Authentication
+                              scheme details
+                            properties:
+                              header:
+                                default: internal-key
+                                description: Header is the header name used to pass
+                                  the Test Console Key
+                                type: string
+                              sendTokenToUpstream:
+                                type: boolean
+                            type: object
+                        type: object
+                      disabled:
+                        description: Disabled is to disable all authentications
+                        nullable: true
+                        type: boolean
+                      serviceRef:
+                        description: ServiceRef service using for Authentication
+                        properties:
+                          group:
+                            type: string
+                          kind:
+                            type: string
+                          name:
+                            type: string
+                          port:
+                            format: int32
+                            type: integer
+                        type: object
+                    type: object
+                  mutualSSL:
+                    type: string
+                  type:
+                    type: string
+                type: object
+              targetRef:
+                description: PolicyTargetReference identifies an API object to apply
+                  policy to. This should be used as part of Policy resources that
+                  can target Gateway API resources. For more information on how this
+                  policy attachment model works, and a sample Policy resource, refer
+                  to the policy attachment documentation for Gateway API.
+                properties:
+                  group:
+                    description: Group is the group of the target resource.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the target resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  namespace:
+                    description: Namespace is the namespace of the referent. When
+                      unspecified, the local namespace is inferred. Even when policy
+                      targets a resource in a different namespace, it MUST only apply
+                      to traffic originating from the same namespace as the policy.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+            type: object
+          status:
+            description: AuthenticationStatus defines the observed state of Authentication
+            properties:
+              accepted:
+                description: Accepted represents whether the Authentication is accepted
+                  or not.
+                type: boolean
+              events:
+                description: Events contains a list of events related to the Authentication.
+                items:
                   type: string
-                status:
-                  description: Status denotes the state of the Authentication in its
-                    lifecycle. Possible values could be Accepted, Invalid, Deploy etc.
-                  minLength: 4
-                  type: string
-                transitionTime:
-                  description: TransitionTime represents the last known transition timestamp.
-                  format: date-time
-                  type: string
-              required:
-                - accepted
-                - status
-                - transitionTime
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                type: array
+              message:
+                description: Message represents a user friendly message that explains
+                  the current state of the Authentication.
+                minLength: 4
+                type: string
+              status:
+                description: Status denotes the state of the Authentication in its
+                  lifecycle. Possible values could be Accepted, Invalid, Deploy etc.
+                minLength: 4
+                type: string
+              transitionTime:
+                description: TransitionTime represents the last known transition timestamp.
+                format: date-time
+                type: string
+            required:
+            - accepted
+            - status
+            - transitionTime
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/helm-charts/templates/data-plane/config-deployer/configurator-api-no-authentication-policy.yaml
+++ b/helm-charts/templates/data-plane/config-deployer/configurator-api-no-authentication-policy.yaml
@@ -24,6 +24,8 @@ metadata:
 spec:
   override:
     ext:
+      authTypes:
+        mutualSSL: optional
       disabled: true
     type: "ext"
   targetRef:

--- a/helm-charts/templates/data-plane/gateway-components/adapter/webhook/adapter-mutating-webhook-config.yaml
+++ b/helm-charts/templates/data-plane/gateway-components/adapter/webhook/adapter-mutating-webhook-config.yaml
@@ -64,6 +64,26 @@ webhooks:
         - apipolicies
   sideEffects: None
 - admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: {{ template "apk-helm.resource.prefix" . }}-adapter-service
+      namespace: {{ .Release.Namespace }}
+      path: /mutate-dp-wso2-com-v1alpha1-authentication
+  failurePolicy: Fail
+  name: mauthentication.kb.io
+  rules:
+  - apiGroups:
+    - dp.wso2.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - authentications
+  sideEffects: None
+- admissionReviewVersions:
     - v1
   clientConfig:
     service:

--- a/helm-charts/templates/data-plane/gateway-components/adapter/webhook/adapter-validation-webhook-config.yaml
+++ b/helm-charts/templates/data-plane/gateway-components/adapter/webhook/adapter-validation-webhook-config.yaml
@@ -83,6 +83,26 @@ webhooks:
       resources:
         - apipolicies
   sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: {{ template "apk-helm.resource.prefix" . }}-adapter-service
+      namespace: {{ .Release.Namespace }}
+      path: /validate-dp-wso2-com-v1alpha1-authentication
+  failurePolicy: Fail
+  name: vauthentication.kb.io
+  rules:
+  - apiGroups:
+    - dp.wso2.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - authentications
+  sideEffects: None
 {{ if .Values.wso2.apk.dp.ratelimiter.enabled }}
 - admissionReviewVersions:
     - v1

--- a/helm-charts/templates/idp/authenticationEndpoint-domain-api--authentication.yaml
+++ b/helm-charts/templates/idp/authenticationEndpoint-domain-api--authentication.yaml
@@ -25,6 +25,8 @@ metadata:
 spec:
   override:
     ext:
+      authTypes: 
+        mutualSSL: optional
       disabled: true
     type: "ext"
   targetRef:

--- a/helm-charts/templates/idp/commonoauth-domain-api-no-authentication.yaml
+++ b/helm-charts/templates/idp/commonoauth-domain-api-no-authentication.yaml
@@ -25,6 +25,8 @@ metadata:
 spec:
   override:
     ext:
+      authTypes:
+        mutualSSL: optional
       disabled: true
     type: "ext"
   targetRef:

--- a/helm-charts/templates/idp/dcr-domain-api-no-authentication.yaml
+++ b/helm-charts/templates/idp/dcr-domain-api-no-authentication.yaml
@@ -25,6 +25,8 @@ metadata:
 spec:
   override:
     ext:
+      authTypes:
+        mutualSSL: optional
       disabled: true
     type: "ext"
   targetRef:

--- a/helm-charts/templates/idp/oauth-domain-api-no-authentication.yaml
+++ b/helm-charts/templates/idp/oauth-domain-api-no-authentication.yaml
@@ -25,6 +25,8 @@ metadata:
 spec:
   override:
     ext:
+      authTypes:
+        mutualSSL: optional
       disabled: true
     type: "ext"
   targetRef:

--- a/test/integration/integration/tests/resources/tests/disable-api-level-security.yaml
+++ b/test/integration/integration/tests/resources/tests/disable-api-level-security.yaml
@@ -78,7 +78,8 @@ spec:
   default:
     type: ext
     ext:
-      mutualSSL: optional
+      authTypes:
+        mutualSSL: optional
       disabled: false
       serviceRef: 
         group: wso2/v1alpha2

--- a/test/integration/integration/tests/resources/tests/disable-api-level-security.yaml
+++ b/test/integration/integration/tests/resources/tests/disable-api-level-security.yaml
@@ -76,9 +76,9 @@ spec:
     ext:
       disabled: true            
   default:
-    mutualSSL: optional
     type: ext
     ext:
+      mutualSSL: optional
       disabled: false
       serviceRef: 
         group: wso2/v1alpha2

--- a/test/integration/integration/tests/resources/tests/disable-api-level-security.yaml
+++ b/test/integration/integration/tests/resources/tests/disable-api-level-security.yaml
@@ -76,8 +76,10 @@ spec:
     ext:
       disabled: true            
   default:
+    mutualSSL: optional
     type: ext
     ext:
+      disabled: false
       serviceRef: 
         group: wso2/v1alpha2
         kind: Backend

--- a/test/integration/integration/tests/resources/tests/disable-resource-level-security.yaml
+++ b/test/integration/integration/tests/resources/tests/disable-resource-level-security.yaml
@@ -84,7 +84,8 @@ spec:
   default:
     type: ext
     ext:
-      mutualSSL: optional
+      authTypes:
+        mutualSSL: optional
       serviceRef: 
         group: wso2/v1alpha2
         kind: Backend

--- a/test/integration/integration/tests/resources/tests/disable-resource-level-security.yaml
+++ b/test/integration/integration/tests/resources/tests/disable-resource-level-security.yaml
@@ -82,9 +82,9 @@ spec:
     ext:
       disabled: true            
   default:
-    mutualSSL: optional
     type: ext
     ext:
+      mutualSSL: optional
       serviceRef: 
         group: wso2/v1alpha2
         kind: Backend

--- a/test/integration/integration/tests/resources/tests/disable-resource-level-security.yaml
+++ b/test/integration/integration/tests/resources/tests/disable-resource-level-security.yaml
@@ -82,6 +82,7 @@ spec:
     ext:
       disabled: true            
   default:
+    mutualSSL: optional
     type: ext
     ext:
       serviceRef: 

--- a/test/integration/integration/tests/resources/tests/prod-and-sand-apis.yaml
+++ b/test/integration/integration/tests/resources/tests/prod-and-sand-apis.yaml
@@ -97,7 +97,8 @@ spec:
   default:
     type: ext
     ext:
-      mutualSSL: optional
+      authTypes:
+        mutualSSL: optional
       serviceRef: 
         group: wso2/v1alpha2
         kind: Backend

--- a/test/integration/integration/tests/resources/tests/prod-and-sand-apis.yaml
+++ b/test/integration/integration/tests/resources/tests/prod-and-sand-apis.yaml
@@ -98,6 +98,7 @@ spec:
     mutualSSL: optional
     type: ext
     ext:
+      mutualSSL: optional
       serviceRef: 
         group: wso2/v1alpha2
         kind: Backend

--- a/test/integration/integration/tests/resources/tests/prod-and-sand-apis.yaml
+++ b/test/integration/integration/tests/resources/tests/prod-and-sand-apis.yaml
@@ -95,7 +95,6 @@ spec:
     ext:
       disabled: true            
   default:
-    mutualSSL: optional
     type: ext
     ext:
       mutualSSL: optional

--- a/test/integration/integration/tests/resources/tests/prod-and-sand-apis.yaml
+++ b/test/integration/integration/tests/resources/tests/prod-and-sand-apis.yaml
@@ -95,6 +95,7 @@ spec:
     ext:
       disabled: true            
   default:
+    mutualSSL: optional
     type: ext
     ext:
       serviceRef: 


### PR DESCRIPTION
## Purpose
$subject

### CR structure
```
apiVersion: dp.wso2.com/v1alpha1
kind: Authentication
metadata:
  name: sand-http-bin-authentication
spec:
  override:
    type: ext
    ext:
      mutualSSL: mandatory
      disabled: false
      serviceRef:
        group: wso2/v1alpha2
        kind: Backend
        name: ext_authz-server
        port: 1234
      authTypes:
        apiKey:
          - in: Header
            name: x-api-key
  default:
    mutualSSL: mandatory
    type: ext
    ext:
      serviceRef: 
        group: wso2/v1alpha2
        kind: Backend
        name: ext_authz-server
        port: 1234
      authTypes:
        apiKey:
          - in: Header
            name: x-api-key
  targetRef:
    kind: API
    name: http-bin-api1 #provide API ref name
    group: ""
```