### PR TITLE
Enable basic auth for backend endpoint security

### DIFF
--- a/common-go-libs/constants/constant.go
+++ b/common-go-libs/constants/constant.go
@@ -208,6 +208,6 @@ const (
 )
 
 const (
-	DIRECTION_REQUEST  = "Request"
-	DIRECTION_RESPONSE = "Response"
+	REQUEST_FLOW  = "Request"
+	RESPONSE_FLOW = "Response"
 )

--- a/common-go-libs/constants/constant.go
+++ b/common-go-libs/constants/constant.go
@@ -158,6 +158,8 @@ const (
 	MediationAITokenRatelimit = "AITokenRatelimit"
 	// MediationAIProvider holds the name of the AI Provider mediation policy.
 	MediationAIProvider = "AIProvider"
+	// MediationBackendBasicSecurity holds the name of the Backend Basic Auth mediation policy.
+	MediationBackendBasicSecurity = "BackendBasicAuth"
 	// MediationBackendAPIKey holds the name of the Backend API Key mediation policy.
 	MediationBackendAPIKey = "BackendAPIKey"
 	// MediationWordCountGuardrail holds the name of the Word Count Guardrail mediation policy.

--- a/runtime/config-deployer-service-go/internal/crbuilder/builder.go
+++ b/runtime/config-deployer-service-go/internal/crbuilder/builder.go
@@ -919,8 +919,22 @@ func GenerateHTTPRoutes(bundle *dto.APIResourceBundle, withVersion bool, environ
 					endpointSecurityType, _ := securityType(ec.EndpointSecurity.SecurityType)
 					switch endpointSecurityType {
 					case securityTypeBasic:
-						// Handle Basic endpoint security
-						// Access fields: securityType.UserNameKey, securityType.PasswordKey
+						basicSecurity, ok := ec.EndpointSecurity.SecurityType.(*model.BasicEndpointSecurity)
+						if !ok {
+							if securityMap, mapOk := ec.EndpointSecurity.SecurityType.(map[string]interface{}); mapOk {
+								basicSecurity = convertMapToBasicEndpointSecurity(securityMap)
+							} else {
+								logger.Sugar().Errorf("Failed to convert endpoint security to BasicEndpointSecurity for endpoint %v", ec.Endpoint)
+								continue
+							}
+						}
+						uniqueHash := generateBasicSecurityHash(basicSecurity)
+						if routePoliciesL[uniqueHash] == nil {
+							basicSecurityPolicy := createBasicEndpointSecurityMediationPolicy(uniqueHash, ec.EndpointSecurity, basicSecurity)
+							routePoliciesL[uniqueHash] = basicSecurityPolicy
+							objects = append(objects, basicSecurityPolicy)
+						}
+						delete(routePoliciesL, constants.BaseRoutePolicy)
 					case securityTypeAPIKey:
 						apiKeySecurity, ok := ec.EndpointSecurity.SecurityType.(*model.APIKeyEndpointSecurity)
 						if !ok {
@@ -2228,6 +2242,98 @@ func securityType(securityType interface{}) (string, error) {
 		}
 		return "", fmt.Errorf("unsupported security type: %T", securityType)
 	}
+}
+
+// convertMapToBasicEndpointSecurity converts a map representation of BasicEndpointSecurity to the struct.
+func convertMapToBasicEndpointSecurity(securityMap map[string]interface{}) *model.BasicEndpointSecurity {
+	basicSecurity := &model.BasicEndpointSecurity{}
+
+	if secretName, exists := securityMap["secretName"]; exists {
+		if secretNameStr, ok := secretName.(string); ok {
+			basicSecurity.SecretName = secretNameStr
+		}
+	}
+
+	if userNameKey, exists := securityMap["userNameKey"]; exists {
+		if apiKeyNameKeyStr, ok := userNameKey.(string); ok {
+			basicSecurity.UserNameKey = apiKeyNameKeyStr
+		}
+	}
+
+	if passwordKey, exists := securityMap["passwordKey"]; exists {
+		if apiKeyValueKeyStr, ok := passwordKey.(string); ok {
+			basicSecurity.PasswordKey = apiKeyValueKeyStr
+		}
+	}
+
+	return basicSecurity
+}
+
+// generateBasicSecurityHash generates a SHA256 hash for the given APIKeyEndpointSecurity configuration.
+func generateBasicSecurityHash(apiKeySecurity *model.BasicEndpointSecurity) string {
+	if apiKeySecurity == nil {
+		return ""
+	}
+
+	// Concatenate all fields in a consistent order
+	hashInput := fmt.Sprintf("%s|%s|%s",
+		apiKeySecurity.SecretName,
+		apiKeySecurity.UserNameKey,
+		apiKeySecurity.PasswordKey,
+	)
+
+	// Generate SHA256 hash
+	hasher := sha256.New()
+	hasher.Write([]byte(hashInput))
+	hashBytes := hasher.Sum(nil)
+
+	// Return hex encoded hash
+	return hex.EncodeToString(hashBytes)
+}
+
+// createBasicEndpointSecurityMediationPolicy creates a Mediation policy for API Key security.
+func createBasicEndpointSecurityMediationPolicy(name string, endpointSecurity *model.EndpointSecurity,
+	basicSecurity *model.BasicEndpointSecurity) *dpv2alpha1.RoutePolicy {
+	basicAuthMediationPolicy := &dpv2alpha1.Mediation{
+		PolicyName:    constantscommon.MediationBackendBasicSecurity,
+		PolicyID:      "",
+		PolicyVersion: "",
+		Parameters: []*dpv2alpha1.Parameter{
+			{
+				Key:   "Enabled",
+				Value: strconv.FormatBool(*endpointSecurity.Enabled),
+			},
+			{
+				Key:   "UserNameKey",
+				Value: basicSecurity.UserNameKey,
+			},
+			{
+				Key:   "PasswordKey",
+				Value: basicSecurity.PasswordKey,
+			},
+			{
+				Key: "BasicAuth",
+				ValueRef: &gwapiv1a2.LocalObjectReference{
+					Name: gwapiv1a2.ObjectName(basicSecurity.SecretName),
+					Kind: constantscommon.KindSecret,
+				},
+			},
+		},
+	}
+	routePolicy := &dpv2alpha1.RoutePolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind:       constants.WSO2KubernetesGatewayRoutePolicyKind,
+			APIVersion: constants.WSO2KubernetesGatewayRoutePolicyAPIVersion,
+		},
+		Spec: dpv2alpha1.RoutePolicySpec{
+			RequestMediation:  []*dpv2alpha1.Mediation{basicAuthMediationPolicy},
+			ResponseMediation: make([]*dpv2alpha1.Mediation, 0),
+		},
+	}
+	return routePolicy
 }
 
 // convertMapToAPIKeyEndpointSecurity converts a map representation of APIKeyEndpointSecurity to the struct.

