### PR TITLE
Update Prometheus functionality in adapter and common controller

### DIFF
--- a/adapter/config/default_config.go
+++ b/adapter/config/default_config.go
@@ -32,7 +32,7 @@ var defaultConfig = &Config{
 			Namespaces: nil,
 		},
 		Environment: "Default",
-		Metrics: metrics{
+		Metrics: Metrics{
 			Enabled: false,
 			Type:    "prometheus",
 			Port:    18006,
@@ -192,7 +192,7 @@ var defaultConfig = &Config{
 			MaximumSize: 10000,
 			ExpiryTime:  15,
 		},
-		Metrics: metrics{
+		Metrics: Metrics{
 			Enabled: false,
 			Type:    "azure",
 		},

--- a/adapter/config/types.go
+++ b/adapter/config/types.go
@@ -302,10 +302,9 @@ type tracing struct {
 
 // Metrics defines the configuration for metrics collection.
 type Metrics struct {
-	Enabled            bool
-	Type               string
-	Port               int32
-	CollectionInterval int32
+	Enabled bool
+	Type    string
+	Port    int32
 }
 
 type analyticsAdapter struct {

--- a/adapter/config/types.go
+++ b/adapter/config/types.go
@@ -94,7 +94,7 @@ type adapter struct {
 	// Environment of the Adapter
 	Environment string
 	// Metric represents configurations to expose/export go metrics
-	Metrics metrics
+	Metrics Metrics
 }
 
 // Envoy Listener Component related configurations.
@@ -159,7 +159,7 @@ type enforcer struct {
 	Management                    management
 	RestServer                    restServer
 	Filters                       []filter
-	Metrics                       metrics
+	Metrics                       Metrics
 	MandateSubscriptionValidation bool
 	Client                        httpClient
 }
@@ -300,7 +300,8 @@ type tracing struct {
 	ConfigProperties map[string]string
 }
 
-type metrics struct {
+// Metrics defines the configuration for metrics collection.
+type Metrics struct {
 	Enabled            bool
 	Type               string
 	Port               int32

--- a/adapter/internal/adapter/adapter.go
+++ b/adapter/internal/adapter/adapter.go
@@ -20,14 +20,12 @@ package adapter
 
 import (
 	"crypto/tls"
-	"strings"
 	"time"
 
 	discoveryv3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	xdsv3 "github.com/envoyproxy/go-control-plane/pkg/server/v3"
 	enforcerCallbacks "github.com/wso2/apk/adapter/internal/discovery/xds/enforcercallbacks"
 	routercb "github.com/wso2/apk/adapter/internal/discovery/xds/routercallbacks"
-	"github.com/wso2/apk/adapter/internal/loggers"
 	"github.com/wso2/apk/adapter/internal/operator"
 	apiservice "github.com/wso2/apk/adapter/pkg/discovery/api/wso2/discovery/service/api"
 	configservice "github.com/wso2/apk/adapter/pkg/discovery/api/wso2/discovery/service/config"
@@ -35,7 +33,6 @@ import (
 	wso2_server "github.com/wso2/apk/adapter/pkg/discovery/protocol/server/v3"
 	"github.com/wso2/apk/adapter/pkg/health"
 	healthservice "github.com/wso2/apk/adapter/pkg/health/api/wso2/health/service"
-	"github.com/wso2/apk/adapter/pkg/metrics"
 	"github.com/wso2/apk/adapter/pkg/utils/tlsutils"
 
 	"context"
@@ -183,13 +180,7 @@ func Run(conf *config.Config) {
 	// Set enforcer startup configs
 	xds.UpdateEnforcerConfig(conf)
 
-	go operator.InitOperator(conf.Adapter.Metrics.Port)
-
-	// Start the metrics server
-	if conf.Adapter.Metrics.Enabled && strings.EqualFold(conf.Adapter.Metrics.Type, metrics.PrometheusMetricType) {
-		loggers.LoggerAPKOperator.Info("Starting Prometheus Metrics Server ....")
-		go metrics.StartPrometheusMetricsServer()
-	}
+	go operator.InitOperator(conf.Adapter.Metrics)
 
 OUTER:
 	for {

--- a/adapter/internal/operator/operator.go
+++ b/adapter/internal/operator/operator.go
@@ -107,6 +107,11 @@ func InitOperator(metricsConfig config.Metrics) {
 
 	if metricsConfig.Enabled {
 		options.Metrics.BindAddress = fmt.Sprintf(":%d", metricsConfig.Port)
+		// Register the metrics collector
+		if strings.EqualFold(metricsConfig.Type, metrics.PrometheusMetricType) {
+			loggers.LoggerAPKOperator.Info("Registering Prometheus metrics collector.")
+			metrics.RegisterPrometheusCollector()
+		}
 	} else {
 		options.Metrics.BindAddress = "0"
 	}
@@ -143,12 +148,6 @@ func InitOperator(metricsConfig config.Metrics) {
 	}
 	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
 		loggers.LoggerAPKOperator.ErrorC(logging.PrintError(logging.Error2603, logging.BLOCKER, "Unable to set up ready check: %v", err))
-	}
-
-	// Register the metrics collector
-	if metricsConfig.Enabled && strings.EqualFold(metricsConfig.Type, metrics.PrometheusMetricType) {
-		loggers.LoggerAPKOperator.Info("Registering Prometheus metrics collector.")
-		go metrics.RegisterPrometheusCollector()
 	}
 
 	go synchronizer.HandleAPILifeCycleEvents(&ch, &successChannel)

--- a/adapter/internal/operator/operator.go
+++ b/adapter/internal/operator/operator.go
@@ -19,6 +19,7 @@ package operator
 
 import (
 	"flag"
+	"strconv"
 
 	"github.com/wso2/apk/adapter/config"
 	"github.com/wso2/apk/adapter/internal/loggers"
@@ -67,11 +68,12 @@ func init() {
 }
 
 // InitOperator starts the Kubernetes gateway operator
-func InitOperator() {
+func InitOperator(prometheusPort int32) {
 	var metricsAddr string
 	var enableLeaderElection bool
 	var probeAddr string
-	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
+	port := strconv.FormatInt(int64(prometheusPort), 10)
+	flag.StringVar(&metricsAddr, "metrics-bind-address", ":"+port, "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
@@ -103,6 +105,7 @@ func InitOperator() {
 		// after the manager stops then its usage might be unsafe.
 		// LeaderElectionReleaseOnCancel: true,
 	})
+
 	if err != nil {
 		loggers.LoggerAPKOperator.ErrorC(logging.PrintError(logging.Error2600, logging.BLOCKER, "Unable to start manager: %v", err))
 	}

--- a/adapter/internal/operator/operator.go
+++ b/adapter/internal/operator/operator.go
@@ -145,7 +145,7 @@ func InitOperator(metricsConfig config.Metrics) {
 
 	// Register the metrics collector
 	if metricsConfig.Enabled && strings.EqualFold(metricsConfig.Type, metrics.PrometheusMetricType) {
-		loggers.LoggerAPKOperator.Info("Starting Prometheus Metrics Server ....")
+		loggers.LoggerAPKOperator.Info("Registering Prometheus metrics collector.")
 		go metrics.RegisterPrometheusCollector()
 	}
 

--- a/adapter/internal/operator/operator.go
+++ b/adapter/internal/operator/operator.go
@@ -106,7 +106,9 @@ func InitOperator(metricsConfig config.Metrics) {
 	}
 
 	if metricsConfig.Enabled {
-		options.MetricsBindAddress = fmt.Sprintf(":%d", metricsConfig.Port)
+		options.Metrics.BindAddress = fmt.Sprintf(":%d", metricsConfig.Port)
+	} else {
+		options.Metrics.BindAddress = "0"
 	}
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), options)

--- a/adapter/pkg/metrics/metrics.go
+++ b/adapter/pkg/metrics/metrics.go
@@ -20,16 +20,10 @@
 package metrics
 
 import (
-	"fmt"
-	"net/http"
-	"strconv"
-
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 	xds "github.com/wso2/apk/adapter/internal/discovery/xds"
-	logger "github.com/wso2/apk/adapter/internal/loggers"
-	"github.com/wso2/apk/adapter/pkg/logging"
 	commonmetrics "github.com/wso2/apk/common-go-libs/pkg/metrics"
+	k8smetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
 var (
@@ -94,17 +88,9 @@ func (collector *AdapterCollector) Collect(ch chan<- prometheus.Metric) {
 }
 
 // StartPrometheusMetricsServer initializes and starts the metrics server to expose metrics to prometheus.
-func StartPrometheusMetricsServer(port int32) {
+func StartPrometheusMetricsServer() {
 
 	collector := adapterMetricsCollector()
+	k8smetrics.Registry.MustRegister(collector)
 	prometheus.MustRegister(collector)
-	http.Handle("/metrics", promhttp.Handler())
-	err := http.ListenAndServe(":"+strconv.Itoa(int(port)), nil)
-	if err != nil {
-		logger.LoggerAPK.ErrorC(logging.ErrorDetails{
-			Message:   fmt.Sprintln("Prometheus metrics server error:", err),
-			Severity:  logging.MAJOR,
-			ErrorCode: 1110,
-		})
-	}
 }

--- a/adapter/pkg/metrics/metrics.go
+++ b/adapter/pkg/metrics/metrics.go
@@ -87,8 +87,8 @@ func (collector *AdapterCollector) Collect(ch chan<- prometheus.Metric) {
 	ch <- prometheus.MustNewConstMetric(collector.internalClusterCount, prometheus.GaugeValue, internalClusterCount)
 }
 
-// StartPrometheusMetricsServer initializes and starts the metrics server to expose metrics to prometheus.
-func StartPrometheusMetricsServer() {
+// RegisterPrometheusCollector registers the Prometheus collector for metrics.
+func RegisterPrometheusCollector() {
 
 	collector := adapterMetricsCollector()
 	k8smetrics.Registry.MustRegister(collector)

--- a/common-controller/commoncontroller/common_controller.go
+++ b/common-controller/commoncontroller/common_controller.go
@@ -206,12 +206,6 @@ func InitCommonControllerServer(conf *config.Config) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	// Start the metrics server
-	if conf.CommonController.Metrics.Enabled && strings.EqualFold(conf.CommonController.Metrics.Type, metrics.PrometheusMetricType) {
-		loggers.LoggerAPKOperator.Info("Starting Prometheus Metrics Server ....")
-		go metrics.StartPrometheusMetricsServer(conf.CommonController.Metrics.Port)
-	}
-
 	loggers.LoggerAPKOperator.Info("Starting common controller ....")
 
 	rateLimiterCache := xds.GetRateLimiterCache()
@@ -225,7 +219,13 @@ func InitCommonControllerServer(conf *config.Config) {
 	// Start Enforcer xDS gRPC server
 	runCommonEnforcerServer(port)
 
-	go operator.InitOperator()
+	go operator.InitOperator(conf.CommonController.Metrics.Port)
+
+	// Start the metrics server
+	if conf.CommonController.Metrics.Enabled && strings.EqualFold(conf.CommonController.Metrics.Type, metrics.PrometheusMetricType) {
+		loggers.LoggerAPKOperator.Info("Starting Prometheus Metrics Server ....")
+		go metrics.StartPrometheusMetricsServer()
+	}
 
 OUTER:
 	for {

--- a/common-controller/commoncontroller/common_controller.go
+++ b/common-controller/commoncontroller/common_controller.go
@@ -25,7 +25,6 @@ import (
 	"net"
 	"os"
 	"os/signal"
-	"strings"
 	"time"
 
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -41,7 +40,6 @@ import (
 	"github.com/wso2/apk/common-controller/internal/server"
 	utils "github.com/wso2/apk/common-controller/internal/utils"
 	xds "github.com/wso2/apk/common-controller/internal/xds"
-	"github.com/wso2/apk/common-controller/pkg/metrics"
 	apkmgt "github.com/wso2/apk/common-go-libs/pkg/discovery/api/wso2/discovery/service/apkmgt"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -219,13 +217,7 @@ func InitCommonControllerServer(conf *config.Config) {
 	// Start Enforcer xDS gRPC server
 	runCommonEnforcerServer(port)
 
-	go operator.InitOperator(conf.CommonController.Metrics.Port)
-
-	// Start the metrics server
-	if conf.CommonController.Metrics.Enabled && strings.EqualFold(conf.CommonController.Metrics.Type, metrics.PrometheusMetricType) {
-		loggers.LoggerAPKOperator.Info("Starting Prometheus Metrics Server ....")
-		go metrics.StartPrometheusMetricsServer()
-	}
+	go operator.InitOperator(conf.CommonController.Metrics)
 
 OUTER:
 	for {

--- a/common-controller/go.mod
+++ b/common-controller/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/jackc/pgx/v5 v5.5.2
 	github.com/onsi/ginkgo/v2 v2.14.0
 	github.com/onsi/gomega v1.30.0
-	github.com/prometheus/client_golang v1.18.0
+	github.com/prometheus/client_golang v1.18.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/sirupsen/logrus v1.9.0
 	k8s.io/apimachinery v0.29.2

--- a/common-controller/internal/config/default_config.go
+++ b/common-controller/internal/config/default_config.go
@@ -43,7 +43,7 @@ var defaultConfig = &Config{
 			RetryInterval: 5,
 			Persistence:   persistence{Type: "K8s"},
 		},
-		Metrics: metrics{
+		Metrics: Metrics{
 			Enabled: false,
 			Type:    "prometheus",
 			Port:    18006,

--- a/common-controller/internal/config/types.go
+++ b/common-controller/internal/config/types.go
@@ -107,10 +107,9 @@ type webServer struct {
 
 // Metrics defines the configuration for metrics collection.
 type Metrics struct {
-	Enabled            bool
-	Type               string
-	Port               int32
-	CollectionInterval int32
+	Enabled bool
+	Type    string
+	Port    int32
 }
 
 type database struct {

--- a/common-controller/internal/config/types.go
+++ b/common-controller/internal/config/types.go
@@ -48,7 +48,7 @@ type commoncontroller struct {
 	WebServer         webServer
 	InternalAPIServer internalAPIServer
 	ControlPlane      controlplane
-	Metrics           metrics
+	Metrics           Metrics
 	Database          database
 }
 type controlplane struct {
@@ -105,7 +105,8 @@ type webServer struct {
 	Port int64
 }
 
-type metrics struct {
+// Metrics defines the configuration for metrics collection.
+type Metrics struct {
 	Enabled            bool
 	Type               string
 	Port               int32

--- a/common-controller/internal/operator/operator.go
+++ b/common-controller/internal/operator/operator.go
@@ -208,7 +208,7 @@ func InitOperator(metricsConfig config.Metrics) {
 
 	// Register the metrics collector
 	if metricsConfig.Enabled && strings.EqualFold(metricsConfig.Type, metrics.PrometheusMetricType) {
-		loggers.LoggerAPKOperator.Info("Starting Prometheus Metrics Server ....")
+		loggers.LoggerAPKOperator.Info("Registering Prometheus metrics collector.")
 		go metrics.RegisterPrometheusCollector()
 	}
 

--- a/common-controller/internal/operator/operator.go
+++ b/common-controller/internal/operator/operator.go
@@ -106,6 +106,12 @@ func InitOperator(metricsConfig config.Metrics) {
 
 	if metricsConfig.Enabled {
 		options.Metrics.BindAddress = fmt.Sprintf(":%d", metricsConfig.Port)
+
+		// Register the metrics collector
+		if strings.EqualFold(metricsConfig.Type, metrics.PrometheusMetricType) {
+			loggers.LoggerAPKOperator.Info("Registering Prometheus metrics collector.")
+			metrics.RegisterPrometheusCollector()
+		}
 	} else {
 		options.Metrics.BindAddress = "0"
 	}
@@ -206,12 +212,6 @@ func InitOperator(metricsConfig config.Metrics) {
 				grpcClient.StartEventStreaming()
 			}
 		}()
-	}
-
-	// Register the metrics collector
-	if metricsConfig.Enabled && strings.EqualFold(metricsConfig.Type, metrics.PrometheusMetricType) {
-		loggers.LoggerAPKOperator.Info("Registering Prometheus metrics collector.")
-		go metrics.RegisterPrometheusCollector()
 	}
 
 	setupLog.Info("starting manager")

--- a/common-controller/internal/operator/operator.go
+++ b/common-controller/internal/operator/operator.go
@@ -20,6 +20,7 @@ package operator
 import (
 	"flag"
 	"os"
+	"strconv"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
@@ -64,12 +65,13 @@ func init() {
 }
 
 // InitOperator initializes the operator
-func InitOperator() {
+func InitOperator(prometheusPort int32) {
 	var metricsAddr string
 	var enableLeaderElection bool
 	var probeAddr string
 	controlPlaneID := uuid.New().String()
-	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
+	port := strconv.FormatInt(int64(prometheusPort), 10)
+	flag.StringVar(&metricsAddr, "metrics-bind-address", ":"+port, "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+

--- a/common-controller/internal/operator/operator.go
+++ b/common-controller/internal/operator/operator.go
@@ -105,7 +105,9 @@ func InitOperator(metricsConfig config.Metrics) {
 	}
 
 	if metricsConfig.Enabled {
-		options.MetricsBindAddress = fmt.Sprintf(":%d", metricsConfig.Port)
+		options.Metrics.BindAddress = fmt.Sprintf(":%d", metricsConfig.Port)
+	} else {
+		options.Metrics.BindAddress = "0"
 	}
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), options)

--- a/common-controller/pkg/metrics/metrics.go
+++ b/common-controller/pkg/metrics/metrics.go
@@ -24,8 +24,8 @@ import (
 	k8smetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
-// StartPrometheusMetricsServer initializes and starts the metrics server to expose metrics to prometheus.
-func StartPrometheusMetricsServer() {
+// RegisterPrometheusCollector registers the Prometheus collector for metrics.
+func RegisterPrometheusCollector() {
 
 	collector := metrics.CustomMetricsCollector()
 	k8smetrics.Registry.MustRegister(collector)

--- a/common-controller/pkg/metrics/metrics.go
+++ b/common-controller/pkg/metrics/metrics.go
@@ -20,29 +20,13 @@
 package metrics
 
 import (
-	"fmt"
-	"net/http"
-	"strconv"
-
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"github.com/wso2/apk/adapter/pkg/logging"
-	logger "github.com/wso2/apk/common-controller/internal/loggers"
 	metrics "github.com/wso2/apk/common-go-libs/pkg/metrics"
+	k8smetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
 // StartPrometheusMetricsServer initializes and starts the metrics server to expose metrics to prometheus.
-func StartPrometheusMetricsServer(port int32) {
+func StartPrometheusMetricsServer() {
 
 	collector := metrics.CustomMetricsCollector()
-	prometheus.MustRegister(collector)
-	http.Handle("/metrics", promhttp.Handler())
-	err := http.ListenAndServe(":"+strconv.Itoa(int(port)), nil)
-	if err != nil {
-		logger.LoggerAPK.ErrorC(logging.ErrorDetails{
-			Message:   fmt.Sprintln("Prometheus metrics server error:", err),
-			Severity:  logging.MAJOR,
-			ErrorCode: 1110,
-		})
-	}
+	k8smetrics.Registry.MustRegister(collector)
 }

--- a/common-go-libs/pkg/metrics/metrics.go
+++ b/common-go-libs/pkg/metrics/metrics.go
@@ -39,7 +39,6 @@ var (
 
 // Collector contains the descriptions of the custom metrics exposed
 type Collector struct {
-	internalRouteCount *prometheus.Desc
 	hostInfo           *prometheus.Desc
 	availableCPUs      *prometheus.Desc
 	freePhysicalMemory *prometheus.Desc
@@ -52,11 +51,6 @@ type Collector struct {
 // CustomMetricsCollector contains the descriptions of the custom metrics exposed
 func CustomMetricsCollector() *Collector {
 	return &Collector{
-		internalRouteCount: prometheus.NewDesc(
-			"internal_route_count",
-			"Number of internal routes created.",
-			nil, nil,
-		),
 		hostInfo: prometheus.NewDesc(
 			"host_info",
 			"Host Info",
@@ -98,7 +92,6 @@ func CustomMetricsCollector() *Collector {
 // Describe sends all the descriptors of the metrics collected by this Collector
 // to the provided channel.
 func (collector *Collector) Describe(ch chan<- *prometheus.Desc) {
-	ch <- collector.internalRouteCount
 	ch <- collector.hostInfo
 	ch <- collector.availableCPUs
 	ch <- collector.freePhysicalMemory


### PR DESCRIPTION
This PR contains the following changes.

1. The operator present in both the adapter and common controller inherently have a metrics endpoint available by default at port 8080. Instead of spinning up an additional Prometheus server, the code was refactored to utilise the existing metrics endpoint to expose Prometheus metrics.
2. Additionally, the existing method of providing the metrics bind address needed to be refactored due to the gateway API dependency update from PR #2121.
3. This PR fixes #2134 