### PR TITLE
Exclude log paths from read only file system

### DIFF
--- a/helm-charts/templates/data-plane/gateway-components/adapter/adapter-deployment.yaml
+++ b/helm-charts/templates/data-plane/gateway-components/adapter/adapter-deployment.yaml
@@ -122,6 +122,10 @@ spec:
               mountPath: /home/wso2/security/truststore/partition-server.crt
               subPath: {{.Values.wso2.apk.dp.partitionServer.tls.fileName | default "tls.crt"}}
             {{- end }}
+            - name: adapter-logs-volume
+              mountPath: /home/wso2/logs
+            - name: adapter-temp-volume
+              mountPath: /tmp
           readinessProbe:
             exec:
               command: [ "sh", "check_health.sh" ]
@@ -194,4 +198,8 @@ spec:
           secret:
             secretName: {{.Values.wso2.apk.dp.partitionServer.tls.secretName}}
         {{- end }}
+        - name: adapter-logs-volume
+          emptyDir: {}
+        - name: adapter-temp-volume
+          emptyDir: {}
 {{- end -}}

--- a/helm-charts/templates/data-plane/gateway-components/gateway-runtime/gateway-runtime-deployment.yaml
+++ b/helm-charts/templates/data-plane/gateway-components/gateway-runtime/gateway-runtime-deployment.yaml
@@ -161,6 +161,8 @@ spec:
               mountPath: /home/wso2/security/truststore/idp-tls.pem
               subPath: {{ .Values.wso2.apk.idp.tls.fileName }}
             {{ end }}
+            - name: enforcer-logs-volume
+              mountPath: /home/wso2/logs
           readinessProbe:
             exec:
               command: [ "sh", "check_health.sh" ]
@@ -276,6 +278,8 @@ spec:
               subPath: ca.crt
             {{- end }}
             {{ end }}
+            - name: router-temp-volume
+              mountPath: /tmp
           livenessProbe:
             exec:
               command: [ "sh", "router_check_health.sh", "health" ]
@@ -359,4 +363,8 @@ spec:
           secret:
             secretName: {{ .Values.wso2.apk.idp.tls.secretName }}
           {{ end }}
+        - name: router-temp-volume
+          emptyDir: {}
+        - name: enforcer-logs-volume
+          emptyDir: {}
           {{end}}


### PR DESCRIPTION
## Purpose
Containers require write permission to the following paths to print logs
- Adapter: /home/wso2/logs, /temp
- Enforcer: /home/wso2/logs
- Router: /tmp