### PR TITLE
Moving the agent integration test steps into the apk integration tests workflow file

### DIFF
--- a/.github/workflows/apim-apk-agent-build.yml
+++ b/.github/workflows/apim-apk-agent-build.yml
@@ -1,0 +1,70 @@
+name: Build APIM APK Agent
+on:
+  workflow_call:
+    inputs:
+      aks_deployment:
+        required: true
+        type: boolean
+        description: "Deploy to AKS"
+    secrets:
+      APK_BOT_TOKEN:
+        required: true
+      APK_BOT_USER:
+        required: true
+      APK_BOT_EMAIL:
+        required: true
+      DOCKER_ORGANIZATION:
+        required: true
+      AZURE_ACR_NAME:
+        required: true
+      AZURE_CREDENTIALS:
+        required: true
+
+env:
+  GH_TOKEN: ${{ secrets.APK_BOT_TOKEN }}
+concurrency:
+  group: apim-apk-agent-${{ github.event.number || github.run_id }}
+  cancel-in-progress: true
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: "1.24"
+      - name: Install Revive
+        shell: sh
+        run: |
+          go install github.com/mgechev/revive@v1.3.4
+      - name: Checkout Product APIM Tooling repo
+        uses: actions/checkout@v3
+        with:
+          repository: wso2/product-apim-tooling
+          ref: main
+          path: product-apim-tooling
+          token: ${{ secrets.APK_BOT_TOKEN }}
+      - name: Set release username and email
+        shell: sh
+        run: |
+          git config --global user.name ${{ secrets.APK_BOT_USER }}
+          git config --global user.email ${{ secrets.APK_BOT_EMAIL }}
+      - name: Run Gradle Build
+        run: |
+          cd product-apim-tooling/apim-apk-agent
+          ./gradlew build
+      - name: Login to Azure ACR
+        if: ${{inputs.aks_deployment}}
+        uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+      - name: Push Docker images to ACR
+        if: ${{inputs.aks_deployment}}
+        run: |
+          az acr login -n ${{ secrets.AZURE_ACR_NAME }}
+          cd product-apim-tooling/apim-apk-agent
+          ./gradlew docker_push \
+            -Pfile=main.go \
+            -Pdocker_organization=${{ secrets.DOCKER_ORGANIZATION }} \
+            -Pimage_version=${{ github.sha }} \
+            -PmultiArch=true

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -106,6 +106,19 @@ jobs:
       DOCKER_ORGANIZATION: ${{ secrets.AZURE_ACR_NAME }}.azurecr.io
       AZURE_ACR_NAME: ${{ secrets.AZURE_ACR_NAME }}
       AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
+  
+  build_apim_apk_agent:
+    if: github.event_name == 'pull_request_target' && contains(github.event.label.name, 'trigger-action')
+    uses: ./.github/workflows/apim-apk-agent-build.yml
+    with:
+      aks_deployment: true
+    secrets:
+      APK_BOT_TOKEN: ${{ secrets.APK_BOT_TOKEN }}
+      APK_BOT_USER: ${{ secrets.APK_BOT_USER }}
+      APK_BOT_EMAIL: ${{ secrets.APK_BOT_EMAIL }}
+      DOCKER_ORGANIZATION: ${{ secrets.AZURE_ACR_NAME }}.azurecr.io
+      AZURE_ACR_NAME: ${{ secrets.AZURE_ACR_NAME }}
+      AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
 
   runs_go_integration_tests_on_pull_request:
     if: github.event_name == 'pull_request_target' && contains(github.event.label.name, 'trigger-action')
