### PR TITLE
Install Cert Manager separately

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -163,6 +163,11 @@ jobs:
         helm repo add bitnami https://charts.bitnami.com/bitnami
         helm repo add jetstack https://charts.jetstack.io
         helm dependency build
+        helm install cert-manager jetstack/cert-manager \
+          --namespace apk-integration-test \
+          --create-namespace \
+          --version v1.17.1 \
+          --set crds.enabled=true
         helm install apk-test-setup -n apk-integration-test . --debug --wait --timeout 15m0s \
         --set wso2.subscription.imagePullSecrets=azure-registry \
         --set wso2.apk.dp.configdeployer.deployment.image=${{ secrets.AZURE_ACR_NAME }}.azurecr.io/apk-config-deployer-service:${{ github.sha }} \
@@ -291,6 +296,11 @@ jobs:
         helm repo add bitnami https://charts.bitnami.com/bitnami
         helm repo add jetstack https://charts.jetstack.io
         helm dependency build
+        helm install cert-manager jetstack/cert-manager \
+          --namespace apk-integration-test \
+          --create-namespace \
+          --version v1.17.1 \
+          --set crds.enabled=true
         helm install apk-test-setup -n apk-integration-test . --debug --wait --timeout 15m0s \
         --set wso2.subscription.imagePullSecrets=azure-registry \
         --set wso2.apk.dp.configdeployer.deployment.image=${{ secrets.AZURE_ACR_NAME }}.azurecr.io/apk-config-deployer-service:${{ github.sha }} \

--- a/README.md
+++ b/README.md
@@ -83,7 +83,14 @@ To tryout APK please refer to this [document](https://apk.docs.wso2.com/en/lates
 1. Execute `helm repo add bitnami https://charts.bitnami.com/bitnami` and `helm repo add jetstack https://charts.jetstack.io`.
 2. Clone the repo and cd into the `HELM-HOME` folder.
 3. Execute `helm dependency build` command to download the dependent charts.
-4. Now execute `helm install apk-test .` to install the APK components.
+4. Install cert-manager.
+    ```sh
+        helm install \
+          cert-manager jetstack/cert-manager \
+          --version v1.17.1 \
+          --set crds.enabled=true
+    ```
+5. Now execute `helm install apk-test .` to install the APK components.
 
     > **Optional**
     >
@@ -91,7 +98,7 @@ To tryout APK please refer to this [document](https://apk.docs.wso2.com/en/lates
     >
     > To deploy data plane components only use `--set wso2.apk.cp.enabled=false`
 
-5. Verify the deployment by executing ```kubectl get pods```
+6. Verify the deployment by executing ```kubectl get pods```
 
 ### To Access Deployment through local machine
 


### PR DESCRIPTION
## Purpose
https://github.com/wso2-enterprise/apim-saas/issues/1088

We are going to use the same Helm chart to deploy to the Choreo AWS EU. There, a Cert Manager is installed separately. This PR will install it separately and other changes will come in a different PR.