### PR TITLE
Update helm chart to support azure key vault specific certificate secret

### DIFF
--- a/helm-charts/Chart.yaml
+++ b/helm-charts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: choreo-apk
 description: A Helm chart for APK components
 type: application
-version: 1.3.0-9
+version: 1.3.0-10
 appVersion: "1.3.0"
 dependencies:
   - name: postgresql

--- a/helm-charts/templates/data-plane/gateway-components/adapter/adapter-deployment.yaml
+++ b/helm-charts/templates/data-plane/gateway-components/adapter/adapter-deployment.yaml
@@ -72,6 +72,23 @@ spec:
             value: {{ template "apk-helm.resource.prefix" . }}-adapter-service.{{ .Release.Namespace }}.svc
           volumeMounts:
           {{- if .Values.wso2.apk.secretProviderClass.enabled }}
+            {{- if eq .Values.wso2.apk.secretProviderClass.provider "azure" }}
+            - name: apk-server-tls-secret-volume
+              mountPath: /home/wso2/security/keystore/adapter.key
+              subPath: tls.key
+            - name: apk-server-tls-secret-volume
+              mountPath: /home/wso2/security/keystore/adapter.crt
+              subPath: tls.crt
+            - name: secret-provider-class
+              mountPath: /home/wso2/security/truststore/adapter-ca.crt
+              subPath: adapter-ca.crt
+            - name: apk-server-tls-secret-volume
+              mountPath: /home/wso2/security/truststore/router.crt
+              subPath: tls.crt
+            - name: enforcer-jwks-tls-secret-volume
+              mountPath: /home/wso2/security/truststore/enforcer.crt
+              subPath: tls.crt
+            {{- else }}
             - name: secret-provider-class
               mountPath: /home/wso2/security/keystore/adapter.key
               subPath: adapter.key
@@ -87,6 +104,7 @@ spec:
             - name: secret-provider-class
               mountPath: /home/wso2/security/truststore/enforcer.crt
               subPath: enforcer.crt # TODO: (renuka) should be enforcer-ca.crt check this
+            {{- end }}
           {{- else }}
             - name: adapter-keystore-secret-volume
               mountPath: /home/wso2/security/keystore/adapter.key
@@ -183,6 +201,16 @@ spec:
             readOnly: true
             volumeAttributes:
               secretProviderClass: {{ template "apk-helm.resource.prefix" . }}-secrets
+        {{- if eq .Values.wso2.apk.secretProviderClass.provider "azure" }}
+        - name: apk-server-tls-secret-volume
+          secret:
+            secretName: {{ template "apk-helm.resource.prefix" . }}-apk-server-tls
+            defaultMode: 420
+        - name: enforcer-jwks-tls-secret-volume
+          secret:
+            secretName: {{ template "apk-helm.resource.prefix" . }}-enforcer-jwks-tls
+            defaultMode: 420
+        {{- end }}
       {{- else }}
         - name: adapter-keystore-secret-volume
           secret:

--- a/helm-charts/templates/data-plane/gateway-components/common-controller/common-controller-deployment.yaml
+++ b/helm-charts/templates/data-plane/gateway-components/common-controller/common-controller-deployment.yaml
@@ -74,6 +74,31 @@ spec:
             value: {{ template "apk-helm.resource.prefix" . }}-common-controller-service.{{ .Release.Namespace }}.svc
           volumeMounts:
       {{- if .Values.wso2.apk.secretProviderClass.enabled }}
+            {{- if eq .Values.wso2.apk.secretProviderClass.provider "azure" }}
+            - name: apk-server-tls-secret-volume
+              mountPath: /home/wso2/security/keystore/commoncontroller.key
+              subPath: tls.key
+            - name: apk-server-tls-secret-volume
+              mountPath: /home/wso2/security/keystore/commoncontroller.crt
+              subPath: tls.crt
+            - name: secret-provider-class
+              mountPath: /home/wso2/security/truststore/adapter-ca.crt
+              subPath: adapter-ca.crt
+            - name: apk-server-tls-secret-volume
+              mountPath: /tmp/k8s-webhook-server/serving-certs/tls.key
+              subPath: tls.key
+            - name: apk-server-tls-secret-volume
+              mountPath: /tmp/k8s-webhook-server/serving-certs/tls.crt
+              subPath: tls.crt
+            - name: secret-provider-class
+              mountPath: /tmp/k8s-webhook-server/serving-certs/ca.crt
+              subPath: commoncontroller-ca.crt
+            {{- if and .Values.wso2.apk.dp.enabled .Values.wso2.apk.dp.ratelimiter.enabled }}
+            - name: secret-provider-class
+              mountPath: /home/wso2/security/truststore/ratelimiter-ca.crt
+              subPath: ratelimiter-ca.crt
+            {{- end }}
+            {{- else }}
             - name: secret-provider-class
               mountPath: /home/wso2/security/keystore/commoncontroller.key
               subPath: commoncontroller.key
