### PR TITLE
Use Read-Only filesystem for containers excluding /temp directory

### DIFF
--- a/helm-charts/templates/data-plane/config-deployer/config-ds-deployment.yaml
+++ b/helm-charts/templates/data-plane/config-deployer/config-ds-deployment.yaml
@@ -80,10 +80,13 @@ spec:
               mountPath: /home/wso2apk/config-deployer/security/partition-server.pem
               subPath: {{.Values.wso2.apk.dp.partitionServer.tls.fileName | default "tls.crt"}}
             {{- end }}
+            - name: tmp
+              mountPath: /tmp
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
               drop: ["ALL"]
+            readOnlyRootFilesystem: true
       {{- if and .Values.wso2.subscription .Values.wso2.subscription.imagePullSecrets}}
       imagePullSecrets:
         - name: {{ .Values.wso2.subscription.imagePullSecrets }}
@@ -109,4 +112,6 @@ spec:
           secret:
             secretName: {{.Values.wso2.apk.dp.partitionServer.tls.secretName}}
         {{ end }}
+        - name: tmp
+          emptyDir: {}
 {{- end -}}

--- a/helm-charts/templates/idp/idp-ds/idp-ds-deployment.yaml
+++ b/helm-charts/templates/idp/idp-ds/idp-ds-deployment.yaml
@@ -91,6 +91,8 @@ spec:
             {{- end }}
             - name: db-secret-volume
               mountPath: /home/wso2apk/idp/security/database/
+            - name: tmp
+              mountPath: /tmp
           env:
             - name: DB_PASSWORD
               valueFrom:
@@ -107,6 +109,7 @@ spec:
             capabilities:
               drop: ["ALL"]
             runAsNonRoot: true
+            readOnlyRootFilesystem: true
       {{- if and .Values.wso2.subscription .Values.wso2.subscription.imagePullSecrets}}
       imagePullSecrets:
         - name: {{ .Values.wso2.subscription.imagePullSecrets }}
@@ -141,5 +144,6 @@ spec:
               - key: DB_PASSWORD
                 path: db-password
        {{ end }}
-
+        - name: tmp
+          emptyDir: {}
 {{- end -}}


### PR DESCRIPTION
## Purpose
> $subject
> Ballerina gRPC relies on the Netty library, which in turn necessitates write permissions to the container's /temp directory. Hence we cannot avoid excluding /tmp directory from this constraint.