### PR TITLE
Add debug logs to identify param secret resolving in the Adapter

### DIFF
--- a/adapter/internal/oasparser/model/adapter_internal_api.go
+++ b/adapter/internal/oasparser/model/adapter_internal_api.go
@@ -1483,6 +1483,7 @@ func getResolvedSecretParameterValue(ctx context.Context, kvClient *kvresolver.K
 	// Iterate through the secrets to find the keyName and valueKey
 	for _, secret := range secrets.Secrets {
 		if secret.Key == paramValue.Key {
+			loggers.LoggerAPKOperator.Debugf("Resolved secret for key: %s, value: %s", paramValue.Key, secret.Value)
 			return secret.Value, nil
 		}
 	}

--- a/adapter/internal/operator/utils/utils.go
+++ b/adapter/internal/operator/utils/utils.go
@@ -1059,7 +1059,7 @@ func GetResolvedPolicyParameters(ctx context.Context, client client.Client, kvCl
 
 	for _, paramValue := range policy.Parameters {
 		if (policy.PolicyName == constants.AzureContentSafetyContentModeration && paramValue.Key == constants.AzureContentSafetyKey) ||
-		   (policy.PolicyName == constants.SemanticCaching && (paramValue.Key == constants.SemanticCacheEmbeddingAPIKey || paramValue.Key == constants.SemanticCacheVectorDBPassword)) {
+			(policy.PolicyName == constants.SemanticCaching && (paramValue.Key == constants.SemanticCacheEmbeddingAPIKey || paramValue.Key == constants.SemanticCacheVectorDBPassword)) {
 			value, err := GetResolvedSecretParameterValue(ctx, client, kvClient, namespace, paramValue)
 			if err != nil {
 				return nil, fmt.Errorf("failed to resolve parameter %s: %w", paramValue.Key, err)
@@ -1102,6 +1102,7 @@ func GetResolvedSecretParameterValue(ctx context.Context, client client.Client, 
 	// Iterate through the secrets to find the keyName and valueKey
 	for _, secret := range secrets.Secrets {
 		if secret.Key == paramValue.Key {
+			loggers.LoggerAPKOperator.Debugf("Resolved secret for key: %s, value: %s", paramValue.Key, secret.Value)
 			return secret.Value, nil
 		}
 	}


### PR DESCRIPTION
## Purpose
This PR adds debug logs to identify param secret resolving in the Adapter.

Related issue: https://github.com/wso2/api-manager/issues/3951