@@ -96,6 +121,7 @@ spec:
             - name: secret-provider-class
               mountPath: /home/wso2/security/truststore/ratelimiter-ca.crt
               subPath: ratelimiter-ca.crt
+            {{- end }}
             {{- end }}
       {{- else }}
             - name: common-controller-keystore-secret-volume
@@ -181,6 +207,12 @@ spec:
             readOnly: true
             volumeAttributes:
               secretProviderClass: {{ template "apk-helm.resource.prefix" . }}-secrets
+        {{- if eq .Values.wso2.apk.secretProviderClass.provider "azure" }}
+        - name: apk-server-tls-secret-volume
+          secret:
+            secretName: {{ template "apk-helm.resource.prefix" . }}-apk-server-tls
+            defaultMode: 420
+        {{- end }}
       {{- else }}
         - name: common-controller-keystore-secret-volume
           secret:

--- a/helm-charts/templates/data-plane/gateway-components/gateway-runtime/gateway-runtime-deployment.yaml
+++ b/helm-charts/templates/data-plane/gateway-components/gateway-runtime/gateway-runtime-deployment.yaml
@@ -188,6 +188,40 @@ spec:
             - name: tmp
               mountPath: /tmp
           {{- if .Values.wso2.apk.secretProviderClass.enabled }}
+            {{- if eq .Values.wso2.apk.secretProviderClass.provider "azure" }}
+            - name: apk-server-tls-secret-volume
+              mountPath: /home/wso2/security/keystore/enforcer.key
+              subPath: tls.key
+            - name: apk-server-tls-secret-volume
+              mountPath: /home/wso2/security/keystore/enforcer.crt
+              subPath: tls.crt
+            - name: secret-provider-class
+              mountPath: /home/wso2/security/truststore/apk.crt
+              subPath: enforcer-ca.crt
+            - name: secret-provider-class
+              mountPath: /home/wso2/security/truststore/enforcer.crt
+              subPath: enforcer-ca.crt
+            - name: secret-provider-class
+              mountPath: /home/wso2/security/truststore/adapter.crt
+              subPath: adapter-ca.crt
+            - name: secret-provider-class
+              mountPath: /home/wso2/security/truststore/router.crt
+              subPath: router-ca.crt
+            - name: enforcer-jwks-tls-secret-volume
+              mountPath: /home/wso2/security/keystore/mg.key
+              subPath: tls.key
+            - name: enforcer-jwks-tls-secret-volume
+              mountPath: /home/wso2/security/keystore/mg.pem
+              subPath: tls.crt
+            - name: secret-provider-class
+              mountPath: /home/wso2/security/truststore/mg.pem
+              subPath: enforcer-jwks-ca.crt
+            {{- if and .Values.wso2.apk.dp.enabled .Values.wso2.apk.dp.ratelimiter.enabled }}
+            - name: apk-server-tls-secret-volume
+              mountPath: /home/wso2/security/truststore/ratelimiter.crt
+              subPath: tls.crt
+            {{- end }}
+            {{- else }}
             - name: secret-provider-class
               mountPath: /home/wso2/security/keystore/enforcer.key
               subPath: enforcer.key
@@ -221,6 +255,7 @@ spec:
             - name: secret-provider-class
               mountPath: /home/wso2/security/truststore/ratelimiter.crt
               subPath: ratelimiter.crt
+            {{- end }}
             {{- end }}
           {{- else }}
             - name: enforcer-keystore-secret-volume
@@ -387,6 +422,25 @@ spec:
               value: "2"
           volumeMounts:
           {{- if .Values.wso2.apk.secretProviderClass.enabled }}
