### PR TITLE
Fix ELK analytics test case failure

### DIFF
--- a/gateway/enforcer/internal/analytics/publishers/elk.go
+++ b/gateway/enforcer/internal/analytics/publishers/elk.go
@@ -66,15 +66,15 @@ func (e *ELK) publishEvent(event *dto.Event) {
 		BackendLatency:           event.Latencies.BackendLatency,
 		RequestMediationLatency:  event.Latencies.RequestMediationLatency,
 		ResponseMediationLatency: event.Latencies.ResponseMediationLatency,
-		KeyType: event.Application.KeyType,
-		ApplicationID: event.Application.ApplicationID,
-		ApplicationName: event.Application.ApplicationName,
-		ApplicationOwner: event.Application.ApplicationOwner,
-		UserAgentHeader: event.UserAgentHeader,
-		UserName: event.UserName,
-		UserIP: event.UserIP,
-		RequestTimestamp: event.RequestTimestamp.Format(timeFormat),
-		Properties: event.Properties,
+		KeyType:                  event.Application.KeyType,
+		ApplicationID:            event.Application.ApplicationID,
+		ApplicationName:          event.Application.ApplicationName,
+		ApplicationOwner:         event.Application.ApplicationOwner,
+		UserAgentHeader:          event.UserAgentHeader,
+		UserName:                 event.UserName,
+		UserIP:                   event.UserIP,
+		RequestTimestamp:         event.RequestTimestamp.Format(timeFormat),
+		Properties:               event.Properties,
 	}
 
 	jsonString, err := util.ToJSONString(elkResponseEvent)
@@ -82,7 +82,7 @@ func (e *ELK) publishEvent(event *dto.Event) {
 		e.cfg.Logger.Error(err, "Error while converting to JSON string")
 		return
 	}
-	e.cfg.Logger.Sugar().Debug(fmt.Sprintf("apimMetrics: %s, properties: %s", "apim:response", jsonString))
+	e.cfg.Logger.Info(fmt.Sprintf("apimMetrics: %s, properties: %s", "apim:response", jsonString))
 }
 
 func (e *ELK) publishFault(event *dto.Event) {
@@ -92,23 +92,23 @@ func (e *ELK) publishFault(event *dto.Event) {
 		APIType:                event.API.APIType,
 		APIVersion:             event.API.APIVersion,
 		APICreatorTenantDomain: event.API.APICreatorTenantDomain,
-		APIMethod: event.Operation.APIMethod,
-		TargetResponseCode: event.Target.TargetResponseCode,
-		ProxyResponseCode: event.ProxyResponseCode,
-		CorrelationID: event.MetaInfo.CorrelationID,
-		RegionID: event.MetaInfo.RegionID,
-		GatewayType: event.MetaInfo.GatewayType,
-		KeyType: event.Application.KeyType,
-		ApplicationID: event.Application.ApplicationID,
-		ApplicationName: event.Application.ApplicationName,
-		ApplicationOwner: event.Application.ApplicationOwner,
-		UserAgentHeader: event.UserAgentHeader,
-		UserIP: event.UserIP,
-		RequestTimestamp: event.RequestTimestamp.Format(timeFormat),
-		Properties: event.Properties,
-		ErrorType: "",
-		ErrorCode: event.Target.TargetResponseCode,
-		ErrorMessage: event.Target.ResponseCodeDetail,
+		APIMethod:              event.Operation.APIMethod,
+		TargetResponseCode:     event.Target.TargetResponseCode,
+		ProxyResponseCode:      event.ProxyResponseCode,
+		CorrelationID:          event.MetaInfo.CorrelationID,
+		RegionID:               event.MetaInfo.RegionID,
+		GatewayType:            event.MetaInfo.GatewayType,
+		KeyType:                event.Application.KeyType,
+		ApplicationID:          event.Application.ApplicationID,
+		ApplicationName:        event.Application.ApplicationName,
+		ApplicationOwner:       event.Application.ApplicationOwner,
+		UserAgentHeader:        event.UserAgentHeader,
+		UserIP:                 event.UserIP,
+		RequestTimestamp:       event.RequestTimestamp.Format(timeFormat),
+		Properties:             event.Properties,
+		ErrorType:              "",
+		ErrorCode:              event.Target.TargetResponseCode,
+		ErrorMessage:           event.Target.ResponseCodeDetail,
 	}
 
 	jsonString, err := util.ToJSONString(elkResponseEvent)
@@ -116,7 +116,7 @@ func (e *ELK) publishFault(event *dto.Event) {
 		e.cfg.Logger.Error(err, "Error while converting to JSON string")
 		return
 	}
-	e.cfg.Logger.Sugar().Debug(fmt.Sprintf("apimMetrics: %s, properties: %s", "apim:faulty", jsonString))
+	e.cfg.Logger.Info(fmt.Sprintf("apimMetrics: %s, properties: %s", "apim:faulty", jsonString))
 }
 
 func (e *ELK) isFault(event *dto.Event) bool {


### PR DESCRIPTION
## Purpose
> ELK analytics test case checks for the presence of certain INFO level logs, which were made to be debug level recently in the enforcer. This PR makes those specific ELK level logs INFO level again.