### PR TITLE
Modified adapter logic to add semantic cache policy to response flow internally

### DIFF
--- a/adapter/internal/oasparser/model/adapter_internal_api.go
+++ b/adapter/internal/oasparser/model/adapter_internal_api.go
@@ -1042,14 +1042,26 @@ func (adapterInternalAPI *AdapterInternalAPI) SetInfoHTTPRouteCR(ctx context.Con
 
 			var requestInBuiltPolicies []*InternalInBuiltPolicy
 			var responseInBuiltPolicies []*InternalInBuiltPolicy
+			var semanticCachePolicy *InternalInBuiltPolicy
 			if extracted := extractRequestInBuiltPolicies(ctx, kvClient, resourceAPIPolicy); extracted != nil {
 				loggers.LoggerAPI.Debugf("Request In-Built Policies extracted %v", extracted)
 				requestInBuiltPolicies = extracted
+				// Check for semantic cache policy and store it to the semantic policy list
+				for _, policy := range requestInBuiltPolicies {
+					if policy.PolicyName == "SemanticCache" {
+						loggers.LoggerAPI.Debugf("Semantic cache policy found in request flow %+v", policy)
+						semanticCachePolicy = policy
+					}
+				}
 			}
 
 			if extracted := extractResponseInBuiltPolicies(ctx, kvClient, resourceAPIPolicy); extracted != nil {
 				loggers.LoggerAPI.Debugf("Response In-Built Policies extracted %v", extracted)
 				responseInBuiltPolicies = extracted
+			}
+			if (semanticCachePolicy != nil){ // Append semantic cache policy to end
+				responseInBuiltPolicies = append(responseInBuiltPolicies, semanticCachePolicy)
+				loggers.LoggerAPI.Debugf("Added semantic cache policy to response flow")
 			}
 
 			resource := &Resource{
@@ -1486,13 +1498,13 @@ func getResolvedSecretParameterValue(ctx context.Context, kvClient *kvresolver.K
 	// Resolve the secret using the KVResolverClientImpl
 	kvRefKeys := []string{*paramValue.Value}
 	loggers.LoggerAPI.Debugf("Resolving secret parameter: key=%s, secretID=%s", paramValue.Key, *paramValue.Value)
-	
+
 	secrets, err := kvClient.GetSecrets(ctx, kvRefKeys)
 	if err != nil {
 		loggers.LoggerAPI.ErrorC(logging.PrintError(logging.Error2648, logging.CRITICAL, "Error while reading key from kv client: %s", paramValue.Key))
 		return "", fmt.Errorf("failed to get secrets from kv client: %w", err)
 	}
-	
+
 	loggers.LoggerAPI.Debugf("Retrieved %d secrets from KV client", len(secrets.Secrets))
 	// Iterate through the secrets to find the keyName and valueKey
 	for _, secret := range secrets.Secrets {

--- a/gateway/enforcer/internal/datastore/api_store.go
+++ b/gateway/enforcer/internal/datastore/api_store.go
@@ -151,6 +151,8 @@ func covertRequestInBuiltPoliciesToDTO(logger *logging.Logger, requestPolicies [
 		case inbuiltpolicy.SemanticCacheName:
 			if policy := inbuiltpolicy.NewSemanticCachingPolicy(logger, basePolicy); policy != nil {
 				dtoPolicies = append(dtoPolicies, policy)
+			} else {
+				logger.Sugar().Debug("Skipping the Semantic Cache Policy...")
 			}
 		case inbuiltpolicy.AzureContentSafetyContentModerationName:
 			dtoPolicies = append(dtoPolicies, inbuiltpolicy.NewAzureContentSafetyContentModeration(basePolicy))
@@ -193,6 +195,8 @@ func covertResponseInBuiltPoliciesToDTO(logger *logging.Logger, responsePolicies
 		case inbuiltpolicy.SemanticCacheName:
 			if policy := inbuiltpolicy.NewSemanticCachingPolicy(logger, basePolicy); policy != nil {
 				dtoPolicies = append(dtoPolicies, policy)
+			} else {
+				logger.Info("Skipping the Semantic Cache Policy...")
 			}
 		case inbuiltpolicy.AzureContentSafetyContentModerationName:
 			dtoPolicies = append(dtoPolicies, inbuiltpolicy.NewAzureContentSafetyContentModeration(basePolicy))

--- a/gateway/enforcer/internal/inbuiltpolicy/semantic_cache.go
+++ b/gateway/enforcer/internal/inbuiltpolicy/semantic_cache.go
@@ -157,7 +157,7 @@ func (s *SemanticCachePolicy) HandleResponseBody(logger *logging.Logger, req *en
 
 // NewSemanticCachingPolicy initializes the NewSemanticCachingPolicy policy from the given InBuiltPolicy.
 func NewSemanticCachingPolicy(logger *logging.Logger, inBuiltPolicy dto.InBuiltPolicy) *SemanticCachePolicy {
-	logger.Sugar().Debugf("Initializing Semantic Caching policy: %s", inBuiltPolicy.GetPolicyName())
+	logger.Sugar().Debugf("Initializing Semantic Caching policy: %s", inBuiltPolicy.GetPolicyID())
 	semanticCachePolicy := &SemanticCachePolicy{
 		BaseInBuiltPolicy: dto.BaseInBuiltPolicy{
 			PolicyName:    inBuiltPolicy.GetPolicyName(),

--- a/gateway/enforcer/internal/semanticcache/preprocessor.go
+++ b/gateway/enforcer/internal/semanticcache/preprocessor.go
@@ -268,7 +268,7 @@ func ValidateEmbeddingProviderConfigProps(config EmbeddingProviderConfig) error 
 	if config.EmbeddingEndpoint == "" {
 		return fmt.Errorf("missing embedding endpoint in the embedding provider configuration")
 	}
-	if config.EmbeddingProvider != "MISTRAL_AI" && config.EmbeddingProvider != "AZURE_OPENAI" {
+	if config.EmbeddingProvider != "MISTRAL" && config.EmbeddingProvider != "AZURE_OPENAI" {
 		return fmt.Errorf("missing/Invalid embedding provider found in the embedding provider configuration")
 	}
 	if config.EmbeddingModel == "" {


### PR DESCRIPTION
## Description
- In the current flow, in order to enable semantic caching, it needs to be added to both request and response flows which is not ideal from UX perspective. This PR adds a fix, changing that logic so that once the semantic cache policy is added to request flow, from the adapter, it will automatically add it to response flow internally.

> Related Issues: 
> - https://github.com/wso2/api-manager/issues/3958
> - https://github.com/wso2-enterprise/apim-saas/issues/880