### PR TITLE
Fix bugs in JWT provider creation and add tests

### DIFF
--- a/helm-charts/templates/data-plane/config-deployer/config-deploy-api-create-scope-policy.yaml
+++ b/helm-charts/templates/data-plane/config-deployer/config-deploy-api-create-scope-policy.yaml
@@ -43,13 +43,13 @@ spec:
       claimToHeaders:
         - claim: scope
           header: wso2-scope
-  # authorization:
-  #   rules:
-  #   - name: "api-create-rule"
-  #     action: Allow
-  #     principal:
-  #       jwt:
-  #         provider: {{ template "kubernetes-gateway-helm.resource.prefix" . }}-idp-jwt-issuer
-  #         scopes:
-  #         - apk:api_create
+  authorization:
+    rules:
+    - name: "api-create-rule"
+      action: Allow
+      principal:
+        jwt:
+          provider: {{ template "kubernetes-gateway-helm.resource.prefix" . }}-idp-jwt-issuer
+          scopes:
+          - apk:api_create
 {{- end -}}

--- a/helm-charts/templates/data-plane/config-deployer/config-ds-deployment.yaml
+++ b/helm-charts/templates/data-plane/config-deployer/config-ds-deployment.yaml
@@ -53,6 +53,8 @@ spec:
               protocol: "TCP"
             {{ end }}
 {{ include "kubernetes-gateway-helm.deployment.env" .Values.wso2.kgw.dp.configdeployer.deployment.env | indent 10 }}
+            - name: K8S_RELEASE_NAME
+              value: "{{ .Release.Name }}"
             {{ if and .Values.wso2.kgw.metrics .Values.wso2.kgw.metrics.enabled }}
             - name: METRICS_ENABLED
               value: "true"

--- a/test/cucumber-tests/src/test/resources/artifacts/apk-confs/employees_scope_test_conf_new.yaml
+++ b/test/cucumber-tests/src/test/resources/artifacts/apk-confs/employees_scope_test_conf_new.yaml
@@ -1,0 +1,29 @@
+---
+name: "EmployeeServiceScopeTestAPI"
+basePath: "/test-scope"
+id: "emp-api-test-scope"
+version: "1.0.0"
+type: "REST"
+defaultVersion: false
+endpointConfigurations:
+  production:
+    - endpoint: "https://httpbin.org/anything"
+operations:
+  - target: "/employeewithoutscope"
+    verb: "GET"
+    secured: true
+    scopes: []
+  - target: "/employeewithscope1"
+    verb: "GET"
+    secured: true
+    scopes:
+      - "scope1"
+  - target: "/employeewithscope2"
+    verb: "GET"
+    secured: true
+    scopes:
+      - "scope2"
+  - target: "/employeewithscopes"
+    verb: "GET"
+    secured: true
+    scopes: ["scope1", "scope2"]