+            {{- if eq .Values.wso2.apk.secretProviderClass.provider "azure" }}
+            - name: apk-server-tls-secret-volume
+              mountPath: /home/wso2/security/keystore/router.key
+              subPath: tls.key
+            - name: apk-server-tls-secret-volume
+              mountPath: /home/wso2/security/keystore/router.crt
+              subPath: tls.crt
+            - name: secret-provider-class
+              mountPath: /home/wso2/security/truststore/adapter.crt
+              subPath: adapter-ca.crt
+            - name: secret-provider-class
+              mountPath: /home/wso2/security/truststore/enforcer.crt
+              subPath: enforcer-ca.crt
+            {{- if and .Values.wso2.apk.dp.enabled .Values.wso2.apk.dp.ratelimiter.enabled }}
+            - name: apk-server-tls-secret-volume
+              mountPath: /home/wso2/security/truststore/ratelimiter.crt
+              subPath: tls.crt
+            {{- end }}
+            {{- else }}
             - name: secret-provider-class
               mountPath: /home/wso2/security/keystore/router.key
               subPath: router.key
@@ -404,6 +458,7 @@ spec:
             - name: secret-provider-class
               mountPath: /home/wso2/security/truststore/ratelimiter.crt
               subPath: ratelimiter.crt
+            {{- end }}
             {{- end }}
           {{- else }}
             - name: router-keystore-secret-volume
@@ -492,6 +547,16 @@ spec:
             readOnly: true
             volumeAttributes:
               secretProviderClass: {{ template "apk-helm.resource.prefix" . }}-secrets
+        {{- if eq .Values.wso2.apk.secretProviderClass.provider "azure" }}
+        - name: apk-server-tls-secret-volume
+          secret:
+            secretName: {{ template "apk-helm.resource.prefix" . }}-apk-server-tls
+            defaultMode: 420
+        - name: enforcer-jwks-tls-secret-volume
+          secret:
+            secretName: {{ template "apk-helm.resource.prefix" . }}-enforcer-jwks-tls
+            defaultMode: 420
+        {{- end }}
       {{- else }}
       {{ if and .Values.wso2.apk.dp.enabled .Values.wso2.apk.dp.ratelimiter.enabled }}
         - name: ratelimiter-truststore-secret-volume

--- a/helm-charts/templates/data-plane/ratelimiter/ratelimiter-deployment.yaml
+++ b/helm-charts/templates/data-plane/ratelimiter/ratelimiter-deployment.yaml
@@ -176,6 +176,23 @@ spec:
             {{ end }}
           volumeMounts:
           {{- if .Values.wso2.apk.secretProviderClass.enabled }}
+            {{- if eq .Values.wso2.apk.secretProviderClass.provider "azure" }}
+            - name: apk-server-tls-secret-volume
+              mountPath: /home/wso2/security/keystore/ratelimiter.key
+              subPath: tls.key
+            - name: apk-server-tls-secret-volume
+              mountPath: /home/wso2/security/keystore/ratelimiter.crt
+              subPath: tls.crt
+            - name: secret-provider-class
+              mountPath: /home/wso2/security/truststore/ratelimiter-ca.crt
+              subPath: ratelimiter-ca.crt
+            - name: secret-provider-class
+              mountPath: /home/wso2/security/truststore/adapter.pem
+              subPath: adapter-ca.crt
+            - name: secret-provider-class
+              mountPath: /home/wso2/security/truststore/router.pem
+              subPath: router-ca.crt
+            {{- else }}
             - name: secret-provider-class
               mountPath: /home/wso2/security/keystore/ratelimiter.key
               subPath: ratelimiter.key
@@ -191,6 +208,7 @@ spec:
             - name: secret-provider-class
               mountPath: /home/wso2/security/truststore/router.pem
               subPath: router-ca.crt
+            {{- end }}
           {{- else }}
             - name: ratelimiter-keystore-secret-volume
               mountPath: /home/wso2/security/keystore/ratelimiter.key
@@ -283,6 +301,12 @@ spec:
             readOnly: true
             volumeAttributes:
               secretProviderClass: {{ template "apk-helm.resource.prefix" . }}-secrets
+        {{- if eq .Values.wso2.apk.secretProviderClass.provider "azure" }}
+        - name: apk-server-tls-secret-volume
+          secret:
+            secretName: {{ template "apk-helm.resource.prefix" . }}-apk-server-tls
+            defaultMode: 420
+        {{- end }}
       {{- else }}
         - name: ratelimiter-keystore-secret-volume
           secret:

--- a/helm-charts/templates/secret-providers/secret-provider-azure.yaml
+++ b/helm-charts/templates/secret-providers/secret-provider-azure.yaml
@@ -43,71 +43,53 @@ spec:
           key: tls.key
         - objectName: router.crt
           key: tls.crt
