### PR TITLE
Add systemAPI label to routemetadata of system APIs

### DIFF
--- a/helm-charts/templates/data-plane/config-deployer/config-api-routemetadata.yaml
+++ b/helm-charts/templates/data-plane/config-deployer/config-api-routemetadata.yaml
@@ -23,6 +23,7 @@ metadata:
     api-name: "{{ template "kubernetes-gateway-helm.resource.prefix" . }}-config-api"
     api-version: "2.0.0"
     managed-by: "kgw"
+    systemAPI: "true"
 spec:
   api:
     name: {{ template "kubernetes-gateway-helm.resource.prefix" . }}-config-api

--- a/helm-charts/templates/data-plane/config-deployer/config-deploy-api-routemetadata.yaml
+++ b/helm-charts/templates/data-plane/config-deployer/config-deploy-api-routemetadata.yaml
@@ -23,6 +23,7 @@ metadata:
     api-name: "{{ template "kubernetes-gateway-helm.resource.prefix" . }}-config-deploy-api"
     api-version: "2.0.0"
     managed-by: "kgw"
+    systemAPI: "true"
 spec:
   api:
     name: {{ template "kubernetes-gateway-helm.resource.prefix" . }}-config-deploy-api

--- a/helm-charts/templates/data-plane/gateway-components/common-controller/api/notification-api.yaml
+++ b/helm-charts/templates/data-plane/gateway-components/common-controller/api/notification-api.yaml
@@ -24,6 +24,7 @@ metadata:
     api-name: "{{ template "kubernetes-gateway-helm.resource.prefix" . }}-notification-api"
     api-version: "1.0.0"
     managed-by: "kgw"
+    systemAPI: "true"
 spec:
   api:
     name: {{ template "kubernetes-gateway-helm.resource.prefix" . }}-notification-api

--- a/helm-charts/templates/idp/authenticationEndpoint-domain-api-routemetadata.yaml
+++ b/helm-charts/templates/idp/authenticationEndpoint-domain-api-routemetadata.yaml
@@ -23,6 +23,7 @@ metadata:
     api-name: "idp-domain-service"
     api-version: "1.0.0"
     managed-by: "kgw"
+    systemAPI: "true"
 spec:
   api:
     name: idp-domain-service

--- a/helm-charts/templates/idp/commonoauth-domain-api-routemetadata.yaml
+++ b/helm-charts/templates/idp/commonoauth-domain-api-routemetadata.yaml
@@ -23,6 +23,7 @@ metadata:
     api-name: "idp-domain-service"
     api-version: "1.0.0"
     managed-by: "kgw"
+    systemAPI: "true"
 spec:
   api:
     name: idp-domain-service

--- a/helm-charts/templates/idp/dcr-domain-api-routemetadata.yaml
+++ b/helm-charts/templates/idp/dcr-domain-api-routemetadata.yaml
@@ -23,6 +23,7 @@ metadata:
     api-name: "idp-domain-service"
     api-version: "1.0.0"
     managed-by: "kgw"
+    systemAPI: "true"
 spec:
   api:
     name: idp-domain-service

--- a/helm-charts/templates/idp/oauth-domain-api-routemetadata.yaml
+++ b/helm-charts/templates/idp/oauth-domain-api-routemetadata.yaml
@@ -23,6 +23,7 @@ metadata:
     api-name: "idp-domain-service"
     api-version: "1.0.0"
     managed-by: "kgw"
+    systemAPI: "true"
 spec:
   api:
     name: idp-domain-service


### PR DESCRIPTION
## Purpose
> This PR adds a new metadata field to system API RouteMetadata CRs. This label is checked when on agent startup to identify the system APIs from the existing APIs.

## Approach
> Add systemAPI label with value to true to RouteMetadata of system APIs