### PR TITLE
Updated hostname in weighted routing sample

### DIFF
--- a/developer/tryout/samples/sample-weighted-routing.yaml
+++ b/developer/tryout/samples/sample-weighted-routing.yaml
@@ -47,7 +47,7 @@ metadata:
     api-version: "1.0"
 spec:
   hostnames:
-  - "default.gw.wso2.com"
+  - "default.gw.example.com"
   rules:
   - matches:
     - path:


### PR DESCRIPTION
## Purpose
> Updated hostname in weighted routing sample config from `default.gw.wso2.com` to `default.gw.example.com` in order to work with QSG.