### PR TITLE
Update secret provider values based on provider

### DIFF
--- a/helm-charts/Chart.yaml
+++ b/helm-charts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: choreo-apk
 description: A Helm chart for APK components
 type: application
-version: 1.3.0-8
+version: 1.3.0-9
 appVersion: "1.3.0"
 dependencies:
   - name: postgresql

--- a/helm-charts/templates/secret-providers/secret-provider-azure.yaml
+++ b/helm-charts/templates/secret-providers/secret-provider-azure.yaml
@@ -50,97 +50,97 @@ spec:
     objects: |
       - objectAlias: ratelimiter_redis_credentials
         objectType: secret
-        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.ratelimiterRedisCredentials.key | quote }}
-        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.ratelimiterRedisCredentials.path | quote }}
+        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.ratelimiterRedisCredentials.azure.secretName | quote }}
+        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.ratelimiterRedisCredentials.azure.version | quote }}
       - objectAlias: adapter.key
         objectType: secret
-        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.adapterKey.key | quote }}
-        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.adapterKey.path | quote }}
+        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.adapterKey.azure.secretName | quote }}
+        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.adapterKey.azure.version | quote }}
       - objectAlias: adapter.crt
         objectType: secret
-        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.adapterCert.key | quote }}
-        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.adapterCert.path | quote }}
+        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.adapterCert.azure.secretName | quote }}
+        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.adapterCert.azure.version | quote }}
       - objectAlias: adapter-ca.crt
         objectType: secret
-        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.adapterCaCert.key | quote }}
-        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.adapterCaCert.path | quote }}
+        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.adapterCaCert.azure.secretName | quote }}
+        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.adapterCaCert.azure.version | quote }}
       - objectAlias: enforcer.key
         objectType: secret
-        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerKey.key | quote }}
-        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerKey.path | quote }}
+        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerKey.azure.secretName | quote }}
+        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerKey.azure.version | quote }}
       - objectAlias: enforcer.crt
         objectType: secret
-        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerCert.key | quote }}
-        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerCert.path | quote }}
+        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerCert.azure.secretName | quote }}
+        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerCert.azure.version | quote }}
       - objectAlias: enforcer-ca.crt
         objectType: secret
-        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerCaCert.key | quote }}
-        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerCaCert.path | quote }}
+        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerCaCert.azure.secretName | quote }}
+        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerCaCert.azure.version | quote }}
       - objectAlias: router.key
         objectType: secret
-        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.routerKey.key | quote }}
-        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.routerKey.path | quote }}
+        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.routerKey.azure.secretName | quote }}
+        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.routerKey.azure.version | quote }}
       - objectAlias: router.crt
         objectType: secret
-        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.routerCert.key | quote }}
-        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.routerCert.path | quote }}
+        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.routerCert.azure.secretName | quote }}
+        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.routerCert.azure.version | quote }}
       - objectAlias: router-ca.crt
         objectType: secret
-        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.routerCaCert.key | quote }}
-        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.routerCaCert.path | quote }}
+        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.routerCaCert.azure.secretName | quote }}
+        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.routerCaCert.azure.version | quote }}
       - objectAlias: ratelimiter.key
         objectType: secret
-        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.ratelimiterKey.key | quote }}
-        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.ratelimiterKey.path | quote }}
+        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.ratelimiterKey.azure.secretName | quote }}
+        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.ratelimiterKey.azure.version | quote }}
       - objectAlias: ratelimiter.crt
         objectType: secret
-        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.ratelimiterCert.key | quote }}
-        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.ratelimiterCert.path | quote }}
+        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.ratelimiterCert.azure.secretName | quote }}
+        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.ratelimiterCert.azure.version | quote }}
       - objectAlias: ratelimiter-ca.crt
         objectType: secret
-        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.ratelimiterCaCert.key | quote }}
-        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.ratelimiterCaCert.path | quote }}
+        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.ratelimiterCaCert.azure.secretName | quote }}
+        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.ratelimiterCaCert.azure.version | quote }}
       - objectAlias: commoncontroller.key
         objectType: secret
-        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.commonControllerKey.key | quote }}
-        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.commonControllerKey.path | quote }}
+        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.commonControllerKey.azure.secretName | quote }}
+        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.commonControllerKey.azure.version | quote }}
       - objectAlias: commoncontroller.crt
         objectType: secret
