### PR TITLE
Add CR generation for AI guardrail policies

### DIFF
--- a/common-go-libs/constants/constant.go
+++ b/common-go-libs/constants/constant.go
@@ -204,3 +204,8 @@ const (
 	// LabelKGWCPInitiated is the label key for indicating if the KGW was initiated by the control plane.
 	LabelKGWCPInitiated = "kgw.wso2.com/cpInitiated"
 )
+
+const (
+	DIRECTION_REQUEST  = "Request"
+	DIRECTION_RESPONSE = "Response"
+)

--- a/runtime/config-deployer-service-go/resources/conf/apk-schema.json
+++ b/runtime/config-deployer-service-go/resources/conf/apk-schema.json
@@ -389,7 +389,13 @@
             "BackendJwt",
             "RequestMirror",
             "RequestRedirect",
-            "ModelBasedRoundRobin"
+            "ModelBasedRoundRobin",
+            "WordCountGuardrail",
+            "SentenceCountGuardrail",
+            "ContentLengthGuardrail",
+            "PIIMaskingGuardrail",
+            "URLGuardrail",
+            "RegexGuardrail"
           ]
         },
         "policyVersion": {
@@ -402,7 +408,6 @@
           "description": "The ID of the operation policy."
         },
         "parameters": {
-          "type": "object",
           "oneOf": [
             {
               "$ref": "#/schemas/LuaInterceptorProperties"
@@ -424,6 +429,9 @@
             },
             {
               "$ref": "#/schemas/ModelBasedRoundRobinProperties"
+            },
+            {
+              "$ref": "#/schemas/CommonPolicyProperties"
             }
           ]
         }
@@ -445,7 +453,13 @@
             "RemoveHeader",
             "SetHeader",
             "LuaInterceptor",
-            "WASMInterceptor"
+            "WASMInterceptor",
+            "WordCountGuardrail",
+            "SentenceCountGuardrail",
+            "ContentLengthGuardrail",
+            "PIIMaskingGuardrail",
+            "URLGuardrail",
+            "RegexGuardrail"
           ]
         },
         "policyVersion": {
@@ -458,7 +472,6 @@
           "description": "The ID of the operation policy."
         },
         "parameters": {
-          "type": "object",
           "oneOf": [
             {
               "$ref": "#/schemas/LuaInterceptorProperties"
@@ -468,6 +481,9 @@
             },
             {
               "$ref": "#/schemas/HeaderModifierProperties"
+            },
+            {
+              "$ref": "#/schemas/CommonPolicyProperties"
             }
           ]
         }
@@ -1095,6 +1111,32 @@
           "type": "string"
         }
       },