+    - secretName: {{ template "apk-helm.resource.prefix" . }}-apk-server-tls
+      type: kubernetes.io/tls
+      data:
+        - objectName: apk-server.key
+          key: tls.key
+        - objectName: apk-server.crt
+          key: tls.crt
+    - secretName: {{ template "apk-helm.resource.prefix" . }}-enforcer-jwks-tls
+      type: kubernetes.io/tls
+      data:
+        - objectName: enforcer-jwks.key
+          key: tls.key
+        - objectName: enforcer-jwks.crt
+          key: tls.crt
   parameters:
-    keyvaultName: {{ .Values.global.keyVaultName }}
-    tenantId: {{ .Values.global.azureTenantID }}
+    keyvaultName: {{ .Values.wso2.apk.secretProviderClass.azure.keyVaultName }}
+    tenantId: {{ .Values.wso2.apk.secretProviderClass.azure.tenantId }}
     usePodIdentity: "false"
     objects: |
       - objectAlias: ratelimiter_redis_credentials
         objectType: secret
         objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.ratelimiterRedisCredentials.azure.secretName | quote }}
         objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.ratelimiterRedisCredentials.azure.version | quote }}
-      - objectAlias: adapter.key
+      - objectAlias: apk-server.key
         objectType: secret
-        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.adapterKey.azure.secretName | quote }}
-        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.adapterKey.azure.version | quote }}
-      - objectAlias: adapter.crt
+        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.apkServerKey.secretName | quote }}
+        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.apkServerKey.version | quote }}
+      - objectAlias: apk-server.crt
         objectType: secret
-        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.adapterCert.azure.secretName | quote }}
-        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.adapterCert.azure.version | quote }}
+        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.apkServerCert.secretName | quote }}
+        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.apkServerCert.version | quote }}
       - objectAlias: adapter-ca.crt
         objectType: secret
         objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.adapterCaCert.azure.secretName | quote }}
         objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.adapterCaCert.azure.version | quote }}
-      - objectAlias: enforcer.key
-        objectType: secret
-        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerKey.azure.secretName | quote }}
-        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerKey.azure.version | quote }}
-      - objectAlias: enforcer.crt
-        objectType: secret
-        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerCert.azure.secretName | quote }}
-        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerCert.azure.version | quote }}
       - objectAlias: enforcer-ca.crt
         objectType: secret
         objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerCaCert.azure.secretName | quote }}
         objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerCaCert.azure.version | quote }}
-      - objectAlias: router.key
-        objectType: secret
-        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.routerKey.azure.secretName | quote }}
-        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.routerKey.azure.version | quote }}
-      - objectAlias: router.crt
-        objectType: secret
-        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.routerCert.azure.secretName | quote }}
-        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.routerCert.azure.version | quote }}
       - objectAlias: router-ca.crt
         objectType: secret
         objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.routerCaCert.azure.secretName | quote }}
         objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.routerCaCert.azure.version | quote }}
-      - objectAlias: ratelimiter.key
-        objectType: secret
-        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.ratelimiterKey.azure.secretName | quote }}
-        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.ratelimiterKey.azure.version | quote }}
-      - objectAlias: ratelimiter.crt
-        objectType: secret
-        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.ratelimiterCert.azure.secretName | quote }}
-        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.ratelimiterCert.azure.version | quote }}
       - objectAlias: ratelimiter-ca.crt
         objectType: secret
         objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.ratelimiterCaCert.azure.secretName | quote }}
         objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.ratelimiterCaCert.azure.version | quote }}
-      - objectAlias: commoncontroller.key
-        objectType: secret
-        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.commonControllerKey.azure.secretName | quote }}
-        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.commonControllerKey.azure.version | quote }}
-      - objectAlias: commoncontroller.crt
-        objectType: secret
-        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.commonControllerCert.azure.secretName | quote }}
-        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.commonControllerCert.azure.version | quote }}
       - objectAlias: commoncontroller-ca.crt
         objectType: secret
         objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.commonControllerCaCert.azure.secretName | quote }}
@@ -120,14 +102,6 @@ spec:
         objectType: secret
         objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.systemApiListenerCert.azure.secretName | quote }}
         objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.systemApiListenerCert.azure.version | quote }}
