### PR TITLE
Add Azure secret provider support

### DIFF
--- a/helm-charts/Chart.yaml
+++ b/helm-charts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: choreo-apk
 description: A Helm chart for APK components
 type: application
-version: 1.3.0-7
+version: 1.3.0-8
 appVersion: "1.3.0"
 dependencies:
   - name: postgresql

--- a/helm-charts/templates/secret-providers/secret-provider-azure.yaml
+++ b/helm-charts/templates/secret-providers/secret-provider-azure.yaml
@@ -1,0 +1,146 @@
+# Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+{{- if .Values.wso2.apk.secretProviderClass.enabled }}
+{{- if eq .Values.wso2.apk.secretProviderClass.provider "azure" }}
+apiVersion: secrets-store.csi.x-k8s.io/v1
+kind: SecretProviderClass
+metadata:
+  name: {{ template "apk-helm.resource.prefix" . }}-secrets
+  namespace: {{ .Release.Namespace }}
+spec:
+  provider: azure
+  secretObjects:
+    - secretName: {{ template "apk-helm.resource.prefix" . }}-secrets
+      type: Opaque
+      data:
+        - objectName: ratelimiter_redis_credentials
+          key: ratelimiter_redis_credentials
+    - secretName: {{ template "apk-helm.resource.prefix" . }}-system-listener-tls
+      type: Opaque
+      data:
+        - objectName: system-api-listener.key
+          key: tls.key
+        - objectName: system-api-listener.crt
+          key: tls.crt
+    - secretName: {{ template "apk-helm.resource.prefix" . }}-router-tls
+      type: Opaque
+      data:
+        - objectName: router.key
+          key: tls.key
+        - objectName: router.crt
+          key: tls.crt
+  parameters:
+    keyvaultName: {{ .Values.global.keyVaultName }}
+    tenantId: {{ .Values.global.azureTenantID }}
+    usePodIdentity: "false"
+    objects: |
+      - objectAlias: ratelimiter_redis_credentials
+        objectType: secret
+        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.ratelimiterRedisCredentials.key | quote }}
+        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.ratelimiterRedisCredentials.path | quote }}
+      - objectAlias: adapter.key
+        objectType: secret
+        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.adapterKey.key | quote }}
+        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.adapterKey.path | quote }}
+      - objectAlias: adapter.crt
+        objectType: secret
+        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.adapterCert.key | quote }}
+        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.adapterCert.path | quote }}
+      - objectAlias: adapter-ca.crt
+        objectType: secret
+        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.adapterCaCert.key | quote }}
+        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.adapterCaCert.path | quote }}
+      - objectAlias: enforcer.key
+        objectType: secret
+        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerKey.key | quote }}
+        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerKey.path | quote }}
+      - objectAlias: enforcer.crt
+        objectType: secret
+        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerCert.key | quote }}
+        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerCert.path | quote }}
+      - objectAlias: enforcer-ca.crt
+        objectType: secret
+        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerCaCert.key | quote }}
+        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerCaCert.path | quote }}
+      - objectAlias: router.key
+        objectType: secret
+        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.routerKey.key | quote }}
+        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.routerKey.path | quote }}
+      - objectAlias: router.crt
+        objectType: secret
+        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.routerCert.key | quote }}
+        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.routerCert.path | quote }}
+      - objectAlias: router-ca.crt
+        objectType: secret
+        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.routerCaCert.key | quote }}
+        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.routerCaCert.path | quote }}
+      - objectAlias: ratelimiter.key
+        objectType: secret
+        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.ratelimiterKey.key | quote }}
+        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.ratelimiterKey.path | quote }}
+      - objectAlias: ratelimiter.crt
+        objectType: secret
+        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.ratelimiterCert.key | quote }}
+        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.ratelimiterCert.path | quote }}
+      - objectAlias: ratelimiter-ca.crt
+        objectType: secret
+        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.ratelimiterCaCert.key | quote }}
+        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.ratelimiterCaCert.path | quote }}
+      - objectAlias: commoncontroller.key
+        objectType: secret
+        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.commonControllerKey.key | quote }}
+        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.commonControllerKey.path | quote }}
+      - objectAlias: commoncontroller.crt
+        objectType: secret
+        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.commonControllerCert.key | quote }}
+        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.commonControllerCert.path | quote }}
+      - objectAlias: commoncontroller-ca.crt
+        objectType: secret
+        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.commonControllerCaCert.key | quote }}
+        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.commonControllerCaCert.path | quote }}
+      - objectAlias: system-api-listener.key
+        objectType: secret
+        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.systemApiListenerKey.key | quote }}
+        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.systemApiListenerKey.path | quote }}
+      - objectAlias: system-api-listener.crt
+        objectType: secret
+        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.systemApiListenerCert.key | quote }}
+        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.systemApiListenerCert.path | quote }}
+      - objectAlias: enforcer-jwks.key
+        objectType: secret
+        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerJwksKey.key | quote }}
+        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerJwksKey.path | quote }}
+      - objectAlias: enforcer-jwks.crt
+        objectType: secret
+        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerJwksCert.key | quote }}
+        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerJwksCert.path | quote }}
+      - objectAlias: enforcer-jwks-ca.crt
+        objectType: secret
+        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerJwksCaCert.key | quote }}
+        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerJwksCaCert.path | quote }}
+{{ if and .Values.wso2.apk.dp.gatewayRuntime.tracing .Values.wso2.apk.dp.gatewayRuntime.tracing.enabled .Values.wso2.apk.dp.gatewayRuntime.tracing.configProperties .Values.wso2.apk.dp.gatewayRuntime.tracing.configProperties.tls .Values.wso2.apk.dp.gatewayRuntime.tracing.configProperties.tls.enabled }}
+      - objectAlias: tracing-ca.crt
+        objectType: secret
+        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.tracingCaCert.key | quote }}
+        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.tracingCaCert.path | quote }}
+      - objectAlias: tracing.crt
+        objectType: secret
+        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.tracingCert.key | quote }}
+        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.tracingCert.path | quote }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/helm-charts/templates/secret-providers/secret-provider-vault.yaml
+++ b/helm-charts/templates/secret-providers/secret-provider-vault.yaml
@@ -15,6 +15,7 @@
 # under the License.
 
 {{- if .Values.wso2.apk.secretProviderClass.enabled }}