--- a/test/cucumber-tests/src/test/resources/artifacts/definitions/employees_scope_test_api_new.json
+++ b/test/cucumber-tests/src/test/resources/artifacts/definitions/employees_scope_test_api_new.json
@@ -1,0 +1,104 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "EmployeeServiceScopeTestAPI",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://httpbin.org/anything",
+      "description": "Server URL",
+      "variables": {}
+    }
+  ],
+  "paths": {
+    "/employeewithscope": {
+      "get": {
+        "tags": [
+          "employee-controller"
+        ],
+        "operationId": "getEmployees",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "default response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Employee"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/employeewithoutscope": {
+      "get": {
+        "tags": [
+          "employee-controller"
+        ],
+        "operationId": "getEmployees",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "default response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Employee"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Employee": {
+        "type": "object",
+        "properties": {
+          "empId": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "designation": {
+            "type": "string"
+          },
+          "salary": {
+            "type": "number",
+            "format": "double"
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/cucumber-tests/src/test/resources/tests/api/BasicDeploymentAndApiInvocationNew.feature
+++ b/test/cucumber-tests/src/test/resources/tests/api/BasicDeploymentAndApiInvocationNew.feature
@@ -87,47 +87,47 @@ Feature: API Deployment and invocation
     And I send "DELETE" request to "https://default.gw.wso2.com:9095/test-default/employee/12" with body ""
     And the response status code should be 200
 
-  # Scenario: Scope Validation
-  #   Given The system is ready
-  #   And I have a valid subscription
-  #   When I use the APK Conf file "artifacts/apk-confs/employees_scope_test_conf.yaml"
-  #   And the definition file "artifacts/definitions/employees_scope_test_api.json"
-  #   And make the API deployment request
-  #   Then the response status code should be 200
-  #   Then I set headers
-  #     | Authorization | Bearer ${accessToken}         |
-  #     | Host          | carbon.super.gw.wso2.com      |
-  #   And I send "GET" request to "https://default.gw.wso2.com:9095/test-scope/1.0.0/employeewithoutscope/" with body ""
-  #   And I eventually receive 200 response code, not accepting
-  #     | 429 |
-  #   And I send "GET" request to "https://default.gw.wso2.com:9095/test-scope/1.0.0/employeewithscope1/" with body ""
-  #   And the response status code should be 403
-  #   Given I have a valid subscription with scopes
-  #     | scope1 |
-  #   Then I set headers
-  #     | Authorization | Bearer ${accessToken}         |
-  #     | Host          | carbon.super.gw.wso2.com      |
-  #   And I send "GET" request to "https://default.gw.wso2.com:9095/test-scope/1.0.0/employeewithoutscope/" with body ""
-  #   And I eventually receive 200 response code, not accepting
-  #     | 429 |
-  #   And I send "GET" request to "https://default.gw.wso2.com:9095/test-scope/1.0.0/employeewithscope1/" with body ""
-  #   And I eventually receive 200 response code, not accepting
-  #     | 429 |
-  #   And I send "GET" request to "https://default.gw.wso2.com:9095/test-scope/1.0.0/employeewithscope2/" with body ""
-  #   And I eventually receive 403 response code, not accepting
-  #     | 200 |
-  #   And I send "GET" request to "https://default.gw.wso2.com:9095/test-scope/1.0.0/employeewithscopes/" with body ""
-  #   And I eventually receive 403 response code, not accepting
-  #     | 429 |
-  #   Given I have a valid subscription with scopes
-  #     | scope1 |
-  #     | scope2 |
-  #   Then I set headers
-  #     | Authorization | Bearer ${accessToken}         |
-  #     | Host          | carbon.super.gw.wso2.com      |
-  #   And I send "GET" request to "https://default.gw.wso2.com:9095/test-scope/1.0.0/employeewithscopes/" with body ""
-  #   And I eventually receive 200 response code, not accepting
-  #     | 429 |
+  Scenario: Scope Validation
+    Given The system is ready
+    And I have a valid subscription
+    When I use the APK Conf file "artifacts/apk-confs/employees_scope_test_conf_new.yaml"
+    And the definition file "artifacts/definitions/employees_scope_test_api_new.json"
+    And make the API deployment request
+    Then the response status code should be 200
+    Then I set headers
+      | Authorization | Bearer ${accessToken}         |
+      | Host          | carbon.super.gw.wso2.com      |
+    And I send "GET" request to "https://default.gw.wso2.com:9095/test-scope/1.0.0/employeewithoutscope/" with body ""
+    And I eventually receive 200 response code, not accepting
+      | 429 |
+    And I send "GET" request to "https://default.gw.wso2.com:9095/test-scope/1.0.0/employeewithscope1/" with body ""
+    And the response status code should be 403
+    Given I have a valid subscription with scopes
+      | scope1 |
+    Then I set headers
+      | Authorization | Bearer ${accessToken}         |
+      | Host          | carbon.super.gw.wso2.com      |
+    And I send "GET" request to "https://default.gw.wso2.com:9095/test-scope/1.0.0/employeewithoutscope/" with body ""
+    And I eventually receive 200 response code, not accepting
+      | 429 |
+    And I send "GET" request to "https://default.gw.wso2.com:9095/test-scope/1.0.0/employeewithscope1/" with body ""
+    And I eventually receive 200 response code, not accepting
+      | 429 |
+    And I send "GET" request to "https://default.gw.wso2.com:9095/test-scope/1.0.0/employeewithscope2/" with body ""
+    And I eventually receive 403 response code, not accepting
+      | 200 |
+    And I send "GET" request to "https://default.gw.wso2.com:9095/test-scope/1.0.0/employeewithscopes/" with body ""
+    And I eventually receive 403 response code, not accepting
+      | 429 |
+    Given I have a valid subscription with scopes
+      | scope1 |
+      | scope2 |
+    Then I set headers
+      | Authorization | Bearer ${accessToken}         |
+      | Host          | carbon.super.gw.wso2.com      |
+    And I send "GET" request to "https://default.gw.wso2.com:9095/test-scope/1.0.0/employeewithscopes/" with body ""
+    And I eventually receive 200 response code, not accepting
+      | 429 |
 
 
   Scenario Outline: Undeploy API
@@ -140,6 +140,6 @@ Feature: API Deployment and invocation
       | apiID                                    | expectedStatusCode |
       | af081022ed421049c5db87e8cbce67d3477d8415 | 202                |
       | default-version-api-test                 | 202                |
-      # | emp-api-test-scope                       | 202                |
+      | emp-api-test-scope                       | 202                |
       | version-api-test                         | 202                |
       | version-api-test2                        | 202                |

--- a/test/cucumber-tests/src/test/resources/tests/api/deploymentNew.feature
+++ b/test/cucumber-tests/src/test/resources/tests/api/deploymentNew.feature
@@ -1,11 +1,11 @@
 Feature: API Deployment
-  # Scenario: Deploying an API without api create scope
-  #   Given The system is ready
-  #   And I have a valid subscription without api deploy permission
-  #   When I use the APK Conf file "artifacts/apk-confs/cors_API.apk-conf"
-  #   And the definition file "artifacts/definitions/cors_api.yaml"
-  #   And make the API deployment request
-  #   Then the response status code should be 403
+  Scenario: Deploying an API without api create scope
+    Given The system is ready
+    And I have a valid subscription without api deploy permission
+    When I use the APK Conf file "artifacts/apk-confs/cors_API.apk-conf"
+    And the definition file "artifacts/definitions/cors_api.yaml"
+    And make the API deployment request
+    Then the response status code should be 403
     
   Scenario: Deploying an API
     Given The system is ready
@@ -26,11 +26,11 @@ Feature: API Deployment
     And the response body should contain
       |APK configuration is not valid: invalid_type: Invalid type. Expected: boolean, given: string|
   
-  # Scenario Outline: Undeploy an API without api create scope
-  #   Given The system is ready
-  #   And I have a valid subscription without api deploy permission
-  #   When I undeploy the API whose ID is "<apiID>"
-  #   Then the response status code should be 403
+  Scenario Outline: Undeploy an API without api create scope
+    Given The system is ready
+    And I have a valid subscription without api deploy permission
+    When I undeploy the API whose ID is "<apiID>"
+    Then the response status code should be 403
 
   Scenario Outline: Undeploy an API
     Given The system is ready


### PR DESCRIPTION
## Purpose
> This PR fixes bugs in scope validation in security policy and adds integration tests

## Approach
> Enforce the validation of apk:api_create scope in the config deployer security policy.
Add the default in built IDP as a key manager if no kms are defined in apk conf. This fixes bugs in consequent steps in creating authorization specs.
Add cucumber integrations tests to verify the above changes and functionality.
