### PR TITLE
Adding weighted endpoint support in Config-Deployer

### DIFF
--- a/runtime/config-deployer-service/ballerina/APIClient.bal
+++ b/runtime/config-deployer-service/ballerina/APIClient.bal
@@ -250,7 +250,8 @@ public class APIClient {
                     model:Endpoint endpoint = {
                         name: backendService.metadata.name,
                         serviceEntry: false,
-                        url: self.constructURlFromService(sandboxEndpointConfig.endpoint)
+                        url: self.constructURlFromService(sandboxEndpointConfig.endpoint),
+                        weight: sandboxEndpointConfig.weight
                     };
                     sandboxEndpoints.push(endpoint);
                     AIRatelimit? aiRatelimit = sandboxEndpointConfig.aiRatelimit;
@@ -273,7 +274,8 @@ public class APIClient {
                     model:Endpoint endpoint = {
                         name: backendService.metadata.name,
                         serviceEntry: false,
-                        url: self.constructURlFromService(productionEndpointConfig.endpoint)
+                        url: self.constructURlFromService(productionEndpointConfig.endpoint),
+                        weight: productionEndpointConfig.weight
                     };
                     productionEndpoints.push(endpoint);
                     AIRatelimit? aiRatelimit = productionEndpointConfig.aiRatelimit;
@@ -1268,6 +1270,9 @@ public class APIClient {
                     name: <string>endpointItem.name,
                     group: "dp.wso2.com"
                 };
+                if endpointItem.weight != () {
+                    httpBackend.weight = <int>endpointItem.weight;
+                }
                 httpBackendRefs.push(httpBackend);
             }
         }

--- a/runtime/config-deployer-service/ballerina/modules/model/Endpoint.bal
+++ b/runtime/config-deployer-service/ballerina/modules/model/Endpoint.bal
@@ -3,5 +3,6 @@ string url?;
 string namespace?;
 string name?;
 boolean serviceEntry = false;
+int weight?;
 
 |};

--- a/runtime/config-deployer-service/ballerina/resources/apk-conf-schema.yaml
+++ b/runtime/config-deployer-service/ballerina/resources/apk-conf-schema.yaml
@@ -362,6 +362,8 @@ components:
           $ref: "#/components/schemas/Resiliency"
         aiRatelimit:
           $ref: "#/components/schemas/AIRatelimit"
+        weight:
+          type: integer
       additionalProperties: false
     Certificate:
       type: object

--- a/runtime/config-deployer-service/ballerina/tests/resources/apk-schema.json
+++ b/runtime/config-deployer-service/ballerina/tests/resources/apk-schema.json
@@ -546,6 +546,10 @@
         "aiRatelimit": {
           "$ref": "#/schemas/AIRatelimit",
           "description": "AI ratelimit configuration for the API endpoint."
+        },
+        "weight": {
+          "type": "integer",
+          "description": "The weight configuration for the API endpoint."
         }
       },
       "additionalProperties": false

--- a/runtime/config-deployer-service/ballerina/types.bal
+++ b/runtime/config-deployer-service/ballerina/types.bal
@@ -300,12 +300,14 @@ public type EndpointConfigurations record {
 # + certificate - The certificate configuration for the endpoint.
 # + resiliency - The resiliency configuration for the endpoint.
 # + aiRatelimit - The AIRatelimit configuration for the AI ratelimit.
+# + weight - The weight of the endpoint in weighted routing.
 public type EndpointConfiguration record {
     string|K8sService endpoint;
     EndpointSecurity endpointSecurity?;
     Certificate certificate?;
     Resiliency resiliency?;
     AIRatelimit aiRatelimit?;
+    int weight?;
 };
 
 # Configuration of OAuth2 Authentication type.

--- a/runtime/config-deployer-service/docker/config-deployer/conf/apk-schema.json
+++ b/runtime/config-deployer-service/docker/config-deployer/conf/apk-schema.json
@@ -546,6 +546,10 @@
         "aiRatelimit": {
           "$ref": "#/schemas/AIRatelimit",
           "description": "AI ratelimit configuration for the API endpoint."
+        },
+        "weight": {
+          "type": "integer",
+          "description": "The weight configuration for the API endpoint."
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
## Purpose
> Added weighted routing support to the config-deployer, in order to extract weight values from endpointConfigurations in apk-conf files.