+      "additionalProperties": false
+    },
+    "CommonPolicyProperties": {
+      "title": "Common Policy Parameters",
+      "type": "array",
+      "items": {
+        "$ref": "#/schemas/CommonPolicy_parameter"
+      }
+    },
+    "CommonPolicy_parameter": {
+      "title": "Common Policy Parameter",
+      "type": "object",
+      "properties": {
+        "key": {
+          "type": "string",
+          "description": "The key of the parameter."
+        },
+        "value": {
+          "type": "string",
+          "description": "The value of the parameter."
+        }
+      },
+      "required": [
+        "key",
+        "value"
+      ],
       "additionalProperties": false
     },
     "KeyManager": {

--- a/runtime/runtime-ui/schema/apk-conf.yaml
+++ b/runtime/runtime-ui/schema/apk-conf.yaml
@@ -295,6 +295,12 @@ schemas:
           - RequestMirror
           - RequestRedirect
           - ModelBasedRoundRobin
+          - WordCountGuardrail
+          - SentenceCountGuardrail
+          - ContentLengthGuardrail
+          - PIIMaskingGuardrail
+          - URLGuardrail
+          - RegexGuardrail
       policyVersion:
         type: string
         default: v1
@@ -303,7 +309,6 @@ schemas:
         type: string
         description: The ID of the operation policy.
       parameters:
-        type: object
         oneOf:
           - "$ref": "#/schemas/LuaInterceptorProperties"
           - "$ref": "#/schemas/WASMInterceptorProperties"
@@ -312,6 +317,7 @@ schemas:
           - "$ref": "#/schemas/RequestMirrorProperties"
           - "$ref": "#/schemas/RequestRedirectProperties"
           - "$ref": "#/schemas/ModelBasedRoundRobinProperties"
+          - "$ref": "#/schemas/CommonPolicyProperties"
     additionalProperties: false
   APKResponseOperationPolicy:
     title: API Operation Policy
@@ -328,6 +334,12 @@ schemas:
           - SetHeader
           - LuaInterceptor
           - WASMInterceptor
+          - WordCountGuardrail
+          - SentenceCountGuardrail
+          - ContentLengthGuardrail
+          - PIIMaskingGuardrail
+          - URLGuardrail
+          - RegexGuardrail
       policyVersion:
         type: string
         default: v1
@@ -336,11 +348,11 @@ schemas:
         type: string
         description: The ID of the operation policy.
       parameters:
-        type: object
         oneOf:
           - "$ref": "#/schemas/LuaInterceptorProperties"
           - "$ref": "#/schemas/WASMInterceptorProperties"
           - "$ref": "#/schemas/HeaderModifierProperties"
+          - "$ref": "#/schemas/CommonPolicyProperties"
     additionalProperties: false
   HeaderModifierProperties:
     title: Header Modifier Parameters
@@ -773,6 +785,25 @@ schemas:
       type:
         type: string
         default: string
+    additionalProperties: false
+  CommonPolicyProperties:
+    title: Common Policy Parameters
+    type: array
+    items:
+      "$ref": "#/schemas/CommonPolicy_parameter"
+  CommonPolicy_parameter:
+    title: Common Policy Parameter
+    type: object
+    properties:
+      key:
+        type: string
+        description: The key of the parameter.
+      value:
+        type: string
+        description: The value of the parameter.
+    required:
+      - key
+      - value
     additionalProperties: false
   KeyManager:
     type: object

--- a/runtime/runtime-ui/schema/apk-schema.json
+++ b/runtime/runtime-ui/schema/apk-schema.json
@@ -389,7 +389,13 @@
             "BackendJwt",
             "RequestMirror",
             "RequestRedirect",
-            "ModelBasedRoundRobin"
+            "ModelBasedRoundRobin",
+            "WordCountGuardrail",
+            "SentenceCountGuardrail",
+            "ContentLengthGuardrail",
+            "PIIMaskingGuardrail",
+            "URLGuardrail",
+            "RegexGuardrail"
           ]
         },
         "policyVersion": {
@@ -402,7 +408,6 @@
           "description": "The ID of the operation policy."
         },
         "parameters": {
-          "type": "object",
           "oneOf": [
             {
               "$ref": "#/schemas/LuaInterceptorProperties"
@@ -424,6 +429,9 @@
             },
             {
               "$ref": "#/schemas/ModelBasedRoundRobinProperties"
+            },
+            {
+              "$ref": "#/schemas/CommonPolicyProperties"
             }
           ]
         }
@@ -445,7 +453,13 @@
             "RemoveHeader",
             "SetHeader",
             "LuaInterceptor",
-            "WASMInterceptor"
+            "WASMInterceptor",
+            "WordCountGuardrail",
+            "SentenceCountGuardrail",
+            "ContentLengthGuardrail",
+            "PIIMaskingGuardrail",
+            "URLGuardrail",
+            "RegexGuardrail"
           ]
         },
         "policyVersion": {
@@ -458,7 +472,6 @@
           "description": "The ID of the operation policy."
         },
         "parameters": {
-          "type": "object",
           "oneOf": [
             {
               "$ref": "#/schemas/LuaInterceptorProperties"
@@ -468,6 +481,9 @@
             },
             {
               "$ref": "#/schemas/HeaderModifierProperties"
+            },
+            {
+              "$ref": "#/schemas/CommonPolicyProperties"
             }
           ]
         }
@@ -1095,6 +1111,32 @@
           "type": "string"
         }
       },
