### PR TITLE
Add backend API key security

### DIFF
--- a/runtime/config-deployer-service-go/internal/constants/constants.go
+++ b/runtime/config-deployer-service-go/internal/constants/constants.go
@@ -157,3 +157,8 @@ const (
 
 	K8sMaxAnnotationLength = 10000
 )
+
+const (
+	BaseRoutePolicy       = "BaseRoutePolicy"
+	AIProviderRoutePolicy = "AIProviderRoutePolicy"
+)


### PR DESCRIPTION
## Purpose
> This PR enables backend API key in Config Deployer to support API key auth in backends.

## Approach
> Generate the BackendAPIKey and create the RoutePolicy CR.

Related to - https://github.com/wso2/apk/issues/3197