@@ -370,3 +383,283 @@ jobs:
         name: apk-integration-test-cucmber-logs
         path: podlogs/*.log
  
+  runs_agent_cucumber_integration_tests_on_pull_request:
+    if: github.event_name == 'pull_request_target' && contains(github.event.label.name, 'trigger-action')
+    needs: [build_common_controller, build_enforcer, build_config, build_idpds, build_envoy_gateway_extension_server, build_apim_apk_agent]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: azure/login@v1
+      with:
+        creds: ${{ secrets.AZURE_CREDENTIALS }}
+    - name: Create AKS Cluster and set context
+      uses: azure/CLI@v1
+      with:
+        azcliversion: 2.72.0
+        inlineScript: |
+          az aks create --resource-group "${{ secrets.AZURE_RESOURCE_GROUP }}" --name "agent-integ-${{ secrets.AKS_CLUSTER_NAME }}-${{ github.event.number || github.run_id }}" --enable-cluster-autoscaler --min-count 1 --max-count 3 --location "southeastasia" --node-vm-size Standard_DS4_v2 --generate-ssh-keys
+    - uses: azure/aks-set-context@v3
+      with:
+         resource-group: '${{ secrets.AZURE_RESOURCE_GROUP }}'
+         cluster-name: 'agent-integ-${{ secrets.AKS_CLUSTER_NAME }}-${{ github.event.number || github.run_id }}'
+    - name: Create Namespace apk
+      shell: sh
+      run: |
+        kubectl create namespace apk
+        kubectl get ns
+    - name: Create Image pull secret
+      shell: sh
+      run: |
+        kubectl create secret docker-registry azure-registry --docker-server=${{ secrets.AZURE_ACR_NAME }}.azurecr.io --docker-username=${{ secrets.AZURE_ACR_USER }} --docker-password=${{ secrets.AZURE_ACR_PASSWORD }} --docker-email=${{ secrets.APK_BOT_EMAIL }} -n apk
+    - name: Checkout apk-repo.
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: "0"
+        path: apk-repo
+        token: ${{ secrets.APK_BOT_TOKEN }}
+    - name: Set release username and email
+      shell: sh
+      run: |
+        git config --global user.name ${{ secrets.APK_BOT_USER }}
+        git config --global user.email ${{ secrets.APK_BOT_EMAIL }}
+
+    - name: checkout pull request and merge.
+      shell: sh
+      if: github.event_name == 'pull_request_target' && contains(github.event.label.name, 'trigger-action')
+      run: |
+        cd apk-repo
+        gh pr checkout ${{ github.event.number }} -b pr-${{ github.event.number }}
+        git checkout pr-${{ github.event.number }}
+        git merge origin/main
+
+    - name: Helm release deploy APIM CP
+      if: github.event_name == 'pull_request_target' && contains(github.event.label.name, 'trigger-action')
+      shell: sh
+      run: |
+        helm repo add wso2apim https://github.com/wso2/helm-apim/releases/download/acp-4.5.0
+        helm repo update
+        helm install apim wso2apim/wso2am-acp --version 4.5.0-1 -f https://raw.githubusercontent.com/O-sura/JunkYard/refs/heads/main/apim-4.6.0-alpha2-values.yaml -n apk --debug --wait --timeout 10m0s
+        kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.13.2/deploy/static/provider/cloud/deploy.yaml
+        kubectl get pods -n apk
+        kubectl get svc -n apk
+        kubectl get ing -n apk
+    - name: Helm release deploy APK DP
+      if: github.event_name == 'pull_request_target' && contains(github.event.label.name, 'trigger-action')
+      shell: sh
+      run: |
+        cd apk-repo/helm-charts
+        helm repo add bitnami https://charts.bitnami.com/bitnami
+        helm repo add jetstack https://charts.jetstack.io
+        helm dependency build
+        kubectl apply -f certmanager-crds/certmanager-crds.yaml
+        helm install apk -n apk . --debug --wait --timeout 15m0s \
+        --set wso2.subscription.imagePullSecrets=azure-registry \
+        --set wso2.apk.dp.configdeployer.deployment.image=${{ secrets.AZURE_ACR_NAME }}.azurecr.io/apk-config-deployer-service:${{ github.sha }} \
+        --set wso2.apk.dp.configdeployer.deployment.readinessProbe.failureThreshold=10 \
+        --set wso2.apk.dp.adapter.deployment.image=${{ secrets.AZURE_ACR_NAME }}.azurecr.io/apk-adapter:${{ github.sha }} \
+        --set wso2.apk.dp.commonController.deployment.image=${{ secrets.AZURE_ACR_NAME }}.azurecr.io/apk-common-controller:${{ github.sha }} \
+        --set wso2.apk.dp.gatewayRuntime.deployment.enforcer.image=${{ secrets.AZURE_ACR_NAME }}.azurecr.io/apk-enforcer:${{ github.sha }} \
+        --set wso2.apk.dp.gatewayRuntime.deployment.router.image=${{ secrets.AZURE_ACR_NAME }}.azurecr.io/apk-router:${{ github.sha }} \
+        --set wso2.apk.dp.gatewayRuntime.deployment.enforcer.readinessProbe.failureThreshold=10 \
+        --set wso2.apk.dp.gatewayRuntime.deployment.router.readinessProbe.failureThreshold=10 \
+        --set idp.idpds.deployment.image=${{ secrets.AZURE_ACR_NAME }}.azurecr.io/apk-idp-domain-service:${{ github.sha }} \
+        --set idp.idpui.deployment.image=${{ secrets.AZURE_ACR_NAME }}.azurecr.io/apk-idp-ui:${{ github.sha }} \
+        --set wso2.apk.dp.ratelimiter.deployment.image=${{ secrets.AZURE_ACR_NAME }}.azurecr.io/apk-ratelimiter:${{ github.sha }} \
+        --set wso2.apk.dp.ratelimiter.requestTimeoutInMillis=800 \
+        --set wso2.kgw.cp.enabledSubscription=true \
+        --set wso2.kgw.cp.host="apim-apk-agent-service.apk.svc.cluster.local" \
+        --set wso2.kgw.cp.skipSSLVerification=true \
+        --set wso2.kgw.dp.gatewayRuntime.deployment.enforcer.configs.apiKey.enabled=true \
+        --set wso2.kgw.dp.gatewayRuntime.deployment.enforcer.configs.apiKey.issuer="https://am.wso2.com:443/oauth2/token"
+        kubectl get pods -n apk
+        kubectl get svc -n apk
+
+    - name: Checkout Product APIM Tooling repo for Helm
+      uses: actions/checkout@v3
+      with:
+        repository: wso2/product-apim-tooling
+        ref: main
+        path: product-apim-tooling
+        token: ${{ secrets.APK_BOT_TOKEN }}
+    
+    - name: Helm release deploy APIM APK Agent
+      if: github.event_name == 'pull_request_target' && contains(github.event.label.name, 'trigger-action')
+      shell: sh
+      run: |
+        cd product-apim-tooling/helm-charts
+        helm dependency build
+        helm install apim-apk-agent -n apk . -f values.yaml --debug --wait --timeout 5m0s \
+        --set wso2.subscription.imagePullSecrets=azure-registry \
+        --set image.repository=${{ secrets.AZURE_ACR_NAME }}.azurecr.io/apim-apk-agent \
+        --set image.tag=${{ github.sha }} \
+        --set controlPlane.serviceURL=https://apim-wso2am-acp-1-service:9443/ \
+        --set controlPlane.eventListeningEndpoints=amqp://admin:admin@apim-wso2am-acp-1-service:5672?retries='10'&connectdelay='30'" \
+        --set dataPlane.k8ResourceEndpoint=https://apk-wso2-apk-config-ds-service.apk.svc.cluster.local:9443/api/configurator/apis/generate-k8s-resources \
+        --set dataPlane.namespace=apk
+        kubectl get pods -n apk
+        kubectl get svc -n apk
+    - name: Run test cases(CP to DP Flow) 
+      shell: sh
+      run: |
+        cd apk-repo/test/cucumber-tests
+        sh ./scripts/agent-setup-hosts.sh
+        ./gradlew runCpToDpTests
+    - name: Helm release undeploy
+      if: always()
+      shell: sh
+      run: |
+        cd apk-repo/helm-charts
+        kubectl describe pods -n apk
+        kubectl get pods -n apk
+        kubectl get svc -n apk
+        kubectl get apis -n apk
+        kubectl get applications -n apk
+        kubectl get subscriptions -n apk
+        kubectl get tokenissuers -n apk
+        kubectl get httproutes -n apk
+        kubectl get ing -n apk
+        kubectl get pods -l app.kubernetes.io/app: apim-apk-agent | awk '{print $1}' | xargs -I{} kubectl logs {} -n apk
+        helm uninstall apk -n apk --ignore-not-found
+        helm uninstall apim -n apk --ignore-not-found
+        helm uninstall apim-apk-agent -n apk --ignore-not-found
+        kubectl delete namespace apk
+    - name: Publish Test Report(CP to DP Flow)
+      if: always()
+      uses: malinthaprasan/action-surefire-report@v1
+      with:
+       report_paths: 'apk-repo/test/cucumber-tests/build/test-output/junitreports/*.xml'
+       fail_on_test_failures: true
+    # - name: Create Namespace apk #---Starts the DP to CP Flow
+    #   shell: sh
+    #   run: |
+    #     kubectl create namespace apk
+    #     kubectl get ns
+    # - name: Create Image pull secret
+    #   shell: sh
+    #   run: |
+    #     kubectl create secret docker-registry azure-registry --docker-server=${{ secrets.AZURE_ACR_NAME }}.azurecr.io --docker-username=${{ secrets.AZURE_ACR_USER }} --docker-password=${{ secrets.AZURE_ACR_PASSWORD }} --docker-email=${{ secrets.APK_BOT_EMAIL }} -n apk
+    # - name: Checkout apk-repo.
+    #   uses: actions/checkout@v3
+    #   with:
+    #     fetch-depth: "0"
+    #     path: apk-repo
+    #     token: ${{ secrets.APK_BOT_TOKEN }}
+    # - name: Set release username and email
+    #   shell: sh
+    #   run: |
+    #     git config --global user.name ${{ secrets.APK_BOT_USER }}
+    #     git config --global user.email ${{ secrets.APK_BOT_EMAIL }}
+
+    # - name: checkout pull request and merge.
+    #   shell: sh
+    #   if: github.event_name == 'pull_request_target' && contains(github.event.label.name, 'trigger-action')
+    #   run: |
+    #     cd apk-repo
+    #     gh pr checkout ${{ github.event.number }} -b pr-${{ github.event.number }}
+    #     git checkout pr-${{ github.event.number }}
+    #     git merge origin/main
+
+    # - name: Helm release deploy APIM CP
+    #   if: github.event_name == 'pull_request_target' && contains(github.event.label.name, 'trigger-action')
+    #   shell: sh
+    #   run: |
+    #     helm repo add wso2apim https://github.com/wso2/helm-apim/releases/download/acp-4.5.0
+    #     helm repo update
+    #     helm install apim wso2apim/wso2am-acp --version 4.5.0-1 -f https://raw.githubusercontent.com/O-sura/JunkYard/refs/heads/main/apim-4.6.0-alpha-dptocp-values.yaml -n apk --debug --wait --timeout 10m0s
+    #     kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.13.2/deploy/static/provider/cloud/deploy.yaml
+    #     kubectl get pods -n apk
+    #     kubectl get svc -n apk
+    #     kubectl get ing -n apk
+    # - name: Helm release deploy APK DP(DP to CP Flow)
+    #   if: github.event_name == 'pull_request_target' && contains(github.event.label.name, 'trigger-action')
+    #   shell: sh
+    #   run: |
+    #     cd apk-repo/helm-charts
+    #     helm repo add bitnami https://charts.bitnami.com/bitnami
+    #     helm repo add jetstack https://charts.jetstack.io
+    #     helm dependency build
+    #     helm install apk -n apk . --debug --wait --timeout 15m0s \
+    #     --set wso2.subscription.imagePullSecrets=azure-registry \
+    #     --set wso2.kgw.dp.configdeployer.deployment.image=${{ secrets.AZURE_ACR_NAME }}.azurecr.io/kgw-config-deployer-service:${{ github.sha }} \
+    #     --set wso2.kgw.dp.commonController.deployment.image=${{ secrets.AZURE_ACR_NAME }}.azurecr.io/kgw-common-controller:${{ github.sha }} \
+    #     --set idp.idpds.deployment.image=${{ secrets.AZURE_ACR_NAME }}.azurecr.io/kgw-idp-domain-service:${{ github.sha }} \
+    #     --set idp.idpui.deployment.image=${{ secrets.AZURE_ACR_NAME }}.azurecr.io/kgw-idp-ui:${{ github.sha }} \
+    #     --set wso2.kgw.dp.ratelimiter.deployment.image=${{ secrets.AZURE_ACR_NAME }}.azurecr.io/kgw-ratelimiter:${{ github.sha }} \
+    #     --set wso2.kgw.cp.enabledSubscription=true \
+    #     --set wso2.kgw.cp.enableApiPropagation=true \
+    #     --set wso2.kgw.cp.host="apim-common-agent-service.apk.svc.cluster.local" \
+    #     --set wso2.kgw.cp.skipSSLVerification=true \
+    #     --set wso2.kgw.dp.gatewayRuntime.deployment.enforcer.configs.mandateSubscriptionValidation=true \
+    #     --set wso2.kgw.dp.gatewayRuntime.deployment.enforcer.configs.mandateInternalKeyValidation=true \
+    #     --set wso2.kgw.dp.gatewayRuntime.deployment.enforcer.configs.JWKSClient.skipSSLVerification=false \
+    #     --set wso2.kgw.dp.gatewayRuntime.deployment.enforcer.configs.JWKSClient.hostnameVerifier="AllowAll" 
+    #     kubectl get pods -n apk
+    #     kubectl get svc -n apk
+
+    # - name: Checkout APIM GW Connectors repo for Helm
+    #   uses: actions/checkout@v3
+    #   with:
+    #     repository: wso2-extensions/apim-gw-connectors
+    #     ref: main
+    #     path: apim-gw-connectors
+    #     token: ${{ secrets.APK_BOT_TOKEN }}
+
+    # - name: Helm release deploy APIM APK Agent(DP to CP Flow)
+    #   if: github.event_name == 'pull_request_target' && contains(github.event.label.name, 'trigger-action')
+    #   shell: sh
+    #   run: |
+    #     cd apim-gw-connectors/common-agent/helm
+    #     helm dependency build
+    #     helm install apim-apk-agent -n apk . -f ../../apk/helm/values.yaml --debug --wait --timeout 5m0s \
+    #     --set wso2.subscription.imagePullSecrets=azure-registry \     
+    #     --set image.repository=${{ secrets.AZURE_ACR_NAME }}.azurecr.io/apim-k8s-gw-connector \
+    #     --set image.tag=${{ github.sha }} \
+    #     --set controlPlane.serviceURL=https://apim-wso2am-acp-1-service.apk.svc.cluster.local:9443/ \
+    #     --set controlPlane.eventListeningEndpoints="amqp://admin:admin@apim-wso2am-acp-1-service.apk.svc.cluster.local:5672?retries='10'&connectdelay='30'"
+    #     --set dataPlane.namespace=apk 
+    #     kubectl get pods -n apk
+    #     kubectl get svc -n apk
+    # - name: Run test cases(DP to CP Flow) 
+    #   shell: sh
+    #   run: |
+    #     cd apk-repo/test/cucumber-tests
+    #     sh ./scripts/agent-setup-hosts.sh
+    #     ./gradlew runDpToCpTests
+    # - name: Helm release undeploy
+    #   if: always()
+    #   shell: sh
+    #   run: |
+    #     cd apk-repo/helm-charts
+    #     kubectl describe pods -n apk
+    #     kubectl get pods -n apk
+    #     kubectl get svc -n apk
+    #     kubectl get routemetadata -n apk
+    #     kubectl get applications -n apk
+    #     kubectl get subscriptions -n apk
+    #     kubectl get routepolicies -n apk
+    #     kubectl get httproutes -n apk
+    #     kubectl get securitypolicies -n apk
+    #     kubectl get ing -n apk
+    #     kubectl get pods -l app.kubernetes.io/app: apim-common-agent | awk '{print $1}' | xargs -I{} kubectl logs {} -n apk
+    #     helm uninstall apk -n apk --ignore-not-found
+    #     helm uninstall apim -n apk --ignore-not-found
+    #     helm uninstall apim-apk-agent -n apk --ignore-not-found
+    - name: Delete AKS cluster
+      if: always()
+      uses: azure/CLI@v1
+      with:
+        azcliversion: 2.72.0
+        inlineScript: |
+          az aks delete --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} --name agent-integ-${{ secrets.AKS_CLUSTER_NAME }}-${{ github.event.number || github.run_id }} --yes
+    - name: Logout from azure
+      if: always()
+      uses: azure/CLI@v1
+      with:
+        azcliversion: 2.72.0
+        inlineScript: |
+          az logout
+    # - name: Publish Test Report(DP to CP Flow)
+    #   if: always()
+    #   uses: malinthaprasan/action-surefire-report@v1
+    #   with:
+    #    report_paths: 'apk-repo/test/cucumber-tests/build/test-output/junitreports/*.xml'
+    #    fail_on_test_failures: true

--- a/test/cucumber-tests/scripts/agent-setup-hosts.sh
+++ b/test/cucumber-tests/scripts/agent-setup-hosts.sh
@@ -5,7 +5,7 @@ kubectl wait --timeout=5m -n apk deployment/apk-wso2-apk-adapter-deployment --fo
 kubectl wait --timeout=15m -n apk deployment/apk-wso2-apk-gateway-runtime-deployment --for=condition=Available
 kubectl wait --timeout=5m -n apk deployment/apim-apk-agent --for=condition=Available
 IP=$(kubectl get svc apk-wso2-apk-gateway-service -n apk --output jsonpath='{.status.loadBalancer.ingress[0].ip}')
-ING_IP=$(kubectl get ing -n apk apim-wso2am-cp-ingress --output=jsonpath='{.status.loadBalancer.ingress[0].ip}')
+ING_IP=$(kubectl get ing -n apk apim-wso2am-acp-ingress --output=jsonpath='{.status.loadBalancer.ingress[0].ip}')
 CC_IP=$(kubectl get svc apk-wso2-apk-common-controller-web-server-service -n apk --output jsonpath='{.status.loadBalancer.ingress[0].ip}')
 sudo echo "$IP localhost" | sudo tee -a /etc/hosts
 sudo echo "$IP idp.am.wso2.com" | sudo tee -a /etc/hosts


### PR DESCRIPTION
## Purpose
> This PR updates the integration test workflows to ensure consistency across components. Previously, the apim-apk-agent integration tests had a separate workflow that did not use the latest Agent image or the APK component images built from a given PR. With this change, the apim-apk-agent integration tests are now incorporated into the existing APK integration-test workflow, enabling them to run alongside the APK integration and cucumber tests using the latest APIM-APK-Agent and  APK images built from the PR.


Related Issue:
> - https://github.com/wso2/apk/issues/3261