### PR TITLE
Fixing constant name mismatching in the adapter side secret resolving

### DIFF
--- a/adapter/internal/oasparser/constants/constants.go
+++ b/adapter/internal/oasparser/constants/constants.go
@@ -163,8 +163,8 @@ const (
 
 	// Semantic Caching related constants
 	SemanticCaching               = "SemanticCache"
-	SemanticCacheEmbeddingAPIKey  = "embeddingModelAPIKey"
-	SemanticCacheVectorDBPassword = "vectorDBPassword"
+	SemanticCacheEmbeddingAPIKey  = "api_key"
+	SemanticCacheVectorDBPassword = "password"
 
 	// AWS Bedrock Guardrail related constants
 	AWSBedrockGuardrail = "AWSBedrockGuardrail"

--- a/adapter/internal/operator/constants/constants.go
+++ b/adapter/internal/operator/constants/constants.go
@@ -87,8 +87,8 @@ const (
 
 	// Semantic Caching related constants
 	SemanticCaching               = "SemanticCache"
-	SemanticCacheEmbeddingAPIKey  = "embeddingModelAPIKey"
-	SemanticCacheVectorDBPassword = "vectorDBPassword"
+	SemanticCacheEmbeddingAPIKey  = "api_key"
+	SemanticCacheVectorDBPassword = "password"
 
 	// AWS Bedrock Guardrail related constants
 	AWSBedrockGuardrail = "AWSBedrockGuardrail"


### PR DESCRIPTION
## Purpose
- This PR adds the fix for constant name mismatching in secret resolving logic related to semantic caching in the adapter side 

> Related Issues: 
> - https://github.com/wso2/api-manager/issues/3958
> - https://github.com/wso2-enterprise/apim-saas/issues/880