### PR TITLE
Exclude config-deployer/tmp from read only file system

### DIFF
--- a/helm-charts/templates/data-plane/config-deployer/config-ds-deployment.yaml
+++ b/helm-charts/templates/data-plane/config-deployer/config-ds-deployment.yaml
@@ -82,6 +82,8 @@ spec:
             {{- end }}
             - name: tmp
               mountPath: /tmp
+            - name: config-deployer-temp
+              mountPath: /home/wso2apk/config-deployer/tmp
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -113,5 +115,7 @@ spec:
             secretName: {{.Values.wso2.apk.dp.partitionServer.tls.secretName}}
         {{ end }}
         - name: tmp
+          emptyDir: {}
+        - name: config-deployer-temp
           emptyDir: {}
 {{- end -}}


### PR DESCRIPTION
## Purpose
> $subject
> **GET apis/generate-k8s-resources** requires write permissions to the **/home/wso2apk/config-deployer/tmp** directory