### PR TITLE
Add by default API Type when generating apk-conf

### DIFF
--- a/runtime/config-deployer-service/ballerina/tests/ConfigGeneratorClientTest.bal
+++ b/runtime/config-deployer-service/ballerina/tests/ConfigGeneratorClientTest.bal
@@ -111,7 +111,7 @@ public function testGetGeneratedAPKConfFromUrlAndDefinitionNoType() returns erro
 }
 
 @test:Config {}
-public function testGetGeneratedAPKConfFromUrlAndDefinitionInvalidType() returns error? {
+public function testGetGeneratedAPKConfFromUrlAndDefinitionNotDefinedType() returns error? {
     ConfigGeneratorClient configGeneratorClient = new ();
     http:Request request = new;
     mime:Entity[] bodyParts = [];
@@ -122,10 +122,8 @@ public function testGetGeneratedAPKConfFromUrlAndDefinitionInvalidType() returns
     request.setBodyParts(bodyParts, contentType = mime:MULTIPART_FORM_DATA);
 
     OkAnydata|apk_common_lib:APKError|BadRequestError response = configGeneratorClient.getGeneratedAPKConf(request);
-    if response is BadRequestError {
-        BadRequestError badRequest = {body: {code: 90091, message: "API Type need to specified"}};
-        test:assertEquals(response.status.code, http:STATUS_BAD_REQUEST, "Status code mismatched");
-        test:assertEquals(response.body, badRequest.body);
+    if response is OkAnydata {
+        test:assertEquals(response.status.code, http:STATUS_OK, "Status code mismatched");
     } else {
         test:assertFail("Error occurred while generating APK conf");
     }


### PR DESCRIPTION
## Purpose
This will set the default API type as REST if user not defined it when generating the apk-conf file

## Fixes
- https://github.com/wso2/apk/issues/1709