### PR TITLE
Revert "Test ratelimit functionality with default version"

### DIFF
--- a/test/integration/integration/tests/default-api-version.go
+++ b/test/integration/integration/tests/default-api-version.go
@@ -52,7 +52,7 @@ var DefaultAPIVersion = suite.IntegrationTest{
 				},
 				Backend:   "infra-backend-v1",
 				Namespace: ns,
-				Response:  http.Response{StatusCode: 200},
+				Response: http.Response{StatusCode: 200},
 			},
 			{
 				Request: http.Request{
@@ -67,24 +67,7 @@ var DefaultAPIVersion = suite.IntegrationTest{
 				},
 				Backend:   "infra-backend-v1",
 				Namespace: ns,
-				Response:  http.Response{StatusCode: 200},
-			},
-
-			// Test ratelimit for default version api
-			{
-				Request: http.Request{
-					Host:   "default-api-version.test.gw.wso2.com",
-					Path:   "/default-api-version/v2/echo-full",
-					Method: "GET",
-				},
-				ExpectedRequest: &http.ExpectedRequest{
-					Request: http.Request{
-						Path: "/v2/echo-full",
-					},
-				},
-				Backend:   "infra-backend-v1",
-				Namespace: ns,
-				Response:  http.Response{StatusCode: 429},
+				Response: http.Response{StatusCode: 200},
 			},
 		}
 		for i := range testCases {

--- a/test/integration/integration/tests/resources/tests/default-api-version.yaml
+++ b/test/integration/integration/tests/resources/tests/default-api-version.yaml
@@ -54,20 +54,3 @@ spec:
     - group: dp.wso2.com
       kind: Backend
       name: infra-backend-v1
----
-apiVersion: dp.wso2.com/v1alpha1
-kind: RateLimitPolicy
-metadata:
-  name: ratelimitter
-  namespace: gateway-integration-test-infra
-spec:
-  default:
-    type: Api
-    api:
-      rateLimit:
-        requestsPerUnit: 2
-        unit: Minute
-  targetRef:
-    kind: API
-    name: default-api-version
-    group: gateway.networking.k8s.io


### PR DESCRIPTION
Reverts wso2/apk#1367

Execution order is not guaranteed so need to find a better way to test rate-limit behavior