### PR TITLE
Add Backend retries/timeouts support in config deployer API Level

### DIFF
--- a/api-schema.json
+++ b/api-schema.json
@@ -291,7 +291,50 @@
     },
     "Resiliency": {
       "type": "object",
+      "description": "Endpoint resiliency related configurations of the API\n",
       "properties": {
+        "timeout": {
+          "$ref": "#/components/schemas/Timeout"
+        },
+        "retryPolicy": {
+          "$ref": "#/components/schemas/RetryPolicy"
+        }
+      }
+    },
+    "Timeout": {
+      "type": "object",
+      "properties": {
+        "maxRouteTimeoutSeconds": {
+          "type": "integer",
+          "example": 60
+        },
+        "routeIdleTimeoutSeconds": {
+          "type": "integer",
+          "example": 400
+        },
+        "routeTimeoutSeconds": {
+          "type": "integer",
+          "example": 40
+        }
+      }
+    },
+    "RetryPolicy": {
+      "type": "object",
+      "properties": {
+        "count": {
+          "type": "integer",
+          "example": 3
+        },
+        "baseIntervalInMillis": {
+          "type": "integer",
+          "example": 1000
+        },
+        "statusCodes": {
+          "type": "array",
+          "items": {
+            "type": "integer"
+          }
+        }
       }
     },
     "Authentication": {

--- a/runtime/config-deployer-service/ballerina/APIClient.bal
+++ b/runtime/config-deployer-service/ballerina/APIClient.bal
@@ -1017,16 +1017,8 @@ public class APIClient {
         }
         Resiliency? resiliency = endpointConfig.resiliency;
         if resiliency is Resiliency {
-            backendService.spec.retry = {
-                count: resiliency.retryPolicy?count;
-                baseIntervalInMillis: resiliency.retryPolicy?baseIntervalInMillis;
-                statusCodes: resiliency.retryPolicy?statusCodes;
-            };
-            backendService.spec.timeout = {
-                maxRouteTimeoutSeconds: resiliency.timeout?maxRouteTimeoutSeconds;
-                routeIdleTimeoutSeconds: resiliency.timeout?routeIdleTimeoutSeconds;
-                routeTimeoutSeconds: resiliency.timeout?routeTimeoutSeconds;
-            };
+            backendService.spec.timeout = resiliency.timeout;
+            backendService.spec.retryConfig = resiliency.retryPolicy;
         }
         return backendService;
     }

--- a/runtime/config-deployer-service/ballerina/APIClient.bal
+++ b/runtime/config-deployer-service/ballerina/APIClient.bal
@@ -1015,6 +1015,19 @@ public class APIClient {
                 }
             };
         }
+        Resiliency? resiliency = endpointConfig.resiliency;
+        if resiliency is Resiliency {
+            backendService.spec.retry = {
+                count: resiliency.retryPolicy?count;
+                baseIntervalInMillis: resiliency.retryPolicy?baseIntervalInMillis;
+                statusCodes: resiliency.retryPolicy?statusCodes;
+            };
+            backendService.spec.timeout = {
+                maxRouteTimeoutSeconds: resiliency.timeout?maxRouteTimeoutSeconds;
+                routeIdleTimeoutSeconds: resiliency.timeout?routeIdleTimeoutSeconds;
+                routeTimeoutSeconds: resiliency.timeout?routeTimeoutSeconds;
+            };
+        }
         return backendService;
     }
 

--- a/runtime/config-deployer-service/ballerina/APIClient.bal
+++ b/runtime/config-deployer-service/ballerina/APIClient.bal
@@ -1018,7 +1018,7 @@ public class APIClient {
         Resiliency? resiliency = endpointConfig.resiliency;
         if resiliency is Resiliency {
             backendService.spec.timeout = resiliency.timeout;
-            backendService.spec.retryConfig = resiliency.retryPolicy;
+            backendService.spec.'retry = resiliency.retryPolicy;
         }
         return backendService;
     }