+{{- if eq .Values.wso2.apk.secretProviderClass.provider "vault" }}
 apiVersion: secrets-store.csi.x-k8s.io/v1
 kind: SecretProviderClass
 metadata:
@@ -116,5 +117,6 @@ spec:
       - objectName: tracing.crt
         secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.tracingCert.key | quote }}
         secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.tracingCert.path | quote }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/helm-charts/values.yaml
+++ b/helm-charts/values.yaml
@@ -32,7 +32,7 @@ wso2:
 
   apk:
     secretProviderClass:
-      enabled: true
+      enabled: false
       provider: "vault"
       vault:
         url: ""

--- a/helm-charts/values.yaml
+++ b/helm-charts/values.yaml
@@ -32,10 +32,13 @@ wso2:
 
   apk:
     secretProviderClass:
-      enabled: false
+      enabled: true
+      provider: "vault"
       vault:
         url: ""
         roleName: ""
+        keyVaultName: ""
+        azureTenantID: ""
       secrets:
         ratelimiterRedisCredentials:
           key: ""
@@ -83,6 +86,12 @@ wso2:
           key: ""
           path: ""
         commonControllerCaCert:
+          key: ""
+          path: ""
+        systemApiListenerKey:
+          key: ""
+          path: ""
+        systemApiListenerCert:
           key: ""
           path: ""
         enforcerJwksKey:


### PR DESCRIPTION
## Purpose

This pull request introduces support for Azure Key Vault as a secret provider in addition to HashiCorp Vault, and refines how secret providers are configured and deployed with the Helm charts. The changes make the secret management setup more flexible and allow users to choose between Azure and Vault providers via configuration.

## Approach

**Secret Provider Support Enhancements:**

* Added a new template file `secret-provider-azure.yaml` for configuring Azure Key Vault as a secret provider, including all necessary secret mappings and parameters.
* Updated logic in the Vault secret provider template (`secret-provider-vault.yaml`, formerly `secret-provider-class.yaml`) to conditionally render only when Vault is selected as the provider. [[1]](diffhunk://#diff-dc490fb6cf1de7a1be538794d031afc421b18d87e1cd17fc48273024311e847fR18) [[2]](diffhunk://#diff-dc490fb6cf1de7a1be538794d031afc421b18d87e1cd17fc48273024311e847fR122)

**Configuration Improvements:**

* Added a `.Values.wso2.apk.secretProviderClass.provider` field to `values.yaml` to allow selection between "vault" and "azure" providers, and set the default to "vault".
* Enabled the secret provider class by default in `values.yaml` to ensure secrets are provisioned automatically.
* Extended the configuration options under the Vault section in `values.yaml` to include Azure-specific fields (`keyVaultName`, `azureTenantID`) for easier switching and management.

## Related Issue

https://github.com/wso2-enterprise/apim-saas/issues/1093


