### PR TITLE
Add nodePublishSecretRef to secret provider class volumes

### DIFF
--- a/helm-charts/Chart.yaml
+++ b/helm-charts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: choreo-apk
 description: A Helm chart for APK components
 type: application
-version: 1.3.0-11
+version: 1.3.0-12
 appVersion: "1.3.0"
 dependencies:
   - name: postgresql

--- a/helm-charts/templates/data-plane/gateway-components/adapter/adapter-deployment.yaml
+++ b/helm-charts/templates/data-plane/gateway-components/adapter/adapter-deployment.yaml
@@ -201,6 +201,10 @@ spec:
             readOnly: true
             volumeAttributes:
               secretProviderClass: {{ template "apk-helm.resource.prefix" . }}-secrets
+            {{- if .Values.wso2.apk.secretProviderClass.nodePublishSecretRef }}
+            nodePublishSecretRef:
+              name: {{ .Values.wso2.apk.secretProviderClass.nodePublishSecretRef }}
+            {{- end }}
         {{- if eq .Values.wso2.apk.secretProviderClass.provider "azure" }}
         - name: apk-server-tls-secret-volume
           secret:

--- a/helm-charts/templates/data-plane/gateway-components/common-controller/common-controller-deployment.yaml
+++ b/helm-charts/templates/data-plane/gateway-components/common-controller/common-controller-deployment.yaml
@@ -207,6 +207,10 @@ spec:
             readOnly: true
             volumeAttributes:
               secretProviderClass: {{ template "apk-helm.resource.prefix" . }}-secrets
+            {{- if .Values.wso2.apk.secretProviderClass.nodePublishSecretRef }}
+            nodePublishSecretRef:
+              name: {{ .Values.wso2.apk.secretProviderClass.nodePublishSecretRef }}
+            {{- end }}
         {{- if eq .Values.wso2.apk.secretProviderClass.provider "azure" }}
         - name: apk-server-tls-secret-volume
           secret:

--- a/helm-charts/templates/data-plane/gateway-components/gateway-runtime/gateway-runtime-deployment.yaml
+++ b/helm-charts/templates/data-plane/gateway-components/gateway-runtime/gateway-runtime-deployment.yaml
@@ -547,6 +547,10 @@ spec:
             readOnly: true
             volumeAttributes:
               secretProviderClass: {{ template "apk-helm.resource.prefix" . }}-secrets
+            {{- if .Values.wso2.apk.secretProviderClass.nodePublishSecretRef }}
+            nodePublishSecretRef:
+              name: {{ .Values.wso2.apk.secretProviderClass.nodePublishSecretRef }}
+            {{- end }}
         {{- if eq .Values.wso2.apk.secretProviderClass.provider "azure" }}
         - name: apk-server-tls-secret-volume
           secret:

--- a/helm-charts/templates/data-plane/ratelimiter/ratelimiter-deployment.yaml
+++ b/helm-charts/templates/data-plane/ratelimiter/ratelimiter-deployment.yaml
@@ -301,6 +301,10 @@ spec:
             readOnly: true
             volumeAttributes:
               secretProviderClass: {{ template "apk-helm.resource.prefix" . }}-secrets
+            {{- if .Values.wso2.apk.secretProviderClass.nodePublishSecretRef }}
+            nodePublishSecretRef:
+              name: {{ .Values.wso2.apk.secretProviderClass.nodePublishSecretRef }}
+            {{- end }}
         {{- if eq .Values.wso2.apk.secretProviderClass.provider "azure" }}
         - name: apk-server-tls-secret-volume
           secret:

--- a/helm-charts/values.yaml
+++ b/helm-charts/values.yaml
@@ -40,6 +40,7 @@ wso2:
       azure:
         keyVaultName: ""
         tenantId: ""
+      nodePublishSecretRef: ""
       secrets:
         apkServerKey:
           azure:


### PR DESCRIPTION
## Purpose

This pull request enhances the configuration of secret provider classes in several Helm chart deployment templates by introducing support for the `nodePublishSecretRef` parameter. 

## Approach

**Helm chart deployment improvements:**

* Added support for the optional `nodePublishSecretRef` parameter in the secret volume configuration for the following deployments: `adapter-deployment.yaml`, `common-controller-deployment.yaml`, `gateway-runtime-deployment.yaml`, and `ratelimiter-deployment.yaml`. This enables referencing a specific Kubernetes secret when mounting secrets with the CSI driver. 

**Configuration enhancements:**

* Introduced the `nodePublishSecretRef` field under `wso2.apk.secretProviderClass` in `values.yaml`, allowing users to configure this value via Helm values.