### PR TITLE
Remove enforcer metadata nil check

### DIFF
--- a/gateway/enforcer/internal/extproc/ext_proc.go
+++ b/gateway/enforcer/internal/extproc/ext_proc.go
@@ -310,10 +310,6 @@ func (s *ExternalProcessingServer) Process(srv envoy_service_proc_v3.ExternalPro
 				// return status.Errorf(codes.Unknown, "cannot extract metadata: %v", err)
 				break
 			}
-			if metadata == nil {
-				s.log.Error(err, "metadata is nil")
-				break
-			}
 			requestConfigHolder.ExternalProcessingEnvoyMetadata = metadata
 
 			// s.log.Info(fmt.Sprintf("Matched api bjc: %v", requestConfigHolder.MatchedAPI.BackendJwtConfiguration))


### PR DESCRIPTION
### Purpose

Metadata nil checks were previously added to prevent nil pointer errors
However, request header flow has a nil check later on in the flow which is required for authentication of the token
Therefore this nil check needs to be removed.