--- a/runtime/config-deployer-service-go/internal/crbuilder/builder.go
+++ b/runtime/config-deployer-service-go/internal/crbuilder/builder.go
@@ -1045,7 +1045,7 @@ func GenerateHTTPRoutes(bundle *dto.APIResourceBundle, withVersion bool, environ
 								routePoliciesL[modelBasedRoundRobinPolicy.Name] = modelBasedRoundRobinPolicy
 								objects = append(objects, modelBasedRoundRobinPolicy)
 							case *model.CommonPolicy:
-								aiGuardrailPolicy := generateAIGuardrailPolicy(policy, constantscommon.DIRECTION_REQUEST)
+								aiGuardrailPolicy := generateAIGuardrailPolicy(policy, constantscommon.REQUEST_FLOW)
 								routePoliciesL[aiGuardrailPolicy.Name] = aiGuardrailPolicy
 								objects = append(objects, aiGuardrailPolicy)
 							}
@@ -1078,7 +1078,7 @@ func GenerateHTTPRoutes(bundle *dto.APIResourceBundle, withVersion bool, environ
 							case *model.LuaInterceptorPolicy, *model.WASMInterceptorPolicy:
 								interceptorPolicyList = append(interceptorPolicyList, &policy)
 							case *model.CommonPolicy:
-								aiGuardrailPolicy := generateAIGuardrailPolicy(policy, constantscommon.DIRECTION_RESPONSE)
+								aiGuardrailPolicy := generateAIGuardrailPolicy(policy, constantscommon.RESPONSE_FLOW)
 								routePoliciesL[aiGuardrailPolicy.Name] = aiGuardrailPolicy
 								objects = append(objects, aiGuardrailPolicy)
 							}