--- a/runtime/config-deployer-service/ballerina/modules/model/Backend.bal
+++ b/runtime/config-deployer-service/ballerina/modules/model/Backend.bal
@@ -28,6 +28,8 @@ public type BackendSpec record {|
     string protocol;
     TLSConfig tls?;
     SecurityConfig security?;
+    Timeout timeout?;
+    RetryConfig retryConfig?;
 |};
 
 public type BackendService record {
@@ -54,6 +56,18 @@ public type SecretRefConfig record {
 public type RefConfig record {
     string key;
     string name;
+};
+
+public type Timeout record {
+    int maxRouteTimeoutSeconds?;
+    int routeIdleTimeoutSeconds?;
+    int routeTimeoutSeconds?;
+};
+
+public type RetryConfig record {
+    int count?;
+    int baseIntervalInMillis?;
+    int[] statusCodes?;
 };
 
 public type TLSConfig record {

--- a/runtime/config-deployer-service/ballerina/modules/model/Backend.bal
+++ b/runtime/config-deployer-service/ballerina/modules/model/Backend.bal
@@ -29,7 +29,7 @@ public type BackendSpec record {|
     TLSConfig tls?;
     SecurityConfig security?;
     Timeout timeout?;
-    RetryConfig retryConfig?;
+    Retry 'retry?;
 |};
 
 public type BackendService record {
@@ -64,7 +64,7 @@ public type Timeout record {
     int routeTimeoutSeconds?;
 };
 
-public type RetryConfig record {
+public type Retry record {
     int count?;
     int baseIntervalInMillis?;
     int[] statusCodes?;

--- a/runtime/config-deployer-service/ballerina/resources/apk-conf-schema.yaml
+++ b/runtime/config-deployer-service/ballerina/resources/apk-conf-schema.yaml
@@ -228,7 +228,31 @@ components:
           type: string
     Resiliency:
       type: object
-      properties: {}
+      properties:
+        timeout:
+          $ref: "#/components/schemas/Timeout"
+        retryPolicy:
+          $ref: "#/components/schemas/RetryPolicy"
+    Timeout:
+      type: object
+      properties:
+        maxRouteTimeoutSeconds:
+          type: integer
+        routeIdleTimeoutSeconds:
+          type: integer
+        routeTimeoutSeconds:
+          type: integer
+    RetryPolicy:
+      type: object
+      properties:
+        count:
+          type: integer
+        baseIntervalInMillis:
+          type: integer
+        statusCodes:
+          type: array
+          items:
+            type: integer
     APKOperations:
       title: Operation
       type: object

--- a/runtime/config-deployer-service/ballerina/tests/resources/apk-schema.json
+++ b/runtime/config-deployer-service/ballerina/tests/resources/apk-schema.json
@@ -312,7 +312,50 @@
     },
     "Resiliency": {
       "type": "object",
+      "description": "Endpoint resiliency related configurations of the API\n",
       "properties": {
+        "timeout": {
+          "$ref": "#/schemas/Timeout"
+        },
+        "retryPolicy": {
+          "$ref": "#/schemas/RetryPolicy"
+        }
+      }
+    },
+    "Timeout": {
+      "type": "object",
+      "properties": {
+        "maxRouteTimeoutSeconds": {
+          "type": "integer",
+          "example": 60
+        },
+        "routeIdleTimeoutSeconds": {
+          "type": "integer",
+          "example": 400
+        },
+        "routeTimeoutSeconds": {
+          "type": "integer",
+          "example": 40
+        }
+      }
+    },
+    "RetryPolicy": {
+      "type": "object",
+      "properties": {
+        "count": {
+          "type": "integer",
+          "example": 3
+        },
+        "baseIntervalInMillis": {
+          "type": "integer",
+          "example": 1000
+        },
+        "statusCodes": {
+          "type": "array",
+          "items": {
+            "type": "integer"
+          }
+        }
       }
     },
     "APKOperations": {

--- a/runtime/config-deployer-service/ballerina/tests/resources/backend-retry.apk-conf
+++ b/runtime/config-deployer-service/ballerina/tests/resources/backend-retry.apk-conf
@@ -1,0 +1,28 @@
+---
+organization: "wso2"
+name: "test-cors"
+context: "/test_cors"
+version: "2.0.0"
+type: "REST"
+endpointConfigurations:
+    production:
+        endpoint: "https://httpbin.org"
+        resiliency:
+          timeout:
+            maxRouteTimeoutSeconds: 60
+            routeIdleTimeoutSeconds: 400
+            routeTimeoutSeconds: 40
+          retryPolicy:
+            count: 3
+            baseIntervalInMillis: 1000
+            statusCodes:
+              - 504
+operations:
+    - target: "/anything"
+      verb: "GET"
+      authTypeEnabled: true
+      scopes: []
+vhosts:
+  production: ["gw.am.wso2.com"]
+  sandbox: []
+

--- a/runtime/config-deployer-service/ballerina/tests/resources/backend-retry.yaml
+++ b/runtime/config-deployer-service/ballerina/tests/resources/backend-retry.yaml
@@ -1,0 +1,27 @@
+openapi: 3.0.1
+info:
+  title: test-backend-retry-timeout
+  description: 'A simple HTTP Request & Response Service.<br/> <br/> <b>Run locally:
+    </b> <code>$ docker run -p 80:80 kennethreitz/httpbin</code>'
+  contact:
+    url: https://kennethreitz.org
+    email: me@kennethreitz.org
+  version: 2.0.0
+servers:
+- url: https://httpbin.org
+tags:
+- name: HTTP Methods
+  description: Testing different HTTP verbs
+- name: Auth
+  description: Auth methods
+paths:
+  /anything:
+    get:
+      tags:
+      - Anything
+      summary: Returns anything passed in request data.
+      responses:
+        200:
+          description: Anything passed in request
+          content: {}
+components: {}

--- a/runtime/config-deployer-service/ballerina/types.bal
+++ b/runtime/config-deployer-service/ballerina/types.bal
@@ -220,6 +220,20 @@ public type EndpointConfiguration record {
 };
 
 public type Resiliency record {
+    Timeout timeout?;
+    RetryPolicy retryPolicy?;
+};
+
+public type Timeout record {
+    int maxRouteTimeoutSeconds?;
+    int routeIdleTimeoutSeconds?;
+    int routeTimeoutSeconds?;
+};
+
+public type RetryPolicy record {
+    int count?;
+    int baseIntervalInMillis?;
+    int[] statusCodes?;
 };
 
 public type EndpointConfigurations record {

--- a/runtime/config-deployer-service/docker/config-deployer/conf/apk-schema.json
+++ b/runtime/config-deployer-service/docker/config-deployer/conf/apk-schema.json
@@ -312,7 +312,50 @@
     },
     "Resiliency": {
       "type": "object",
+      "description": "Endpoint resiliency related configurations of the API\n",
       "properties": {
+        "timeout": {
+          "$ref": "#/schemas/Timeout"
+        },
+        "retryPolicy": {
+          "$ref": "#/schemas/RetryPolicy"
+        }
+      }
+    },
+    "Timeout": {
+      "type": "object",
+      "properties": {
+        "maxRouteTimeoutSeconds": {
+          "type": "integer",
+          "example": 60
+        },
+        "routeIdleTimeoutSeconds": {
+          "type": "integer",
+          "example": 400
+        },
+        "routeTimeoutSeconds": {
+          "type": "integer",
+          "example": 40
+        }
+      }
+    },
+    "RetryPolicy": {
+      "type": "object",
+      "properties": {
+        "count": {
+          "type": "integer",
+          "example": 3
+        },
+        "baseIntervalInMillis": {
+          "type": "integer",
+          "example": 1000
+        },
+        "statusCodes": {
+          "type": "array",
+          "items": {
+            "type": "integer"
+          }
+        }
       }
     },
     "APKOperations": {

--- a/runtime/runtime-ui/schema/apk-conf.yaml
+++ b/runtime/runtime-ui/schema/apk-conf.yaml
@@ -215,8 +215,32 @@ schemas:
       passwordKey:
         type: string
   Resiliency:
+      type: object
+      properties:
+        timeout:
+          $ref: "#/schemas/Timeout"
+        retryPolicy:
+          $ref: "#/schemas/RetryPolicy"
+  Timeout:
     type: object
-    properties: {}
+    properties:
+      maxRouteTimeoutSeconds:
+        type: integer
+      routeIdleTimeoutSeconds:
+        type: integer
+      routeTimeoutSeconds:
+        type: integer
+  RetryPolicy:
+    type: object
+    properties:
+      count:
+        type: integer
+      baseIntervalInMillis:
+        type: integer
+      statusCodes:
+        type: array
+        items:
+          type: integer
   APKOperations:
     title: Operation
     type: object

--- a/runtime/runtime-ui/schema/apk-schema.json
+++ b/runtime/runtime-ui/schema/apk-schema.json
@@ -317,7 +317,50 @@
     },
     "Resiliency": {
       "type": "object",
+      "description": "Endpoint resiliency related configurations of the API\n",
       "properties": {
+        "timeout": {
+          "$ref": "#/schemas/Timeout"
+        },
+        "retryPolicy": {
+          "$ref": "#/schemas/RetryPolicy"
+        }
+      }
+    },
+    "Timeout": {
+      "type": "object",
+      "properties": {
+        "maxRouteTimeoutSeconds": {
+          "type": "integer",
+          "example": 60
+        },
+        "routeIdleTimeoutSeconds": {
+          "type": "integer",
+          "example": 400
+        },
+        "routeTimeoutSeconds": {
+          "type": "integer",
+          "example": 40
+        }
+      }
+    },
+    "RetryPolicy": {
+      "type": "object",
+      "properties": {
+        "count": {
+          "type": "integer",
+          "example": 3
+        },
+        "baseIntervalInMillis": {
+          "type": "integer",
+          "example": 1000
+        },
+        "statusCodes": {
+          "type": "array",
+          "items": {
+            "type": "integer"
+          }
+        }
       }
     },
     "APKOperations": {


### PR DESCRIPTION
## Purpose
Fixes https://github.com/wso2/apk/issues/1339

The configuration in apk-conf file would be as follows.

```
endpointConfigurations:
  production:
    endpoint: "https://run.mocky.io/v3/85516819-1edd-412b-a32b-a9284705a0b4"
    resiliency:
      retryPolicy:
        count: 3
        baseIntervalInMillis: 1000
        statusCodes:
        - 504
      timeout:
        maxRouteTimeoutSeconds: 60
        routeIdleTimeoutSeconds: 400
        routeTimeoutSeconds: 40
```

A generated Backend CR from the above config looks as follows.

```
- apiVersion: dp.wso2.com/v1alpha1
  kind: Backend
  metadata:
    creationTimestamp: "2023-07-10T05:16:48Z"
    generation: 1
    labels:
      api-name: 18f1b798551599f4986e137c3b58c5cc524b579c
      api-version: 782650dad14a47661ff5170fb27c2a5610214cf9
      managed-by: apk
      organization: ca660bf19297d26c4d75e181527267301974a2cc
    name: backend-7c8433535e70130d9e740bde9173322796e0d627-api
    namespace: apk
    resourceVersion: "11225"
    uid: 50a3f490-0098-4def-91a0-73d960b9e28b
  spec:
    basePath: /v3/85516819-1edd-412b-a32b-a9284705a0b4
    protocol: https
    retry:
      baseIntervalMillis: 2000
      count: 3
      statusCodes:
      - 504
    services:
    - host: run.mocky.io
      port: 443
    timeout:
      maxRouteTimeoutSeconds: 60
      routeIdleTimeoutSeconds: 400
      routeTimeoutSeconds: 40
kind: List
metadata:
  resourceVersion: ""
```