-        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.commonControllerCert.key | quote }}
-        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.commonControllerCert.path | quote }}
+        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.commonControllerCert.azure.secretName | quote }}
+        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.commonControllerCert.azure.version | quote }}
       - objectAlias: commoncontroller-ca.crt
         objectType: secret
-        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.commonControllerCaCert.key | quote }}
-        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.commonControllerCaCert.path | quote }}
+        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.commonControllerCaCert.azure.secretName | quote }}
+        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.commonControllerCaCert.azure.version | quote }}
       - objectAlias: system-api-listener.key
         objectType: secret
-        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.systemApiListenerKey.key | quote }}
-        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.systemApiListenerKey.path | quote }}
+        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.systemApiListenerKey.azure.secretName | quote }}
+        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.systemApiListenerKey.azure.version | quote }}
       - objectAlias: system-api-listener.crt
         objectType: secret
-        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.systemApiListenerCert.key | quote }}
-        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.systemApiListenerCert.path | quote }}
+        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.systemApiListenerCert.azure.secretName | quote }}
+        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.systemApiListenerCert.azure.version | quote }}
       - objectAlias: enforcer-jwks.key
         objectType: secret
-        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerJwksKey.key | quote }}
-        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerJwksKey.path | quote }}
+        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerJwksKey.azure.secretName | quote }}
+        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerJwksKey.azure.version | quote }}
       - objectAlias: enforcer-jwks.crt
         objectType: secret
-        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerJwksCert.key | quote }}
-        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerJwksCert.path | quote }}
+        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerJwksCert.azure.secretName | quote }}
+        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerJwksCert.azure.version | quote }}
       - objectAlias: enforcer-jwks-ca.crt
         objectType: secret
-        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerJwksCaCert.key | quote }}
-        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerJwksCaCert.path | quote }}
+        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerJwksCaCert.azure.secretName | quote }}
+        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerJwksCaCert.azure.version | quote }}
 {{ if and .Values.wso2.apk.dp.gatewayRuntime.tracing .Values.wso2.apk.dp.gatewayRuntime.tracing.enabled .Values.wso2.apk.dp.gatewayRuntime.tracing.configProperties .Values.wso2.apk.dp.gatewayRuntime.tracing.configProperties.tls .Values.wso2.apk.dp.gatewayRuntime.tracing.configProperties.tls.enabled }}
       - objectAlias: tracing-ca.crt
         objectType: secret
-        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.tracingCaCert.key | quote }}
-        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.tracingCaCert.path | quote }}
+        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.tracingCaCert.azure.secretName | quote }}
+        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.tracingCaCert.azure.version | quote }}
       - objectAlias: tracing.crt
         objectType: secret
-        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.tracingCert.key | quote }}
-        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.tracingCert.path | quote }}
+        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.tracingCert.azure.secretName | quote }}
+        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.tracingCert.azure.version | quote }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/helm-charts/templates/secret-providers/secret-provider-vault.yaml
+++ b/helm-charts/templates/secret-providers/secret-provider-vault.yaml
@@ -48,75 +48,75 @@ spec:
     roleName: {{ .Values.wso2.apk.secretProviderClass.vault.roleName }}
     objects: |
       - objectName: ratelimiter_redis_credentials
-        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.ratelimiterRedisCredentials.vault.secretKey | quote }}
-        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.ratelimiterRedisCredentials.vault.secretPath | quote }}
+        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.ratelimiterRedisCredentials.vault.key | quote }}
+        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.ratelimiterRedisCredentials.vault.path | quote }}
       - objectName: adapter.key
-        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.adapterKey.vault.secretKey | quote }}
-        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.adapterKey.vault.secretPath | quote }}
+        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.adapterKey.vault.key | quote }}
+        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.adapterKey.vault.path | quote }}
       - objectName: adapter.crt
-        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.adapterCert.vault.secretKey | quote }}
-        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.adapterCert.vault.secretPath | quote }}
+        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.adapterCert.vault.key | quote }}
+        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.adapterCert.vault.path | quote }}
       - objectName: adapter-ca.crt
-        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.adapterCaCert.vault.secretKey | quote }}
-        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.adapterCaCert.vault.secretPath | quote }}
+        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.adapterCaCert.vault.key | quote }}
+        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.adapterCaCert.vault.path | quote }}
       - objectName: enforcer.key
