### PR TITLE
Fix secret provider template for azure

### DIFF
--- a/helm-charts/Chart.yaml
+++ b/helm-charts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: choreo-apk
 description: A Helm chart for APK components
 type: application
-version: 1.3.0-10
+version: 1.3.0-11
 appVersion: "1.3.0"
 dependencies:
   - name: postgresql

--- a/helm-charts/templates/secret-providers/secret-provider-azure.yaml
+++ b/helm-charts/templates/secret-providers/secret-provider-azure.yaml
@@ -34,28 +34,28 @@ spec:
       data:
         - objectName: system-api-listener.key
           key: tls.key
-        - objectName: system-api-listener.crt
+        - objectName: system-api-listener.key
           key: tls.crt
     - secretName: {{ template "apk-helm.resource.prefix" . }}-router-tls
       type: Opaque
       data:
-        - objectName: router.key
+        - objectName: apk-server.key
           key: tls.key
-        - objectName: router.crt
+        - objectName: apk-server.key
           key: tls.crt
     - secretName: {{ template "apk-helm.resource.prefix" . }}-apk-server-tls
       type: kubernetes.io/tls
       data:
         - objectName: apk-server.key
           key: tls.key
-        - objectName: apk-server.crt
+        - objectName: apk-server.key
           key: tls.crt
     - secretName: {{ template "apk-helm.resource.prefix" . }}-enforcer-jwks-tls
       type: kubernetes.io/tls
       data:
         - objectName: enforcer-jwks.key
           key: tls.key
-        - objectName: enforcer-jwks.crt
+        - objectName: enforcer-jwks.key
           key: tls.crt
   parameters:
     keyvaultName: {{ .Values.wso2.apk.secretProviderClass.azure.keyVaultName }}
@@ -68,12 +68,16 @@ spec:
         objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.ratelimiterRedisCredentials.azure.version | quote }}
       - objectAlias: apk-server.key
         objectType: secret
-        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.apkServerKey.secretName | quote }}
-        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.apkServerKey.version | quote }}
-      - objectAlias: apk-server.crt
+        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.apkServerKey.azure.secretName | quote }}
+        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.apkServerKey.azure.version | quote }}
+      - objectAlias: enforcer-jwks.key
         objectType: secret
-        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.apkServerCert.secretName | quote }}
-        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.apkServerCert.version | quote }}
+        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerJwksKey.azure.secretName | quote }}
+        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerJwksKey.azure.version | quote }}
+      - objectAlias: system-api-listener.key
+        objectType: secret
+        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.systemApiListenerKey.azure.secretName | quote }}
+        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.systemApiListenerKey.azure.version | quote }}
       - objectAlias: adapter-ca.crt
         objectType: secret
         objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.adapterCaCert.azure.secretName | quote }}
@@ -94,14 +98,6 @@ spec:
         objectType: secret
         objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.commonControllerCaCert.azure.secretName | quote }}
         objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.commonControllerCaCert.azure.version | quote }}
-      - objectAlias: system-api-listener.key
-        objectType: secret
-        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.systemApiListenerKey.azure.secretName | quote }}
-        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.systemApiListenerKey.azure.version | quote }}
-      - objectAlias: system-api-listener.crt
-        objectType: secret
-        objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.systemApiListenerCert.azure.secretName | quote }}
-        objectVersion: {{ .Values.wso2.apk.secretProviderClass.secrets.systemApiListenerCert.azure.version | quote }}
       - objectAlias: enforcer-jwks-ca.crt
         objectType: secret
         objectName: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerJwksCaCert.azure.secretName | quote }}

--- a/helm-charts/values.yaml
+++ b/helm-charts/values.yaml
@@ -42,11 +42,9 @@ wso2:
         tenantId: ""
       secrets:
         apkServerKey:
-          secretName: ""
-          version: ""
-        apkServerCert:
-          secretName: ""
-          version: ""
+          azure:
+            secretName: ""
+            version: ""
         ratelimiterRedisCredentials:
           azure:
             secretName: ""
@@ -144,6 +142,9 @@ wso2:
             key: ""
             path: ""
         enforcerJwksKey:
+          azure:
+            secretName: ""
+            secretVersion: ""
           vault:
             key: ""
             path: ""


### PR DESCRIPTION
## Purpose

This pull request updates the Azure secret provider configuration in the Helm chart to streamline secret management and improve consistency. The main changes include consolidating key and certificate references, updating secret definitions to use the new Azure structure, and removing unused certificate object aliases.

## Approach

**Secret definition and referencing updates:**

* Updated the `apkServerKey` and `enforcerJwksKey` secret definitions in `values.yaml` to use the new `azure` structure, which nests `secretName` and `version` under the `azure` key.

**Removal of unused certificate aliases:**

* Removed the `system-api-listener.crt` and other certificate object aliases from the secret provider template, ensuring only key objects are referenced for both key and certificate data.