-      - objectAlias: enforcer-jwks.key
-        objectType: secret
-        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerJwksKey.azure.secretName | quote }}
-        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerJwksKey.azure.version | quote }}
-      - objectAlias: enforcer-jwks.crt
-        objectType: secret
-        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerJwksCert.azure.secretName | quote }}
-        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerJwksCert.azure.version | quote }}
       - objectAlias: enforcer-jwks-ca.crt
         objectType: secret
         objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerJwksCaCert.azure.secretName | quote }}

--- a/helm-charts/values.yaml
+++ b/helm-charts/values.yaml
@@ -37,9 +37,16 @@ wso2:
       vault:
         url: ""
         roleName: ""
+      azure:
         keyVaultName: ""
-        azureTenantID: ""
+        tenantId: ""
       secrets:
+        apkServerKey:
+          secretName: ""
+          version: ""
+        apkServerCert:
+          secretName: ""
+          version: ""
         ratelimiterRedisCredentials:
           azure:
             secretName: ""
@@ -48,16 +55,10 @@ wso2:
             key: ""
             path: ""
         adapterKey:
-          azure:
-            secretName: ""
-            version: ""
           vault:
             key: ""
             path: ""
         adapterCert:
-          azure:
-            secretName: ""
-            version: ""
           vault:
             key: ""
             path: ""
@@ -69,16 +70,10 @@ wso2:
             key: ""
             path: ""
         enforcerKey:
-          azure:
-            secretName: ""
-            version: ""
           vault:
             key: ""
             path: ""
         enforcerCert:
-          azure:
-            secretName: ""
-            version: ""
           vault:
             key: ""
             path: ""
@@ -90,16 +85,10 @@ wso2:
             key: ""
             path: ""
         routerKey:
-          azure:
-            secretName: ""
-            version: ""
           vault:
             key: ""
             path: ""
         routerCert:
-          azure:
-            secretName: ""
-            version: ""
           vault:
             key: ""
             path: ""
@@ -111,16 +100,10 @@ wso2:
             key: ""
             path: ""
         ratelimiterKey:
-          azure:
-            secretName: ""
-            version: ""
           vault:
             key: ""
             path: ""
         ratelimiterCert:
-          azure:
-            secretName: ""
-            version: ""
           vault:
             key: ""
             path: ""
@@ -132,16 +115,10 @@ wso2:
             key: ""
             path: ""
         commonControllerKey:
-          azure:
-            secretName: ""
-            version: ""
           vault:
             key: ""
             path: ""
         commonControllerCert:
-          azure:
-            secretName: ""
-            version: ""
           vault:
             key: ""
             path: ""
@@ -167,16 +144,10 @@ wso2:
             key: ""
             path: ""
         enforcerJwksKey:
-          azure:
-            secretName: ""
-            version: ""
           vault:
             key: ""
             path: ""
         enforcerJwksCert:
-          azure:
-            secretName: ""
-            version: ""
           vault:
             key: ""
             path: ""


### PR DESCRIPTION
## Purpose

This pull request introduces significant improvements to Azure Key Vault integration for Helm deployments of APK components. The changes standardize and streamline how secrets and TLS certificates are managed and mounted for Azure, update secret references and naming conventions, and enhance support for Azure-specific configurations across multiple components.

## Approach

**Azure Key Vault Integration and Secret Handling**
* Added explicit support for Azure as a secret provider, with conditional logic in deployment templates to mount secrets and TLS certificates from Azure Key Vault for all major components (`adapter`, `common-controller`, `gateway-runtime`, `ratelimiter`). This includes new volume mounts and secret references for Azure-provided TLS assets. 
* Updated the `secret-provider-azure.yaml` template to add new secret definitions (`apk-server-tls`, `enforcer-jwks-tls`) and refactored object aliases and references to align with Azure Key Vault naming and structure. This also includes changes to parameter names (e.g., `tenantId` instead of `azureTenantID`). 
**Helm Values and Configuration**
* Extended `values.yaml` to include Azure-specific configuration fields for Key Vault and new secret references (`apkServerKey`, `apkServerCert`, etc.), improving clarity and flexibility for Azure deployments.

**Versioning**
* Bumped the Helm chart version from `1.3.0-9` to `1.3.0-10` to reflect these updates.

**Conditional Logic and Volume Mounts**
* Added Azure-specific conditional blocks in deployment templates to ensure correct mounting of secrets and certificates only when Azure is selected as the provider, reducing the risk of misconfiguration and improving maintainability. 