-        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerKey.vault.secretKey | quote }}
-        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerKey.vault.secretPath | quote }}
+        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerKey.vault.key | quote }}
+        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerKey.vault.path | quote }}
       - objectName: enforcer.crt
-        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerCert.vault.secretKey | quote }}
-        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerCert.vault.secretPath | quote }}
+        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerCert.vault.key | quote }}
+        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerCert.vault.path | quote }}
       - objectName: enforcer-ca.crt
-        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerCaCert.vault.secretKey | quote }}
-        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerCaCert.vault.secretPath | quote }}
+        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerCaCert.vault.key | quote }}
+        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerCaCert.vault.path | quote }}
       - objectName: router.key
-        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.routerKey.vault.secretKey | quote }}
-        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.routerKey.vault.secretPath | quote }}
+        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.routerKey.vault.key | quote }}
+        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.routerKey.vault.path | quote }}
       - objectName: router.crt
-        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.routerCert.vault.secretKey | quote }}
-        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.routerCert.vault.secretPath | quote }}
+        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.routerCert.vault.key | quote }}
+        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.routerCert.vault.path | quote }}
       - objectName: router-ca.crt
-        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.routerCaCert.vault.secretKey | quote }}
-        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.routerCaCert.vault.secretPath | quote }}
+        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.routerCaCert.vault.key | quote }}
+        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.routerCaCert.vault.path | quote }}
       - objectName: ratelimiter.key
-        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.ratelimiterKey.vault.secretKey | quote }}
-        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.ratelimiterKey.vault.secretPath | quote }}
+        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.ratelimiterKey.vault.key | quote }}
+        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.ratelimiterKey.vault.path | quote }}
       - objectName: ratelimiter.crt
-        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.ratelimiterCert.vault.secretKey | quote }}
-        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.ratelimiterCert.vault.secretPath | quote }}
+        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.ratelimiterCert.vault.key | quote }}
+        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.ratelimiterCert.vault.path | quote }}
       - objectName: ratelimiter-ca.crt
-        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.ratelimiterCaCert.vault.secretKey | quote }}
-        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.ratelimiterCaCert.vault.secretPath | quote }}
+        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.ratelimiterCaCert.vault.key | quote }}
+        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.ratelimiterCaCert.vault.path | quote }}
       - objectName: commoncontroller.key
-        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.commonControllerKey.vault.secretKey | quote }}
-        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.commonControllerKey.vault.secretPath | quote }}
+        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.commonControllerKey.vault.key | quote }}
+        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.commonControllerKey.vault.path | quote }}
       - objectName: commoncontroller.crt
-        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.commonControllerCert.vault.secretKey | quote }}
-        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.commonControllerCert.vault.secretPath | quote }}
+        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.commonControllerCert.vault.key | quote }}
+        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.commonControllerCert.vault.path | quote }}
       - objectName: commoncontroller-ca.crt
-        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.commonControllerCaCert.vault.secretKey | quote }}
-        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.commonControllerCaCert.vault.secretPath | quote }}
+        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.commonControllerCaCert.vault.key | quote }}
+        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.commonControllerCaCert.vault.path | quote }}
       - objectName: system-api-listener.key
-        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.systemApiListenerKey.vault.secretKey | quote }}
-        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.systemApiListenerKey.vault.secretPath | quote }}
+        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.systemApiListenerKey.vault.key | quote }}
+        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.systemApiListenerKey.vault.path | quote }}
       - objectName: system-api-listener.crt
-        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.systemApiListenerCert.vault.secretKey | quote }}
-        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.systemApiListenerCert.vault.secretPath | quote }}
+        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.systemApiListenerCert.vault.key | quote }}
+        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.systemApiListenerCert.vault.path | quote }}
       - objectName: enforcer-jwks.key
-        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerJwksKey.vault.secretKey | quote }}
-        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerJwksKey.vault.secretPath | quote }}
+        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerJwksKey.vault.key | quote }}
+        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerJwksKey.vault.path | quote }}
       - objectName: enforcer-jwks.crt
-        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerJwksCert.vault.secretKey | quote }}
-        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerJwksCert.vault.secretPath | quote }}
+        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerJwksCert.vault.key | quote }}
+        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerJwksCert.vault.path | quote }}
       - objectName: enforcer-jwks-ca.crt
