### PR TITLE
Fix parameter secret resolving in the Adapter

### DIFF
--- a/adapter/internal/oasparser/model/adapter_internal_api.go
+++ b/adapter/internal/oasparser/model/adapter_internal_api.go
@@ -1497,14 +1497,14 @@ func getResolvedSecretParameterValue(ctx context.Context, kvClient *kvresolver.K
 	// Iterate through the secrets to find the keyName and valueKey
 	for _, secret := range secrets.Secrets {
 		loggers.LoggerAPI.Debugf("Checking secret: ID=%s, Key=%s", secret.ID, secret.Key)
-		if secret.Key == paramValue.Key {
-			loggers.LoggerAPI.Debugf("Found matching secret for key: %s", paramValue.Key)
+		if secret.Key == *paramValue.Value {
+			loggers.LoggerAPI.Debugf("Found matching secret for key: %s", *paramValue.Value)
 			return secret.Value, nil
 		}
 	}
-	
-	loggers.LoggerAPI.Debugf("Secret not found for key: %s", paramValue.Key)
-	return "", fmt.Errorf("secret not found for key: %s", paramValue.Key)
+
+	loggers.LoggerAPI.Debugf("Secret not found for key: %s", *paramValue.Value)
+	return "", fmt.Errorf("secret not found for key: %s", *paramValue.Value)
 }
 
 // getResolvedParameterValue resolves a ParameterValue to its actual string value

--- a/adapter/internal/operator/utils/utils.go
+++ b/adapter/internal/operator/utils/utils.go
@@ -1117,12 +1117,12 @@ func GetResolvedSecretParameterValue(ctx context.Context, client client.Client, 
 	// Iterate through the secrets to find the keyName and valueKey
 	for _, secret := range secrets.Secrets {
 		loggers.LoggerAPKOperator.Debugf("Checking secret: ID=%s, Key=%s", secret.ID, secret.Key)
-		if secret.Key == paramValue.Key {
-			loggers.LoggerAPKOperator.Debugf("Found matching secret for key: %s", paramValue.Key)
+		if secret.Key == *paramValue.Value {
+			loggers.LoggerAPKOperator.Debugf("Found matching secret for key: %s", *paramValue.Value)
 			return secret.Value, nil
 		}
 	}
-	
-	loggers.LoggerAPKOperator.Debugf("Secret not found for key: %s", paramValue.Key)
-	return "", fmt.Errorf("secret not found for key: %s", paramValue.Key)
+
+	loggers.LoggerAPKOperator.Debugf("Secret not found for key: %s", *paramValue.Value)
+	return "", fmt.Errorf("secret not found for key: %s", *paramValue.Value)
 }


### PR DESCRIPTION
## Purpose
This PR fixes parameter secret resolving in the Adapter.

Related issue: https://github.com/wso2/api-manager/issues/3951