### PR TITLE
Extract base path from the backend endpoint and append to httproute

### DIFF
--- a/runtime/config-deployer-service-go/internal/api/handlers/deployer.go
+++ b/runtime/config-deployer-service-go/internal/api/handlers/deployer.go
@@ -92,9 +92,16 @@ func HandleAPIUndeployment(cxt *gin.Context, apiId string, organization *dto.Org
 	k8sClient := config.GetManager().GetClient()
 	routeMetadataList, err := util.GetRouteMetadataList(apiId, namespace, k8sClient)
 	if err != nil {
+		cxt.JSON(http.StatusInternalServerError, gin.H{
+			"code":    909022,
+			"message": "Failed to list route metadata" + err.Error(),
+		})
+		return
+	}
+	if routeMetadataList == nil || len(routeMetadataList.Items) == 0 {
 		cxt.JSON(http.StatusNotFound, gin.H{
 			"code":    909001,
-			"message": apiId + " not found: " + err.Error(),
+			"message": apiId + " not found in namespace " + namespace,
 		})
 		return
 	}


### PR DESCRIPTION
## Purpose
> The Backend CR can only contain the hostname and the port of the backend. Not the full path

## Approach
> Extract base path from the backend endpoint and append to the path rewrite of the HTTPRoute
Fix bug in API undeploy resource in case where the given API id is not found.