@@ -2643,7 +2643,7 @@ func generateAIGuardrailPolicy(policy *model.CommonPolicy, direction string) *dp
 	}
 	name := util.GeneratePolicyHash(policy)
 	var requestMediation, responseMediation []*dpv2alpha1.Mediation
-	if direction == constantscommon.DIRECTION_REQUEST {
+	if direction == constantscommon.REQUEST_FLOW {
 		requestMediation = []*dpv2alpha1.Mediation{aiGuardrailPolicy}
 		responseMediation = make([]*dpv2alpha1.Mediation, 0)
 	} else {

--- a/runtime/config-deployer-service-go/internal/util/apkconf.go
+++ b/runtime/config-deployer-service-go/internal/util/apkconf.go
@@ -234,13 +234,13 @@ func ProcessOperationPolicies(operation *model.APKOperations) []string {
 
 	if len(operation.OperationPolicies.Request) > 0 {
 		requestPolicyNames := extractRequestPolicyNames(operation.OperationPolicies.Request)
-		requestKeyParts := buildKeyParts(requestPolicyNames, constantscommon.DIRECTION_REQUEST)
+		requestKeyParts := buildKeyParts(requestPolicyNames, constantscommon.REQUEST_FLOW)
 		allKeyParts = append(allKeyParts, requestKeyParts...)
 	}
 
 	if len(operation.OperationPolicies.Response) > 0 {
 		responsePolicyNames := extractResponsePolicyNames(operation.OperationPolicies.Response)
-		responseKeyParts := buildKeyParts(responsePolicyNames, constantscommon.DIRECTION_RESPONSE)
+		responseKeyParts := buildKeyParts(responsePolicyNames, constantscommon.RESPONSE_FLOW)
 		allKeyParts = append(allKeyParts, responseKeyParts...)
 	}
 

--- a/test/cucumber-tests/src/test/resources/artifacts/apk-confs/basic_auth_conf.yaml
+++ b/test/cucumber-tests/src/test/resources/artifacts/apk-confs/basic_auth_conf.yaml
@@ -7,7 +7,7 @@ type: "REST"
 defaultVersion: true
 endpointConfigurations:
   production:
-    - endpoint: "http://backend:80/anything"
+    - endpoint: "http://backend.apk-integration-test.svc.cluster.local:80/anything"
       endpointSecurity:
         enabled: true
         securityType:
@@ -25,7 +25,7 @@ operations:
     scopes: []
     endpointConfigurations:
       production:
-        - endpoint: "http://backend:80/anything/test"
+        - endpoint: "http://backend.apk-integration-test.svc.cluster.local:80/anything"
           endpointSecurity:
             enabled: true
             securityType:

--- a/test/cucumber-tests/src/test/resources/artifacts/definitions/basic_auth_api.json
+++ b/test/cucumber-tests/src/test/resources/artifacts/definitions/basic_auth_api.json
@@ -6,7 +6,7 @@
   },
   "servers": [
     {
-      "url": "http://backend:80/anything",
+      "url": "http://backend.apk-integration-test.svc.cluster.local:80/anything",
       "description": "Server URL",
       "variables": {}
     }


### PR DESCRIPTION
## Purpose
> This pull request introduces support for backend basic authentication security policies. 

## Approach

**Backend Basic Authentication Support:**

* Added a new constant `MediationBackendBasicSecurity` to represent backend basic authentication mediation policies in `constant.go`.
* Implemented functions `convertMapToBasicEndpointSecurity`, `generateBasicSecurityHash`, and `createBasicEndpointSecurityMediationPolicy` in `builder.go` to handle conversion, hashing, and creation of basic auth security policies.
* Updated the basic endpoint security handling logic in `GenerateHTTPRoutes` to utilize the new conversion and policy creation functions, ensuring correct processing of basic auth configurations.

**Test Configuration Updates:**

* Modified backend endpoint URLs in test files to use the cluster-local service name, ensuring integration tests target the correct backend.