### PR TITLE
Adding kvResolving logic for semantic caching

### DIFF
--- a/adapter/internal/oasparser/constants/constants.go
+++ b/adapter/internal/oasparser/constants/constants.go
@@ -160,4 +160,7 @@ const (
 	// Azure Content Safety Content Moderation related constants
 	AzureContentSafetyContentModeration = "AzureContentSafetyContentModeration"
 	AzureContentSafetyKey               = "azureContentSafetyKey"
+	SemanticCaching                     = "SemanticCache"
+	SemanticCacheEmbeddingAPIKey        = "embeddingModelAPIKey"
+	SemanticCacheVectorDBPassword       = "vectorDBPassword"
 )

--- a/adapter/internal/oasparser/model/adapter_internal_api.go
+++ b/adapter/internal/oasparser/model/adapter_internal_api.go
@@ -1453,7 +1453,8 @@ func getResolvedPolicyParameters(ctx context.Context, kvClient *kvresolver.KVRes
 	resolvedParams := make(map[string]string)
 
 	for _, paramValue := range policy.Parameters {
-		if policy.PolicyName == constants.AzureContentSafetyContentModeration && paramValue.Key == constants.AzureContentSafetyKey {
+		if (policy.PolicyName == constants.AzureContentSafetyContentModeration && paramValue.Key == constants.AzureContentSafetyKey) ||
+		   (policy.PolicyName == constants.SemanticCaching && (paramValue.Key == constants.SemanticCacheEmbeddingAPIKey || paramValue.Key == constants.SemanticCacheVectorDBPassword)) {
 			value, err := getResolvedSecretParameterValue(ctx, kvClient, namespace, paramValue)
 			if err != nil {
 				return nil, fmt.Errorf("failed to resolve parameter %s: %w", paramValue.Key, err)

--- a/adapter/internal/operator/constants/constants.go
+++ b/adapter/internal/operator/constants/constants.go
@@ -84,4 +84,7 @@ const (
 	// Azure Content Safety Content Moderation related constants
 	AzureContentSafetyContentModeration = "AzureContentSafetyContentModeration"
 	AzureContentSafetyKey               = "azureContentSafetyKey"
+	SemanticCaching                     = "SemanticCache"
+	SemanticCacheEmbeddingAPIKey        = "embeddingModelAPIKey"
+	SemanticCacheVectorDBPassword       = "vectorDBPassword"
 )

--- a/adapter/internal/operator/utils/utils.go
+++ b/adapter/internal/operator/utils/utils.go
@@ -1058,7 +1058,8 @@ func GetResolvedPolicyParameters(ctx context.Context, client client.Client, kvCl
 	resolvedParams := make(map[string]string)
 
 	for _, paramValue := range policy.Parameters {
-		if policy.PolicyName == constants.AzureContentSafetyContentModeration && paramValue.Key == "azureContentSafetyKey" {
+		if (policy.PolicyName == constants.AzureContentSafetyContentModeration && paramValue.Key == constants.AzureContentSafetyKey) ||
+		   (policy.PolicyName == constants.SemanticCaching && (paramValue.Key == constants.SemanticCacheEmbeddingAPIKey || paramValue.Key == constants.SemanticCacheVectorDBPassword)) {
 			value, err := GetResolvedSecretParameterValue(ctx, client, kvClient, namespace, paramValue)
 			if err != nil {
 				return nil, fmt.Errorf("failed to resolve parameter %s: %w", paramValue.Key, err)


### PR DESCRIPTION
## Description
This PR adds the secret resolving logic for the semantic caching in the Adapter side.

> Related Issues: 
> - https://github.com/wso2-enterprise/apim-saas/issues/880
> - https://github.com/wso2/api-manager/issues/3958