### PR TITLE
Update docker image to fix stop cache key increment when keys are overlimited issue

### DIFF
--- a/ratelimiter/Dockerfile
+++ b/ratelimiter/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 # -----------------------------------------------------------------------
 
-FROM envoyproxy/ratelimit:965f0bc8
+FROM envoyproxy/ratelimit:624a5893
 LABEL maintainer="WSO2 Docker Maintainers <wso2.com>"
 
 RUN apk update && apk upgrade --no-cache
@@ -34,6 +34,7 @@ ENV GRPC_PORT=8091
 ENV USE_STATSD=false
 ENV LOG_LEVEL=INFO
 ENV LOCAL_CACHE_SIZE_IN_BYTES=1024000
+ENV STOP_CACHE_KEY_INCREMENT_WHEN_OVERLIMIT=true
 
 ENV GRPC_SERVER_USE_TLS=true
 ENV GRPC_SERVER_TLS_KEY=/home/wso2/security/keystore/ratelimiter.key

--- a/test/cucumber-tests/src/test/resources/tests/api/CustomRatelimit.feature
+++ b/test/cucumber-tests/src/test/resources/tests/api/CustomRatelimit.feature
@@ -61,9 +61,9 @@ Feature: Custom ratelimit
 # Request 9 - for org_id descriptor
     And I send "GET" request to "https://default.gw.wso2.com:9095/test-custom-ratelimit/employee" with body ""
     Then the response status code should be 200
-# Request 10 - for org_id descriptor TODO Once the ratelimitter bug is fixed this should return a 200
+# Request 10 - for org_id descriptor
     And I send "GET" request to "https://default.gw.wso2.com:9095/test-custom-ratelimit/employee" with body ""
-    Then the response status code should be 429
+    Then the response status code should be 200
 # Request 11 - for org_id descriptor
     And I send "GET" request to "https://default.gw.wso2.com:9095/test-custom-ratelimit/employee" with body ""
     Then the response status code should be 429


### PR DESCRIPTION
## Purpose
This is to fix cache key incorrect issue in envoy ratelimit when keys are over the limit.

### Fixes
- https://github.com/wso2/apk/issues/1795
- https://github.com/envoyproxy/ratelimit/issues/440

