### PR TITLE
Adding Weighted Routing Capability

### DIFF
--- a/adapter/internal/oasparser/envoyconf/routes_configs.go
+++ b/adapter/internal/oasparser/envoyconf/routes_configs.go
@@ -126,21 +126,59 @@ func generateRouteMatch(routeRegex string) *routev3.RouteMatch {
 	return match
 }
 
-func generateRouteAction(apiType string, routeConfig *model.EndpointConfig, ratelimitCriteria *ratelimitCriteria, mirrorClusterNames []string, isBackendBasedAIRatelimitEnabled bool, descriptorValueForBackendBasedAIRatelimit string) (action *routev3.Route_Route) {
-	action = &routev3.Route_Route{
-		Route: &routev3.RouteAction{
-			HostRewriteSpecifier: &routev3.RouteAction_AutoHostRewrite{
-				AutoHostRewrite: &wrapperspb.BoolValue{
-					Value: true,
+func generateRouteAction(apiType string, routeConfig *model.EndpointConfig, ratelimitCriteria *ratelimitCriteria, mirrorClusterNames []string, isBackendBasedAIRatelimitEnabled bool, descriptorValueForBackendBasedAIRatelimit string, weightedCluster *routev3.WeightedCluster_ClusterWeight, isWeighted bool) (action *routev3.Route_Route) {
+	
+	if isWeighted {
+		// check if weightedCluster is already in the list
+		exists := false
+		for i, existingWeightedCluster := range weightedClusters {
+			if existingWeightedCluster.Name == weightedCluster.Name {
+				if existingWeightedCluster.Weight.GetValue() == weightedCluster.Weight.GetValue() {
+					exists = true
+				} else {
+					// Remove the existing entry with the same name but different weight
+					weightedClusters = append(weightedClusters[:i], weightedClusters[i+1:]...)
+				}
+			}
+		}
+
+		// if not existing, add to the list
+		if !exists {
+			weightedClusters = append(weightedClusters, weightedCluster)		
+		}
+		action = &routev3.Route_Route{
+			Route: &routev3.RouteAction{
+				HostRewriteSpecifier: &routev3.RouteAction_AutoHostRewrite{
+					AutoHostRewrite: &wrapperspb.BoolValue{
+						Value: true,
+					},
+				},
+				UpgradeConfigs:    getUpgradeConfig(apiType),
+				MaxStreamDuration: getMaxStreamDuration(apiType),
+				ClusterSpecifier: &routev3.RouteAction_WeightedClusters{
+					WeightedClusters: &routev3.WeightedCluster{
+						Clusters: weightedClusters,
+					},
 				},
 			},
-			UpgradeConfigs:    getUpgradeConfig(apiType),
-			MaxStreamDuration: getMaxStreamDuration(apiType),
-			ClusterSpecifier: &routev3.RouteAction_ClusterHeader{
-				ClusterHeader: clusterHeaderName,
+		}
+    } else {
+		action = &routev3.Route_Route{
+			Route: &routev3.RouteAction{
+				HostRewriteSpecifier: &routev3.RouteAction_AutoHostRewrite{
+					AutoHostRewrite: &wrapperspb.BoolValue{
+						Value: true,
+					},
+				},
+				UpgradeConfigs:    getUpgradeConfig(apiType),
+				MaxStreamDuration: getMaxStreamDuration(apiType),
+				ClusterSpecifier: &routev3.RouteAction_ClusterHeader{
+					ClusterHeader: clusterHeaderName,
+				},
 			},
-		},
+		}
 	}
+
 	if routeConfig != nil {
 		action.Route.IdleTimeout = durationpb.New(time.Duration(routeConfig.IdleTimeoutInSeconds) * time.Second)
 	}

--- a/adapter/internal/oasparser/model/adapter_internal_api.go
+++ b/adapter/internal/oasparser/model/adapter_internal_api.go
@@ -182,6 +182,8 @@ type Endpoint struct {
 	Certificate []byte
 	// Subject Alternative Names to verify in the public certificate
 	AllowedSANs []string
+	// Weight assigned for the endpoint (optional)
+	Weight int32
 }
 
 // EndpointSecurity contains parameters of endpoint security at api.json
@@ -628,6 +630,12 @@ func (adapterInternalAPI *AdapterInternalAPI) SetInfoHTTPRouteCR(httpRoute *gwap
 						HealthyThreshold:   resolvedBackend.HealthCheck.HealthyThreshold,
 					}
 				}
+				if backend.Weight != nil {
+					// Extracting weights from HTTPRoute if weights are defined
+					resolvedBackend.Weight = *backend.Weight
+					loggers.LoggerAPI.Infof("Weighted Routing Capability is enabled for the Resolved Backend %s with weight %d", backendName.String(), resolvedBackend.Weight)
+				}
+
 				endPoints = append(endPoints, GetEndpoints(backendName, resourceParams.BackendMapping)...)
 				backendBasePath = GetBackendBasePath(backendName, resourceParams.BackendMapping)
 				switch resolvedBackend.Security.Type {

--- a/adapter/internal/oasparser/model/http_route.go
+++ b/adapter/internal/oasparser/model/http_route.go
@@ -175,6 +175,7 @@ func GetEndpoints(backendName types.NamespacedName, backendMapping map[string]*d
 					URLType:     string(backend.Protocol),
 					Certificate: []byte(backend.TLS.ResolvedCertificate),
 					AllowedSANs: backend.TLS.AllowedSANs,
+					Weight: 	 backend.Weight,
 				})
 			}
 		}

--- a/common-go-libs/apis/dp/v1alpha2/resolvedbackend.go
+++ b/common-go-libs/apis/dp/v1alpha2/resolvedbackend.go
@@ -29,6 +29,7 @@ type ResolvedBackend struct {
 	Retry          *RetryConfig
 	BasePath       string `json:"basePath"`
 	HealthCheck    *HealthCheck
+	Weight 	   	   int32
 }
 
 // ResolvedTLSConfig defines enpoint TLS configurations


### PR DESCRIPTION
## Purpose
> Fixes #2769 

## Goals
> Introducing weighted routing capability to WSO2 APK, a key capability for distributing traffic based on custom-defined weights for backend endpoints. 

## Approach
> When multiple backendRefs are present in an applied HTTPRoute CR, if weight values are defined, then those weight values are extracted from the HTTPRoute CR and configured in the Envoy configuration under a weighted_cluster route.