+      "additionalProperties": false
+    },
+    "CommonPolicyProperties": {
+      "title": "Common Policy Parameters",
+      "type": "array",
+      "items": {
+        "$ref": "#/schemas/CommonPolicy_parameter"
+      }
+    },
+    "CommonPolicy_parameter": {
+      "title": "Common Policy Parameter",
+      "type": "object",
+      "properties": {
+        "key": {
+          "type": "string",
+          "description": "The key of the parameter."
+        },
+        "value": {
+          "type": "string",
+          "description": "The value of the parameter."
+        }
+      },
+      "required": [
+        "key",
+        "value"
+      ],
       "additionalProperties": false
     },
     "KeyManager": {


### PR DESCRIPTION
## Purpose
> This pull request adds support for AI Guardrail policies to the API gateway configuration. The changes ensure that AI Guardrail policies are properly recognized, parsed, and deployed as part of the gateway's route policies.

Related to - https://github.com/wso2/apk/issues/3232

## Approach
> Introduce new policy types for both request and response operations, update the schema and model definitions to handle these policies, and implements logic for generating and processing AI Guardrail policies. 

* Added new AI Guardrail policy types (`WordCountGuardrail`, `SentenceCountGuardrail`, `ContentLengthGuardrail`, `PIIMaskingGuardrail`, `URLGuardrail`, `RegexGuardrail`) to the model (`apk_conf.go`), JSON schema (`apk-schema.json`), and YAML schema (`apk-conf.yaml`). [[1]](diffhunk://#diff-815d7d357fa0a68999ec9086eac562e9a5f4ec864a265d95c7d2656d96f7268aR291-R296) [[2]](diffhunk://#diff-6c761801619842c67aadb881277f1c1efbe7b88cb9e91f961f851345a74cdf56L392-R398) [[3]](diffhunk://#diff-6c761801619842c67aadb881277f1c1efbe7b88cb9e91f961f851345a74cdf56L448-R462) [[4]](diffhunk://#diff-e60b40938275c2a4e74080d14331e69f286062bef2b94b4ef49fc159bd9ad7e9R298-R303)
* Defined `CommonPolicy` and `CommonPolicyParameters` structs for representing AI Guardrail policies and their parameters in the model. [[1]](diffhunk://#diff-815d7d357fa0a68999ec9086eac562e9a5f4ec864a265d95c7d2656d96f7268aL453-L457) [[2]](diffhunk://#diff-6c761801619842c67aadb881277f1c1efbe7b88cb9e91f961f851345a74cdf56R1116-R1141)

* Updated unmarshalling logic to recognize and parse AI Guardrail policies for both request and response operations, and included them in the active policy selection. [[1]](diffhunk://#diff-815d7d357fa0a68999ec9086eac562e9a5f4ec864a265d95c7d2656d96f7268aR511-R514) [[2]](diffhunk://#diff-815d7d357fa0a68999ec9086eac562e9a5f4ec864a265d95c7d2656d96f7268aR537-R540) [[3]](diffhunk://#diff-815d7d357fa0a68999ec9086eac562e9a5f4ec864a265d95c7d2656d96f7268aR569-R571) [[4]](diffhunk://#diff-815d7d357fa0a68999ec9086eac562e9a5f4ec864a265d95c7d2656d96f7268aR586-R588)
* Extended the request and response operation policy structs to include an `AIGuardrailPolicy` field.

* Implemented the `generateAIGuardrailPolicy` function to create route policies for AI Guardrail, handling both request and response directions. Integrated this logic into the HTTP route generation process. [[1]](diffhunk://#diff-e513b681326315506a1e4f13ed3c8bba48a5b0b2c921c21aa5cd72df6cbacc06R1033-R1036) [[2]](diffhunk://#diff-e513b681326315506a1e4f13ed3c8bba48a5b0b2c921c21aa5cd72df6cbacc06R1066-R1069) [[3]](diffhunk://#diff-e513b681326315506a1e4f13ed3c8bba48a5b0b2c921c21aa5cd72df6cbacc06R2522-R2582)

* Updated utility functions to process and include AI Guardrail policy names in key generation for operations, ensuring proper identification and grouping. [[1]](diffhunk://#diff-0de22a429144544812a82415950b2c1bb30ae93e96dc1500b0c293d3066b04d1R269-R272) [[2]](diffhunk://#diff-0de22a429144544812a82415950b2c1bb30ae93e96dc1500b0c293d3066b04d1R294-R297) [[3]](diffhunk://#diff-0de22a429144544812a82415950b2c1bb30ae93e96dc1500b0c293d3066b04d1L309-R323) [[4]](diffhunk://#diff-0de22a429144544812a82415950b2c1bb30ae93e96dc1500b0c293d3066b04d1L234-R243)

### Schema Changes

* Modified both the JSON and YAML schemas to support AI Guardrail policy parameters by adding the `CommonPolicyProperties` definition and referencing it in the operation policy parameter lists. [[1]](diffhunk://#diff-6c761801619842c67aadb881277f1c1efbe7b88cb9e91f961f851345a74cdf56R432-R434) [[2]](diffhunk://#diff-6c761801619842c67aadb881277f1c1efbe7b88cb9e91f961f851345a74cdf56R484-R486) [[3]](diffhunk://#diff-6c761801619842c67aadb881277f1c1efbe7b88cb9e91f961f851345a74cdf56R1116-R1141) [[4]](diffhunk://#diff-e60b40938275c2a4e74080d14331e69f286062bef2b94b4ef49fc159bd9ad7e9R320)

These changes collectively enable the API gateway to support, configure, and deploy AI Guardrail policies for enhanced request and response mediation.
