### PR TITLE
Add backend API key tests

### DIFF
--- a/gateway/enforcer/internal/mediation/backend_api_key.go
+++ b/gateway/enforcer/internal/mediation/backend_api_key.go
@@ -4,6 +4,8 @@ import (
 	dpv2alpha1 "github.com/wso2/apk/common-go-libs/apis/dp/v2alpha1"
 	"github.com/wso2/apk/gateway/enforcer/internal/config"
 	"github.com/wso2/apk/gateway/enforcer/internal/requestconfig"
+
+	"strings"
 )
 
 // BackendAPIKey represents the configuration for Backend API Key policy in the API Gateway.
@@ -72,7 +74,7 @@ func (b *BackendAPIKey) Process(requestConfig *requestconfig.Holder) *Result {
 		b.cfg.Logger.Sugar().Debugf("Backend API Key policy is disabled. Skipping processing.")
 		return result
 	}
-	if b.In == "header" {
+	if strings.ToLower(b.In) == "header" {
 		result.AddHeaders[b.InValue] = b.APIKey
 	}
 	return result

--- a/test/cucumber-tests/src/test/resources/artifacts/apk-confs/backend_apikey_auth_conf_new.yaml
+++ b/test/cucumber-tests/src/test/resources/artifacts/apk-confs/backend_apikey_auth_conf_new.yaml
@@ -1,0 +1,42 @@
+---
+name: "BackendAPIKeySecurity"
+basePath: "/backend-api-key-security"
+version: "3.14"
+id: "backend-api-key-test"
+type: "REST"
+defaultVersion: true
+endpointConfigurations:
+  production:
+    - endpoint: "https://httpbin.org/anything"
+      endpointSecurity:
+        enabled: true
+        securityType:
+          secretName: "mysecret"
+          in: "Header"
+          apiKeyNameKey: "api-key"
+          apiKeyValueKey: "apiKey"
+operations:
+  - target: "/employee"
+    verb: "GET"
+    secured: true
+    scopes: []
+  - target: "/get"
+    verb: "GET"
+    secured: true
+    scopes: []
+  - target: "/post"
+    verb: "POST"
+    secured: true
+    scopes: []
+  - target: "/employee"
+    verb: "POST"
+    secured: true
+    scopes: []
+  - target: "/employee/{employeeId}"
+    verb: "PUT"
+    secured: true
+    scopes: []
+  - target: "/employee/{employeeId}"
+    verb: "DELETE"
+    secured: true
+    scopes: []

--- a/test/cucumber-tests/src/test/resources/artifacts/definitions/backend_apikey_auth_api_new.json
+++ b/test/cucumber-tests/src/test/resources/artifacts/definitions/backend_apikey_auth_api_new.json
@@ -1,0 +1,225 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "EmployeeServiceAPI",
+    "version": "3.14"
+  },
+  "servers": [
+    {
+      "url": "https://httpbin.org/anything",
+      "description": "Server URL",
+      "variables": {}
+    }
+  ],
+  "paths": {
+    "/employee": {
+      "get": {
+        "tags": [
+          "employee-controller"
+        ],
+        "operationId": "getEmployees",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "default response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Employee"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+
+      "post": {
+        "tags": [
+          "employee-controller"
+        ],
+        "operationId": "addEmployee",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Employee"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "default response",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/Employee"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/get": {
+      "get": {
+        "tags": [
+          "employee-controller"
+        ],
+        "operationId": "getEmployees",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "default response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Employee"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/post": {
+      "post": {
+        "tags": [
+          "employee-controller"
+        ],
+        "operationId": "getEmployees",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "default response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Employee"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/employee/{employeeId}": {
+      "put": {
+        "tags": [
+          "employee-controller"
+        ],
+        "operationId": "editEmployee",
+        "parameters": [
+          {
+            "name": "employeeId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "default response",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/Employee"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "employee-controller"
+        ],
+        "operationId": "deleteEmployee",
+        "parameters": [
+          {
+            "name": "employeeId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "default response",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/Employee"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Employee": {
+        "type": "object",
+        "properties": {
+          "empId": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "designation": {
+            "type": "string"
+          },
+          "salary": {
+            "type": "number",
+            "format": "double"
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/cucumber-tests/src/test/resources/tests/api/BackendAPIKeyAuthNew.feature
+++ b/test/cucumber-tests/src/test/resources/tests/api/BackendAPIKeyAuthNew.feature
@@ -1,0 +1,34 @@
+Feature: Backend API Key auth
+  Scenario: Testing API level Endpoint backend api key auth header
+    Given The system is ready
+    And I have a valid subscription
+    When I use the APK Conf file "artifacts/apk-confs/backend_apikey_auth_conf_new.yaml"
+    And the definition file "artifacts/definitions/backend_apikey_auth_api_new.json"
+    And make the API deployment request
+    Then the response status code should be 200
+    Then I set headers
+      |Authorization|Bearer ${accessToken}|
+    And I send "GET" request to "https://default.gw.wso2.com:9095/backend-api-key-security/3.14/employee/" with body ""
+    And I eventually receive 200 response code, not accepting
+      |429|
+    And the response body should contain "\"Api-Key\": \"sampath\""
+
+
+  Scenario Outline: Undeploy API
+    Given The system is ready
+    And I have a valid subscription
+    When I undeploy the API whose ID is "<apiID>"
+    Then the response status code should be <expectedStatusCode>
+
+    Examples:
+      | apiID                 | expectedStatusCode  |
+      | backend-api-key-test          | 202                 |
+
+  Scenario: Testing undeployed API
+    Given The system is ready
+    And I have a valid subscription
+    Then I set headers
+      | Authorization | Bearer ${accessToken} |
+    And I send "GET" request to "https://default.gw.wso2.com:9095/backend-api-key-security/3.14/employee/" with body ""
+    And I eventually receive 404 response code, not accepting
+      | 200 |


### PR DESCRIPTION
## Purpose
> Validate the backend API key security functionality.

## Approach
> Add cucumber integration tests to validate the backend API key is added to the backend request.
Improvement in processing backend API key in enforcer.

Related to: https://github.com/wso2/apk/issues/3197