### PR TITLE
Fix API definition test failures for gRPC and GraphQL APIs

### DIFF
--- a/gateway/enforcer/internal/requestconfig/api.go
+++ b/gateway/enforcer/internal/requestconfig/api.go
@@ -62,3 +62,8 @@ type API struct {
 func (api *API) IsGraphQLAPI() bool {
 	return strings.ToLower(api.APIType) == "graphql"
 }
+
+// IsgRPCAPI checks whether the API is graphql
+func (api *API) IsgRPCAPI() bool {
+	return strings.ToLower(api.APIType) == "grpc"
+}

--- a/test/cucumber-tests/src/test/resources/tests/api/GRPC.feature
+++ b/test/cucumber-tests/src/test/resources/tests/api/GRPC.feature
@@ -46,13 +46,36 @@ Feature: Generating APK conf for gRPC API
         And I eventually receive 200 response code, not accepting
             | 429 |
             | 500 |
-        And the response body should contain endpoint definition for student.proto
+        And the response body should be "artifacts/definitions/student.proto" in resources
 
 
     Scenario: Undeploy API
         Given The system is ready
         And I have a valid subscription
         When I undeploy the API whose ID is "grpc-basic-api"
+        Then the response status code should be 202
+
+    Scenario: Checking api-definition endpoint to get zip API definition file
+        Given The system is ready
+        And I have a valid subscription
+        When I use the APK Conf file "artifacts/apk-confs/grpc/order-with-endpoints.apk-conf"
+        And the definition file "artifacts/definitions/order-definition.zip"
+        And make the API deployment request
+        Then the response status code should be 200
+        Then I set headers
+            | Authorization | Bearer ${accessToken} |
+            | Host          | default.gw.wso2.com   |
+        And I send "GET" request to "https://default.gw.wso2.com:9095/grpcapi.v1/api-definition/" with body ""
+        And I eventually receive 200 response code, not accepting
+            | 429 |
+            | 500 |
+        And the response body should be "artifacts/definitions/order-definition.zip" in resources
+
+
+    Scenario: Undeploy API
+        Given The system is ready
+        And I have a valid subscription
+        When I undeploy the API whose ID is "grpc-order-api"
         Then the response status code should be 202
 
     Scenario: Deploying gRPC API with OAuth2 disabled

--- a/test/cucumber-tests/src/test/resources/tests/api/GraphQL.feature
+++ b/test/cucumber-tests/src/test/resources/tests/api/GraphQL.feature
@@ -5,6 +5,27 @@ Feature: Generating APK conf for GraphQL API
         And generate the APK conf file for a "GRAPHQL" API
         Then the response status code should be 200
 
+    Scenario: Get API definition from a GraphQL API 
+        Given The system is ready
+        And I have a valid subscription
+        When I use the APK Conf file "artifacts/apk-confs/graphql/graphql_conf_without_sub.apk-conf"
+        And the definition file "artifacts/definitions/graphql_sample_api.graphql"
+        And make the API deployment request
+        Then the response status code should be 200
+        Then I set headers
+            | Authorization | Bearer ${accessToken} |
+        And I send "GET" request to "https://default.gw.wso2.com:9095/graphql/3.14/api-definition" with body ""
+        And I eventually receive 200 response code, not accepting
+            | 429 |
+            | 500 |
+        And the response body should be "artifacts/definitions/graphql_sample_api.graphql" in resources
+
+    Scenario: Undeploy API
+        Given The system is ready
+        And I have a valid subscription
+        When I undeploy the API whose ID is "graphql-without-sub"
+        Then the response status code should be 202
+
     Scenario: Deploying APK conf using a valid GraphQL API definition without a subscription resource
         Given The system is ready
         And I have a valid subscription


### PR DESCRIPTION
This PR fixes the API definition test case failures for gRPC APIs, and adds new API definition test cases for gRPC multi .proto APIs and GraphQL APIs

Fixes #2807 