### PR TITLE
Fix type infering issue in semantic_cache/embedding map

### DIFF
--- a/gateway/enforcer/internal/inbuiltpolicy/semantic_cache.go
+++ b/gateway/enforcer/internal/inbuiltpolicy/semantic_cache.go
@@ -85,7 +85,7 @@ func (s *SemanticCachePolicy) HandleRequestBody(logger *logging.Logger, req *env
 		if err != nil {
 			logger.Error(err, "failed to marshal embedding")
 		} else {
-			dynamicMetadataKeyValuePairs, ok := props["dynamicMetadataMap"].(map[string]string)
+			dynamicMetadataKeyValuePairs, ok := props["dynamicMetadataMap"].(map[string]interface{})
 			if ok {
 				dynamicMetadataKeyValuePairs[semanticCacheEmbeddingKey] = string(embeddingBytes)
 			}


### PR DESCRIPTION
## Purpose
- This PR fixes the type inferring issue occurred in the semantic cache logic due to changing the type of the metadata map in the ext_proc

> Related Issues: 
> - https://github.com/wso2/api-manager/issues/3958
> - https://github.com/wso2-enterprise/apim-saas/issues/880