### PR TITLE
Refactor RouteMetadata and HTTPRoute creation

### DIFF
--- a/runtime/config-deployer-service-go/internal/api/routes/artifact_generator.go
+++ b/runtime/config-deployer-service-go/internal/api/routes/artifact_generator.go
@@ -52,13 +52,16 @@ func StartArtifactGeneratorServer(cfg *config.Server) {
 		artifactGeneratorApi.POST("/apis/generate-k8s-resources", func(c *gin.Context) {
 			organization := c.Query("organization")
 			if organization == "" {
-				organization = "default"
+				organization = config.GetConfig().DefaultOrganization
 			}
 			cpInitiated := c.Query("cpInitiated")
 			if cpInitiated == "" {
 				cpInitiated = "false"
 			}
 			namespace := c.Query("namespace")
+			if namespace == "" {
+				namespace = config.GetConfig().DefaultNamespace
+			}
 			organizationObj := dto.NewOrganization("", organization, "default",
 				"default", true)
 			handlers.GetGeneratedK8sResources(c, organizationObj, cpInitiated, namespace)
@@ -79,13 +82,13 @@ func StartArtifactGeneratorServer(cfg *config.Server) {
 			//organizationObj := authenticatedUserContext.Organization
 			organization := c.Query("organization")
 			if organization == "" {
-				organization = "default"
+				organization = config.GetConfig().DefaultOrganization
 			}
 			organizationObj := dto.NewOrganization("", organization, "default",
 				"default", true)
 			namespace := c.Query("namespace")
 			if namespace == "" {
-				namespace = "default"
+				namespace = config.GetConfig().DefaultNamespace
 			}
 			handlers.HandleAPIDeployment(c, organizationObj, "false", namespace)
 		})
@@ -102,13 +105,13 @@ func StartArtifactGeneratorServer(cfg *config.Server) {
 			//organizationObj := authenticatedUserContext.Organization
 			organization := c.Query("organization")
 			if organization == "" {
-				organization = "default"
+				organization = config.GetConfig().DefaultOrganization
 			}
 			organizationObj := dto.NewOrganization("", organization, "default",
 				"default", true)
 			namespace := c.Query("namespace")
 			if namespace == "" {
-				namespace = "default"
+				namespace = config.GetConfig().DefaultNamespace
 			}
 			apiId := c.Query("apiId")
 			handlers.HandleAPIUndeployment(c, apiId, organizationObj, namespace)

--- a/runtime/config-deployer-service-go/internal/config/config.go
+++ b/runtime/config-deployer-service-go/internal/config/config.go
@@ -27,14 +27,17 @@ import (
 
 // Server holds the configuration parameters for the application.
 type Server struct {
-	LogLevel            string `envconfig:"LOG_LEVEL" default:"DEBUG"`
-	Logger              logging.Logger
-	ExtensionServerHost string `envconfig:"EXTENSION_SERVER_HOST" default:"0.0.0.0"`
-	ExtensionServerPort string `envconfig:"EXTENSION_SERVER_PORT" default:"5005"`
-	APKSchemaLocation   string `envconfig:"APK_SCHEMA_LOCATION" default:"conf/apk-schema.json"`
-	ParentGatewayName   string `envconfig:"PARENT_GATEWAY_NAME" default:"wso2-kgw-default"`
-	ParentGatewayNamespace string `envconfig:"PARENT_GATEWAY_NAMESPACE" default:"default"`
+	LogLevel                 string `envconfig:"LOG_LEVEL" default:"DEBUG"`
+	Logger                   logging.Logger
+	ExtensionServerHost      string `envconfig:"EXTENSION_SERVER_HOST" default:"0.0.0.0"`
+	ExtensionServerPort      string `envconfig:"EXTENSION_SERVER_PORT" default:"5005"`
+	APKSchemaLocation        string `envconfig:"APK_SCHEMA_LOCATION" default:"conf/apk-schema.json"`
+	ParentGatewayName        string `envconfig:"PARENT_GATEWAY_NAME" default:"wso2-kgw-default"`
+	ParentGatewayNamespace   string `envconfig:"PARENT_GATEWAY_NAMESPACE" default:"default"`
 	ParentGatewaySectionName string `envconfig:"PARENT_GATEWAY_SECTION_NAME" default:"httpslistener"`
+	GatewayHostName          string `envconfig:"GATEWAY_HOST_NAME" default:"gw.wso2.com"`
+	DefaultNamespace         string `envconfig:"DEFAULT_NAMESPACE" default:"default"`
+	DefaultOrganization      string `envconfig:"DEFAULT_ORGANIZATION" default:"carbon.super"`
 }
 
 type metrics struct {

--- a/runtime/config-deployer-service-go/internal/constants/constants.go
+++ b/runtime/config-deployer-service-go/internal/constants/constants.go
@@ -153,5 +153,7 @@ const (
 	K8sKindReferenceGrant         = "ReferenceGrant"
 	K8sAPIVersionReferenceGrant   = "gateway.networking.k8s.io/v1beta1"
 
+	K8sHTTPRouteEnvTypeAnnotation = "gateway.envoyproxy.io/kgw-envtype"
+
 	K8sMaxAnnotationLength = 10000
 )


### PR DESCRIPTION
## Purpose
> Only one RouteMetadata CR needs to be created per API.

## Approach
> Refactor the CR generation method to only create one RouteMetadata CR per API. Add all the names of the HTTPRoutes as an annotation to this RouteMetadata.
Add an annotation to the HTTPRoute to denote the environment to which the HTTPRoute belongs to.
Fixed bugs in setting the hostname in RouteMetadata and environment in RouteMetadata.
