### PR TITLE
Deleting unused providers upon API deletion

### DIFF
--- a/gateway/enforcer/internal/semanticcache/constants.go
+++ b/gateway/enforcer/internal/semanticcache/constants.go
@@ -15,6 +15,6 @@ const (
 	DefaultThreshold          = 80                              // DefaultThreshold is the default threshold for cache entries
 	DefaultTimeout            = 5000                            // DefaultTimeout is the default timeout for cache operations in milliseconds
 	VectorIndexPrefix         = "apk_semantic_cache_"           // VectorIndexPrefix is the prefix for vector index keys in the cache
-	DefaultTTL                = 36000                           // DefaultTTL is the default time-to-live for cache entries in seconds (10 hours, 36000 seconds
+	DefaultTTL                = 3600                           // DefaultTTL is the default time-to-live for cache entries in seconds (1 hours, 3600 seconds
 	DefaultRequestTimeout     = 30                              // DefaultRequestTimeout is the default timeout for requests in seconds (30 seconds)
 )

--- a/gateway/enforcer/internal/semanticcache/milvus_vectordb_provider.go
+++ b/gateway/enforcer/internal/semanticcache/milvus_vectordb_provider.go
@@ -227,3 +227,11 @@ func (m *MilvusVectorDBProvider) Retrieve(logger *logging.Logger, embeddings []f
 	}
 	return resp, nil
 }
+
+// Close closes the Milvus client connection
+func (m *MilvusVectorDBProvider) Close() error {
+	if m.client != nil {
+		return m.client.Close(context.Background())
+	}
+	return nil
+}

--- a/gateway/enforcer/internal/semanticcache/provider.go
+++ b/gateway/enforcer/internal/semanticcache/provider.go
@@ -17,6 +17,7 @@ type VectorDBProvider interface {
 	CreateIndex(logger *logging.Logger) error
 	Store(logger *logging.Logger, embeddings []float32, response CacheResponse, filter map[string]interface{}) error
 	Retrieve(logger *logging.Logger, embeddings []float32, filter map[string]interface{}) (CacheResponse, error)
+	Close() error
 }
 
 // VectorDBProviderConfig defines the properties required for initializing a vector DB provider

--- a/gateway/enforcer/internal/semanticcache/redis_vectordb_provider.go
+++ b/gateway/enforcer/internal/semanticcache/redis_vectordb_provider.go
@@ -235,6 +235,14 @@ func (r *RedisVectorDBProvider) Retrieve(logger *logging.Logger, embeddings []fl
 	return resp, nil
 }
 
+// Close closes the Redis client connection
+func (r *RedisVectorDBProvider) Close() error {
+	if r.client != nil {
+		return r.client.Close()
+	}
+	return nil
+}
+
 // Helper functions
 
 // FloatsToBytes convert float[] to byte[] for storing in Redis(FROM DOCS)

--- a/gateway/enforcer/internal/util/common.go
+++ b/gateway/enforcer/internal/util/common.go
@@ -17,6 +17,11 @@
 
 package util
 
+import (
+	"crypto/sha256"
+	"encoding/hex"
+)
+
 // Contains checks if a string is present in a slice.
 func Contains(slice []string, item string) bool {
     for _, s := range slice {
@@ -25,4 +30,10 @@ func Contains(slice []string, item string) bool {
         }
     }
     return false
+}
+
+// HashString hashes a string using SHA-256 and returns the hex encoded string.
+func HashString(s string) string {
+	h := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(h[:])
 }


### PR DESCRIPTION
## Purpose
This PR adds the logic for
-  Explicitly deleting the unused vector store and embedding provider clients 
- Handling the addition of same policy with different configurations for different resource endpoints

> Related Issues: 
> - https://github.com/wso2/api-manager/issues/3958
> - https://github.com/wso2-enterprise/apim-saas/issues/880