-        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerJwksCaCert.vault.secretKey | quote }}
-        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerJwksCaCert.vault.secretPath | quote }}
+        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerJwksCaCert.vault.key | quote }}
+        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerJwksCaCert.vault.path | quote }}
 {{ if and .Values.wso2.apk.dp.gatewayRuntime.tracing .Values.wso2.apk.dp.gatewayRuntime.tracing.enabled .Values.wso2.apk.dp.gatewayRuntime.tracing.configProperties .Values.wso2.apk.dp.gatewayRuntime.tracing.configProperties.tls .Values.wso2.apk.dp.gatewayRuntime.tracing.configProperties.tls.enabled }}
       - objectName: tracing-ca.crt
-        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.tracingCaCert.vault.secretKey | quote }}
-        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.tracingCaCert.vault.secretPath | quote }}
+        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.tracingCaCert.vault.key | quote }}
+        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.tracingCaCert.vault.path | quote }}
       - objectName: tracing.crt
-        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.tracingCert.vault.secretKey | quote }}
-        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.tracingCert.vault.secretPath | quote }}
+        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.tracingCert.vault.key | quote }}
+        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.tracingCert.vault.path | quote }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/helm-charts/templates/secret-providers/secret-provider-vault.yaml
+++ b/helm-charts/templates/secret-providers/secret-provider-vault.yaml
@@ -48,75 +48,75 @@ spec:
     roleName: {{ .Values.wso2.apk.secretProviderClass.vault.roleName }}
     objects: |
       - objectName: ratelimiter_redis_credentials
-        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.ratelimiterRedisCredentials.key | quote }}
-        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.ratelimiterRedisCredentials.path | quote }}
+        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.ratelimiterRedisCredentials.vault.secretKey | quote }}
+        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.ratelimiterRedisCredentials.vault.secretPath | quote }}
       - objectName: adapter.key
-        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.adapterKey.key | quote }}
-        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.adapterKey.path | quote }}
+        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.adapterKey.vault.secretKey | quote }}
+        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.adapterKey.vault.secretPath | quote }}
       - objectName: adapter.crt
-        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.adapterCert.key | quote }}
-        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.adapterCert.path | quote }}
+        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.adapterCert.vault.secretKey | quote }}
+        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.adapterCert.vault.secretPath | quote }}
       - objectName: adapter-ca.crt
-        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.adapterCaCert.key | quote }}
-        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.adapterCaCert.path | quote }}
+        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.adapterCaCert.vault.secretKey | quote }}
+        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.adapterCaCert.vault.secretPath | quote }}
       - objectName: enforcer.key
-        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerKey.key | quote }}
-        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerKey.path | quote }}
+        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerKey.vault.secretKey | quote }}
+        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerKey.vault.secretPath | quote }}
       - objectName: enforcer.crt
-        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerCert.key | quote }}
-        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerCert.path | quote }}
+        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerCert.vault.secretKey | quote }}
+        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerCert.vault.secretPath | quote }}
       - objectName: enforcer-ca.crt
-        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerCaCert.key | quote }}
-        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerCaCert.path | quote }}
+        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerCaCert.vault.secretKey | quote }}
+        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerCaCert.vault.secretPath | quote }}
       - objectName: router.key
-        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.routerKey.key | quote }}
-        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.routerKey.path | quote }}
+        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.routerKey.vault.secretKey | quote }}
+        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.routerKey.vault.secretPath | quote }}
       - objectName: router.crt
-        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.routerCert.key | quote }}
-        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.routerCert.path | quote }}
+        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.routerCert.vault.secretKey | quote }}
+        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.routerCert.vault.secretPath | quote }}
       - objectName: router-ca.crt
-        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.routerCaCert.key | quote }}
-        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.routerCaCert.path | quote }}
+        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.routerCaCert.vault.secretKey | quote }}
+        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.routerCaCert.vault.secretPath | quote }}
       - objectName: ratelimiter.key
-        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.ratelimiterKey.key | quote }}
-        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.ratelimiterKey.path | quote }}
+        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.ratelimiterKey.vault.secretKey | quote }}
+        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.ratelimiterKey.vault.secretPath | quote }}
       - objectName: ratelimiter.crt
