### PR TITLE
Add WASM custom filters

### DIFF
--- a/runtime/config-deployer-service-go/internal/model/apk_conf.go
+++ b/runtime/config-deployer-service-go/internal/model/apk_conf.go
@@ -282,6 +282,7 @@ const (
 	PolicyNameBackendJWT           PolicyName = "BackendJwt"
 	PolicyNameInterceptor          PolicyName = "Interceptor"
 	PolicyLuaInterceptor           PolicyName = "LuaInterceptor"
+	PolicyWASMInterceptor          PolicyName = "WASMInterceptor"
 	PolicyNameAddHeader            PolicyName = "AddHeader"
 	PolicyNameSetHeader            PolicyName = "SetHeader"
 	PolicyNameRemoveHeader         PolicyName = "RemoveHeader"
@@ -318,6 +319,7 @@ type APKOperationPolicy interface {
 // APKRequestOperationPolicy represents request operation policies
 type APKRequestOperationPolicy struct {
 	LuaInterceptorPolicy       *LuaInterceptorPolicy       `json:"luaInterceptorPolicy,omitempty" yaml:"luaInterceptorPolicy,omitempty"`
+	WASMInterceptorPolicy      *WASMInterceptorPolicy      `json:"wasmInterceptorPolicy,omitempty" yaml:"wasmInterceptorPolicy,omitempty"`
 	InterceptorPolicy          *InterceptorPolicy          `json:"interceptorPolicy,omitempty" yaml:"interceptorPolicy,omitempty"`
 	BackendJWTPolicy           *BackendJWTPolicy           `json:"backendJWTPolicy,omitempty" yaml:"backendJWTPolicy,omitempty"`
 	HeaderModifierPolicy       *HeaderModifierPolicy       `json:"headerModifierPolicy,omitempty" yaml:"headerModifierPolicy,omitempty"`
@@ -328,10 +330,11 @@ type APKRequestOperationPolicy struct {
 
 // APKResponseOperationPolicy represents response operation policies
 type APKResponseOperationPolicy struct {
-	LuaInterceptorPolicy *LuaInterceptorPolicy `json:"luaInterceptorPolicy,omitempty" yaml:"luaInterceptorPolicy,omitempty"`
-	InterceptorPolicy    *InterceptorPolicy    `json:"interceptorPolicy,omitempty" yaml:"interceptorPolicy,omitempty"`
-	BackendJWTPolicy     *BackendJWTPolicy     `json:"backendJWTPolicy,omitempty" yaml:"backendJWTPolicy,omitempty"`
-	HeaderModifierPolicy *HeaderModifierPolicy `json:"headerModifierPolicy,omitempty" yaml:"headerModifierPolicy,omitempty"`
+	LuaInterceptorPolicy  *LuaInterceptorPolicy  `json:"luaInterceptorPolicy,omitempty" yaml:"luaInterceptorPolicy,omitempty"`
+	WASMInterceptorPolicy *WASMInterceptorPolicy `json:"wasmInterceptorPolicy,omitempty" yaml:"wasmInterceptorPolicy,omitempty"`
+	InterceptorPolicy     *InterceptorPolicy     `json:"interceptorPolicy,omitempty" yaml:"interceptorPolicy,omitempty"`
+	BackendJWTPolicy      *BackendJWTPolicy      `json:"backendJWTPolicy,omitempty" yaml:"backendJWTPolicy,omitempty"`
+	HeaderModifierPolicy  *HeaderModifierPolicy  `json:"headerModifierPolicy,omitempty" yaml:"headerModifierPolicy,omitempty"`
 }
 
 // GetPolicyName implements APKOperationPolicy interface
@@ -415,6 +418,24 @@ type LuaInterceptorPolicyParameters struct {
 	MountInConfigMap *bool   `json:"mountInConfigMap,omitempty" yaml:"mountInConfigMap,omitempty"`
 }
 
+// WASMInterceptorPolicy represents Lua interceptor policy configuration for an operation.
+type WASMInterceptorPolicy struct {
+	BaseOperationPolicy
+	Parameters *WASMInterceptorPolicyParameters `json:"parameters,omitempty" yaml:"parameters,omitempty"`
+}
+
+// WASMInterceptorPolicyParameters represents configuration for Lua Interceptor Policy parameters.
+type WASMInterceptorPolicyParameters struct {
+	Name            string   `json:"name" yaml:"name"`
+	RootID          string   `json:"rootId" yaml:"rootId"`
+	URL             *string  `json:"url,omitempty" yaml:"url,omitempty"`
+	Image           *string  `json:"image,omitempty" yaml:"image,omitempty"`
+	ImagePullPolicy *string  `json:"imagePullPolicy,omitempty" yaml:"imagePullPolicy,omitempty"`
+	Config          *string  `json:"config,omitempty" yaml:"config,omitempty"`
+	FailOpen        *bool    `json:"failOpen,omitempty" yaml:"failOpen,omitempty"`
+	HostKeys        []string `json:"hostKeys,omitempty" yaml:"hostKeys,omitempty"`
+}
+
 // BackendJWTPolicy represents configuration for Backend JWT Policy.
 type BackendJWTPolicy struct {
 	BaseOperationPolicy
@@ -470,6 +491,9 @@ func (p *APKRequestOperationPolicy) UnmarshalJSON(data []byte) error {
 	case PolicyLuaInterceptor:
 		p.LuaInterceptorPolicy = &LuaInterceptorPolicy{}
 		return json.Unmarshal(data, p.LuaInterceptorPolicy)
+	case PolicyWASMInterceptor:
+		p.WASMInterceptorPolicy = &WASMInterceptorPolicy{}
+		return json.Unmarshal(data, p.WASMInterceptorPolicy)
 	case PolicyNameInterceptor:
 		p.InterceptorPolicy = &InterceptorPolicy{}
 		return json.Unmarshal(data, p.InterceptorPolicy)
@@ -504,6 +528,9 @@ func (p *APKResponseOperationPolicy) UnmarshalJSON(data []byte) error {
 	case PolicyLuaInterceptor:
 		p.LuaInterceptorPolicy = &LuaInterceptorPolicy{}
 		return json.Unmarshal(data, p.LuaInterceptorPolicy)
+	case PolicyWASMInterceptor:
+		p.WASMInterceptorPolicy = &WASMInterceptorPolicy{}
+		return json.Unmarshal(data, p.WASMInterceptorPolicy)
 	case PolicyNameInterceptor:
 		p.InterceptorPolicy = &InterceptorPolicy{}
 		return json.Unmarshal(data, p.InterceptorPolicy)
@@ -522,6 +549,9 @@ func (p *APKResponseOperationPolicy) UnmarshalJSON(data []byte) error {
 func (p *APKRequestOperationPolicy) GetActivePolicy() APKOperationPolicy {
 	if p.LuaInterceptorPolicy != nil {
 		return p.LuaInterceptorPolicy
+	}
+	if p.WASMInterceptorPolicy != nil {
+		return p.WASMInterceptorPolicy
 	}
 	if p.InterceptorPolicy != nil {
 		return p.InterceptorPolicy
@@ -548,6 +578,9 @@ func (p *APKRequestOperationPolicy) GetActivePolicy() APKOperationPolicy {
 func (p *APKResponseOperationPolicy) GetActivePolicy() APKOperationPolicy {
 	if p.LuaInterceptorPolicy != nil {
 		return p.LuaInterceptorPolicy
+	}
+	if p.WASMInterceptorPolicy != nil {
+		return p.WASMInterceptorPolicy
 	}
 	if p.InterceptorPolicy != nil {
 		return p.InterceptorPolicy

--- a/runtime/config-deployer-service-go/internal/util/apkconf.go
+++ b/runtime/config-deployer-service-go/internal/util/apkconf.go
@@ -217,39 +217,63 @@ func generateGroupingKey(operation model.APKOperations) string {
 		keyParts = append(keyParts, "scopes:empty")
 	}
 
-	// handle operation.OperationPolicies.request and response LuaInterceptorPolicy differently
+	// handle operation.OperationPolicies.request and response Lua and WASM InterceptorPolicy
 	if operation.OperationPolicies != nil {
 		if len(operation.OperationPolicies.Request) > 0 {
 			var requestLuaInterceptorPolicyNames []string
+			var requestWASMInterceptorPolicyNames []string
 			for _, policy := range operation.OperationPolicies.Request {
 				if policy.LuaInterceptorPolicy != nil {
 					requestLuaInterceptorPolicyNames = append(requestLuaInterceptorPolicyNames,
 						policy.LuaInterceptorPolicy.Parameters.Name)
 				}
+				if policy.WASMInterceptorPolicy != nil {
+					requestWASMInterceptorPolicyNames = append(requestWASMInterceptorPolicyNames,
+						policy.WASMInterceptorPolicy.Parameters.Name)
+				}
 			}
 			sort.Strings(requestLuaInterceptorPolicyNames)
+			sort.Strings(requestWASMInterceptorPolicyNames)
 			if len(requestLuaInterceptorPolicyNames) > 0 {
 				keyParts = append(keyParts, fmt.Sprintf("requestLuaInterceptorPolicyNames:%s",
 					strings.Join(requestLuaInterceptorPolicyNames, ",")))
 			} else {
 				keyParts = append(keyParts, "requestLuaInterceptorPolicyNames:empty")
 			}
+			if len(requestWASMInterceptorPolicyNames) > 0 {
+				keyParts = append(keyParts, fmt.Sprintf("requestWASMInterceptorPolicyNames:%s",
+					strings.Join(requestWASMInterceptorPolicyNames, ",")))
+			} else {
+				keyParts = append(keyParts, "requestWASMInterceptorPolicyNames:empty")
+			}
 		}
 
 		if len(operation.OperationPolicies.Response) > 0 {
 			var responseLuaInterceptorPolicyNames []string
+			var responseWASMInterceptorPolicyNames []string
 			for _, policy := range operation.OperationPolicies.Response {
 				if policy.LuaInterceptorPolicy != nil {
 					responseLuaInterceptorPolicyNames = append(responseLuaInterceptorPolicyNames,
 						policy.LuaInterceptorPolicy.Parameters.Name)
 				}
+				if policy.WASMInterceptorPolicy != nil {
+					responseWASMInterceptorPolicyNames = append(responseWASMInterceptorPolicyNames,
+						policy.WASMInterceptorPolicy.Parameters.Name)
+				}
 			}
 			sort.Strings(responseLuaInterceptorPolicyNames)
+			sort.Strings(responseWASMInterceptorPolicyNames)
 			if len(responseLuaInterceptorPolicyNames) > 0 {
 				keyParts = append(keyParts, fmt.Sprintf("responseLuaInterceptorPolicyNames:%s",
 					strings.Join(responseLuaInterceptorPolicyNames, ",")))
 			} else {
 				keyParts = append(keyParts, "responseLuaInterceptorPolicyNames:empty")
+			}
+			if len(responseWASMInterceptorPolicyNames) > 0 {
+				keyParts = append(keyParts, fmt.Sprintf("responseWASMInterceptorPolicyNames:%s",
+					strings.Join(responseWASMInterceptorPolicyNames, ",")))
+			} else {
+				keyParts = append(keyParts, "responseWASMInterceptorPolicyNames:empty")
 			}
 		}
 	}

--- a/runtime/config-deployer-service-go/resources/conf/apk-schema.json
+++ b/runtime/config-deployer-service-go/resources/conf/apk-schema.json
@@ -386,6 +386,7 @@
             "SetHeader",
             "Interceptor",
             "LuaInterceptor",
+            "WASMInterceptor",
             "BackendJwt",
             "RequestMirror",
             "RequestRedirect",
@@ -409,6 +410,9 @@
             },
             {
               "$ref": "#/schemas/LuaInterceptorProperties"
+            },
+            {
+              "$ref": "#/schemas/WASMInterceptorProperties"
             },
             {
               "$ref": "#/schemas/BackendJWTProperties"
@@ -446,6 +450,7 @@
             "SetHeader",
             "Interceptor",
             "LuaInterceptor",
+            "WASMInterceptor",
             "BackendJwt"
           ]
         },
@@ -466,6 +471,9 @@
             },
             {
               "$ref": "#/schemas/LuaInterceptorProperties"
+            },
+            {
+              "$ref": "#/schemas/WASMInterceptorProperties"
             },
             {
               "$ref": "#/schemas/BackendJWTProperties"
@@ -941,6 +949,49 @@
       "anyOf": [
         { "required": ["sourceCode"] },
         { "required": ["sourceCodeRef"] }
+      ],
+      "additionalProperties": false
+    },
+    "WASMInterceptorProperties": {
+      "title": "WASM Interceptor Parameters",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "rootId": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        },
+        "image": {
+          "type": "string"
+        },
+        "imagePullPolicy": {
+          "type": "string",
+          "enum": ["IfNotPresent", "Always"]
+        },
+        "config": {
+          "type": "string"
+        },
+        "failOpen": {
+          "type": "boolean"
+        },
+        "hostKeys": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "name",
+        "rootId"
+      ],
+      "anyOf": [
+        { "required": ["url"] },
+        { "required": ["image"] }
       ],
       "additionalProperties": false
     },

--- a/runtime/runtime-ui/schema/apk-conf.yaml
+++ b/runtime/runtime-ui/schema/apk-conf.yaml
@@ -291,6 +291,7 @@ schemas:
           - SetHeader
           - Interceptor
           - LuaInterceptor
+          - WASMInterceptor
           - BackendJwt
           - RequestMirror
           - RequestRedirect
@@ -307,6 +308,7 @@ schemas:
         oneOf:
           - "$ref": "#/schemas/InterceptorProperties"
           - "$ref": "#/schemas/LuaInterceptorProperties"
+          - "$ref": "#/schemas/WASMInterceptorProperties"
           - "$ref": "#/schemas/BackendJWTProperties"
           - "$ref": "#/schemas/HeaderModifierProperties"
           - "$ref": "#/schemas/RequestMirrorProperties"
@@ -328,6 +330,7 @@ schemas:
           - SetHeader
           - Interceptor
           - LuaInterceptor
+          - WASMInterceptor
           - BackendJwt
       policyVersion:
         type: string
@@ -341,6 +344,7 @@ schemas:
         oneOf:
           - "$ref": "#/schemas/InterceptorProperties"
           - "$ref": "#/schemas/LuaInterceptorProperties"
+          - "$ref": "#/schemas/WASMInterceptorProperties"
           - "$ref": "#/schemas/BackendJWTProperties"
           - "$ref": "#/schemas/HeaderModifierProperties"
     additionalProperties: false
@@ -693,6 +697,40 @@ schemas:
         type: boolean
     required:
       - name
+    additionalProperties: false
+  WASMInterceptorProperties:
+    title: WASM Interceptor Parameters
+    type: object
+    properties:
+      name:
+        type: string
+      rootId:
+        type: string
+      url:
+        type: string
+      image:
+        type: string
+      imagePullPolicy:
+        type: string
+        enum:
+          - IfNotPresent
+          - Always
+      config:
+        type: string
+      failOpen:
+        type: boolean
+      hostKeys:
+        type: array
+        items:
+          type: string
+    required:
+      - name
+      - rootId
+    anyOf:
+      - required:
+          - url
+      - required:
+          - image
     additionalProperties: false
   ModelBasedRoundRobinProperties:
     title: "Model Based Round Robin Policy Parameters"

--- a/runtime/runtime-ui/schema/apk-schema.json
+++ b/runtime/runtime-ui/schema/apk-schema.json
@@ -386,6 +386,7 @@
             "SetHeader",
             "Interceptor",
             "LuaInterceptor",
+            "WASMInterceptor",
             "BackendJwt",
             "RequestMirror",
             "RequestRedirect",
@@ -409,6 +410,9 @@
             },
             {
               "$ref": "#/schemas/LuaInterceptorProperties"
+            },
+            {
+              "$ref": "#/schemas/WASMInterceptorProperties"
             },
             {
               "$ref": "#/schemas/BackendJWTProperties"
@@ -446,6 +450,7 @@
             "SetHeader",
             "Interceptor",
             "LuaInterceptor",
+            "WASMInterceptor",
             "BackendJwt"
           ]
         },
@@ -466,6 +471,9 @@
             },
             {
               "$ref": "#/schemas/LuaInterceptorProperties"
+            },
+            {
+              "$ref": "#/schemas/WASMInterceptorProperties"
             },
             {
               "$ref": "#/schemas/BackendJWTProperties"
@@ -941,6 +949,49 @@
       "anyOf": [
         { "required": ["sourceCode"] },
         { "required": ["sourceCodeRef"] }
+      ],
+      "additionalProperties": false
+    },
+    "WASMInterceptorProperties": {
+      "title": "WASM Interceptor Parameters",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "rootId": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        },
+        "image": {
+          "type": "string"
+        },
+        "imagePullPolicy": {
+          "type": "string",
+          "enum": ["IfNotPresent", "Always"]
+        },
+        "config": {
+          "type": "string"
+        },
+        "failOpen": {
+          "type": "boolean"
+        },
+        "hostKeys": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "name",
+        "rootId"
+      ],
+      "anyOf": [
+        { "required": ["url"] },
+        { "required": ["image"] }
       ],
       "additionalProperties": false
     },


### PR DESCRIPTION
## Purpose
> Enable WASM policies to be applied as interceptors to inject custom logic.

## Approach
> Create EnvoyGatewayExtensionPolicies for the filters and attach them to the HTTPRoutes.

Related to - https://github.com/wso2/apk/issues/3207