-        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.ratelimiterCert.key | quote }}
-        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.ratelimiterCert.path | quote }}
+        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.ratelimiterCert.vault.secretKey | quote }}
+        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.ratelimiterCert.vault.secretPath | quote }}
       - objectName: ratelimiter-ca.crt
-        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.ratelimiterCaCert.key | quote }}
-        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.ratelimiterCaCert.path | quote }}
+        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.ratelimiterCaCert.vault.secretKey | quote }}
+        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.ratelimiterCaCert.vault.secretPath | quote }}
       - objectName: commoncontroller.key
-        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.commonControllerKey.key | quote }}
-        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.commonControllerKey.path | quote }}
+        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.commonControllerKey.vault.secretKey | quote }}
+        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.commonControllerKey.vault.secretPath | quote }}
       - objectName: commoncontroller.crt
-        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.commonControllerCert.key | quote }}
-        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.commonControllerCert.path | quote }}
+        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.commonControllerCert.vault.secretKey | quote }}
+        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.commonControllerCert.vault.secretPath | quote }}
       - objectName: commoncontroller-ca.crt
-        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.commonControllerCaCert.key | quote }}
-        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.commonControllerCaCert.path | quote }}
+        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.commonControllerCaCert.vault.secretKey | quote }}
+        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.commonControllerCaCert.vault.secretPath | quote }}
       - objectName: system-api-listener.key
-        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.systemApiListenerKey.key | quote }}
-        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.systemApiListenerKey.path | quote }}
+        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.systemApiListenerKey.vault.secretKey | quote }}
+        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.systemApiListenerKey.vault.secretPath | quote }}
       - objectName: system-api-listener.crt
-        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.systemApiListenerCert.key | quote }}
-        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.systemApiListenerCert.path | quote }}
+        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.systemApiListenerCert.vault.secretKey | quote }}
+        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.systemApiListenerCert.vault.secretPath | quote }}
       - objectName: enforcer-jwks.key
-        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerJwksKey.key | quote }}
-        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerJwksKey.path | quote }}
+        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerJwksKey.vault.secretKey | quote }}
+        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerJwksKey.vault.secretPath | quote }}
       - objectName: enforcer-jwks.crt
-        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerJwksCert.key | quote }}
-        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerJwksCert.path | quote }}
+        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerJwksCert.vault.secretKey | quote }}
+        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerJwksCert.vault.secretPath | quote }}
       - objectName: enforcer-jwks-ca.crt
-        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerJwksCaCert.key | quote }}
-        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerJwksCaCert.path | quote }}
+        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerJwksCaCert.vault.secretKey | quote }}
+        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerJwksCaCert.vault.secretPath | quote }}
 {{ if and .Values.wso2.apk.dp.gatewayRuntime.tracing .Values.wso2.apk.dp.gatewayRuntime.tracing.enabled .Values.wso2.apk.dp.gatewayRuntime.tracing.configProperties .Values.wso2.apk.dp.gatewayRuntime.tracing.configProperties.tls .Values.wso2.apk.dp.gatewayRuntime.tracing.configProperties.tls.enabled }}
       - objectName: tracing-ca.crt
-        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.tracingCaCert.key | quote }}
-        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.tracingCaCert.path | quote }}
+        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.tracingCaCert.vault.secretKey | quote }}
+        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.tracingCaCert.vault.secretPath | quote }}
       - objectName: tracing.crt
-        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.tracingCert.key | quote }}
-        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.tracingCert.path | quote }}
+        secretKey: {{ .Values.wso2.apk.secretProviderClass.secrets.tracingCert.vault.secretKey | quote }}
+        secretPath: {{ .Values.wso2.apk.secretProviderClass.secrets.tracingCert.vault.secretPath | quote }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/helm-charts/values.yaml
+++ b/helm-charts/values.yaml
@@ -41,74 +41,166 @@ wso2:
         azureTenantID: ""
       secrets:
         ratelimiterRedisCredentials:
-          key: ""
-          path: ""
+          azure:
+            secretName: ""
+            version: ""
+          vault:
+            secretKey: ""
+            secretPath: ""
         adapterKey:
-          key: ""
-          path: ""
+          azure:
+            secretName: ""
+            version: ""
+          vault:
+            secretKey: ""
+            secretPath: ""
         adapterCert:
-          key: ""
-          path: ""
+          azure:
+            secretName: ""
+            version: ""
+          vault:
+            secretKey: ""
+            secretPath: ""
         adapterCaCert:
-          key: ""
-          path: ""
+          azure:
+            secretName: ""
+            version: ""
+          vault:
+            secretKey: ""
+            secretPath: ""
         enforcerKey:
-          key: ""
-          path: ""
+          azure:
+            secretName: ""
+            version: ""
+          vault:
+            secretKey: ""
+            secretPath: ""
         enforcerCert:
-          key: ""
-          path: ""
+          azure:
+            secretName: ""
+            version: ""
+          vault:
+            secretKey: ""
+            secretPath: ""
         enforcerCaCert:
-          key: ""
-          path: ""
+          azure:
+            secretName: ""
+            version: ""
+          vault:
+            secretKey: ""
+            secretPath: ""
         routerKey:
-          key: ""
-          path: ""
+          azure:
+            secretName: ""
+            version: ""
+          vault:
+            secretKey: ""
+            secretPath: ""
         routerCert:
-          key: ""
-          path: ""
+          azure:
+            secretName: ""
+            version: ""
+          vault:
+            secretKey: ""
+            secretPath: ""
         routerCaCert:
-          key: ""
-          path: ""
+          azure:
+            secretName: ""
+            version: ""
+          vault:
+            secretKey: ""
+            secretPath: ""
         ratelimiterKey:
-          key: ""
-          path: ""
+          azure:
+            secretName: ""
+            version: ""
+          vault:
+            secretKey: ""
+            secretPath: ""
         ratelimiterCert:
-          key: ""
-          path: ""
+          azure:
+            secretName: ""
+            version: ""
+          vault:
+            secretKey: ""
+            secretPath: ""
         ratelimiterCaCert:
-          key: ""
-          path: ""
+          azure:
+            secretName: ""
+            version: ""
+          vault:
+            secretKey: ""
+            secretPath: ""
         commonControllerKey:
-          key: ""
-          path: ""
+          azure:
+            secretName: ""
+            version: ""
+          vault:
+            secretKey: ""
+            secretPath: ""
         commonControllerCert:
-          key: ""
-          path: ""
+          azure:
+            secretName: ""
+            version: ""
+          vault:
+            secretKey: ""
+            secretPath: ""
         commonControllerCaCert:
-          key: ""
-          path: ""
+          azure:
+            secretName: ""
+            version: ""
+          vault:
+            secretKey: ""
+            secretPath: ""
         systemApiListenerKey:
-          key: ""
-          path: ""
+          azure:
+            secretName: ""
+            version: ""
+          vault:
+            secretKey: ""
+            secretPath: ""
         systemApiListenerCert:
-          key: ""
-          path: ""
+          azure:
+            secretName: ""
+            version: ""
+          vault:
+            secretKey: ""
+            secretPath: ""
         enforcerJwksKey:
-          key: ""
-          path: ""
+          azure:
+            secretName: ""
+            version: ""
+          vault:
+            secretKey: ""
+            secretPath: ""
         enforcerJwksCert:
-          key: ""
-          path: ""
+          azure:
+            secretName: ""
+            version: ""
+          vault:
+            secretKey: ""
+            secretPath: ""
         enforcerJwksCaCert:
-          key: ""
-          path: ""
+          azure:
+            secretName: ""
+            version: ""
+          vault:
+            secretKey: ""
+            secretPath: ""
         tracingCaCert:
-          key: ""
-          path: ""
+          azure:
+            secretName: ""
+            version: ""
+          vault:
+            secretKey: ""
+            secretPath: ""
         tracingCert:
-          key: ""
-          path: ""
+          azure:
+            secretName: ""
+            version: ""
+          vault:
+            secretKey: ""
+            secretPath: ""
     helmHooks:
       webhooksCleanupEnabled: true
       webhooksCleanup:

--- a/helm-charts/values.yaml
+++ b/helm-charts/values.yaml
@@ -45,162 +45,162 @@ wso2:
             secretName: ""
             version: ""
           vault:
-            secretKey: ""
-            secretPath: ""
+            key: ""
+            path: ""
         adapterKey:
           azure:
             secretName: ""
             version: ""
           vault:
-            secretKey: ""
-            secretPath: ""
+            key: ""
+            path: ""
         adapterCert:
           azure:
             secretName: ""
             version: ""
           vault:
-            secretKey: ""
-            secretPath: ""
+            key: ""
+            path: ""
         adapterCaCert:
           azure:
             secretName: ""
             version: ""
           vault:
-            secretKey: ""
-            secretPath: ""
+            key: ""
+            path: ""
         enforcerKey:
           azure:
             secretName: ""
             version: ""
           vault:
-            secretKey: ""
-            secretPath: ""
+            key: ""
+            path: ""
         enforcerCert:
           azure:
             secretName: ""
             version: ""
           vault:
-            secretKey: ""
-            secretPath: ""
+            key: ""
+            path: ""
         enforcerCaCert:
           azure:
             secretName: ""
             version: ""
           vault:
-            secretKey: ""
-            secretPath: ""
+            key: ""
+            path: ""
         routerKey:
           azure:
             secretName: ""
             version: ""
           vault:
-            secretKey: ""
-            secretPath: ""
+            key: ""
+            path: ""
         routerCert:
           azure:
             secretName: ""
             version: ""
           vault:
-            secretKey: ""
-            secretPath: ""
+            key: ""
+            path: ""
         routerCaCert:
           azure:
             secretName: ""
             version: ""
           vault:
-            secretKey: ""
-            secretPath: ""
+            key: ""
+            path: ""
         ratelimiterKey:
           azure:
             secretName: ""
             version: ""
           vault:
-            secretKey: ""
-            secretPath: ""
+            key: ""
+            path: ""
         ratelimiterCert:
           azure:
             secretName: ""
             version: ""
           vault:
-            secretKey: ""
-            secretPath: ""
+            key: ""
+            path: ""
         ratelimiterCaCert:
           azure:
             secretName: ""
             version: ""
           vault:
-            secretKey: ""
-            secretPath: ""
+            key: ""
+            path: ""
         commonControllerKey:
           azure:
             secretName: ""
             version: ""
           vault:
-            secretKey: ""
-            secretPath: ""
+            key: ""
+            path: ""
         commonControllerCert:
           azure:
             secretName: ""
             version: ""
           vault:
-            secretKey: ""
-            secretPath: ""
+            key: ""
+            path: ""
         commonControllerCaCert:
           azure:
             secretName: ""
             version: ""
           vault:
-            secretKey: ""
-            secretPath: ""
+            key: ""
+            path: ""
         systemApiListenerKey:
           azure:
             secretName: ""
             version: ""
           vault:
-            secretKey: ""
-            secretPath: ""
+            key: ""
+            path: ""
         systemApiListenerCert:
           azure:
             secretName: ""
             version: ""
           vault:
-            secretKey: ""
-            secretPath: ""
+            key: ""
+            path: ""
         enforcerJwksKey:
           azure:
             secretName: ""
             version: ""
           vault:
-            secretKey: ""
-            secretPath: ""
+            key: ""
+            path: ""
         enforcerJwksCert:
           azure:
             secretName: ""
             version: ""
           vault:
-            secretKey: ""
-            secretPath: ""
+            key: ""
+            path: ""
         enforcerJwksCaCert:
           azure:
             secretName: ""
             version: ""
           vault:
-            secretKey: ""
-            secretPath: ""
+            key: ""
+            path: ""
         tracingCaCert:
           azure:
             secretName: ""
             version: ""
           vault:
-            secretKey: ""
-            secretPath: ""
+            key: ""
+            path: ""
         tracingCert:
           azure:
             secretName: ""
             version: ""
           vault:
-            secretKey: ""
-            secretPath: ""
+            key: ""
+            path: ""
     helmHooks:
       webhooksCleanupEnabled: true
       webhooksCleanup:


### PR DESCRIPTION
## Purpose

This pull request updates the way secret keys and paths are referenced in the Helm chart templates for both Azure and Vault secret providers. The main change is to use provider-specific nested fields (`azure` or `vault`) for secret names, keys, paths, and versions, improving clarity and maintainability in secret management.

## Approach

Secret provider template updates:

#### Azure Secret Provider (`secret-provider-azure.yaml`)
* All secret references now use `.azure.secretName` and `.azure.version` fields instead of the previous `.key` and `.path` for each secret object, ensuring consistency with Azure's secret structure.

## Related Issue

https://github.com/wso2-enterprise/apim-saas/issues/1440