### PR TITLE
Update xds message size

### DIFF
--- a/gateway/enforcer/internal/config/config.go
+++ b/gateway/enforcer/internal/config/config.go
@@ -42,7 +42,7 @@ type Server struct {
 	CommonControllerHostname         string `envconfig:"COMMON_CONTROLLER_HOST_NAME" default:"common-controller"`
 	CommonControllerXdsPort          string `envconfig:"COMMON_CONTROLLER_XDS_PORT" default:"18002"`
 	CommonControllerRestPort         string `envconfig:"COMMON_CONTROLLER_REST_PORT" default:"18003"`
-	XdsMaxMsgSize                    int    `envconfig:"XDS_MAX_MSG_SIZE" default:"4194304"`
+	XdsMaxMsgSize                    int    `envconfig:"XDS_MAX_MSG_SIZE" default:"41943040"` // 40MB
 	EnforcerLabel                    string `envconfig:"ENFORCER_LABEL" default:"enforcer"`
 	EnforcerRegionID                 string `envconfig:"ENFORCER_REGION" default:"UNKNOWN"`
 	XdsMaxRetries                    int    `envconfig:"XDS_MAX_RETRIES" default:"3"`

--- a/helm-charts/Chart.yaml
+++ b/helm-charts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: choreo-apk
 description: A Helm chart for APK components
 type: application
-version: 1.3.0-18
+version: 1.3.0-19
 appVersion: "1.3.0"
 dependencies:
   - name: postgresql

--- a/helm-charts/templates/data-plane/gateway-components/gateway-runtime/gateway-runtime-deployment.yaml
+++ b/helm-charts/templates/data-plane/gateway-components/gateway-runtime/gateway-runtime-deployment.yaml
@@ -101,7 +101,7 @@ spec:
             - name: ENFORCER_REGION
               value: UNKNOWN
             - name: XDS_MAX_MSG_SIZE
-              value: "4194304"
+              value: "41943040"
             - name: XDS_MAX_RETRIES 
               value: "3"
             - name: enforcer_admin_pwd

--- a/helm-charts/templates/data-plane/gateway-components/gateway-runtime/gateway-runtime-deployment.yaml
+++ b/helm-charts/templates/data-plane/gateway-components/gateway-runtime/gateway-runtime-deployment.yaml
@@ -100,8 +100,6 @@ spec:
               value : {{ .Values.wso2.apk.dp.gateway.name | default "wso2-apk-default" }}
             - name: ENFORCER_REGION
               value: UNKNOWN
-            - name: XDS_MAX_MSG_SIZE
-              value: "41943040"
             - name: XDS_MAX_RETRIES 
               value: "3"
             - name: enforcer_admin_pwd

--- a/helm-charts/values.yaml
+++ b/helm-charts/values.yaml
@@ -380,6 +380,7 @@ wso2:
 #              level: DEBUG
             env:
               TOKEN_REVOCATION_ENABLED: "true" 
+              # XDS_MAX_MSG_SIZE: "41943040"
 #            configs:
 #              apiKey:
 #                enabled: true


### PR DESCRIPTION
## Purpose
This PR updates the XDS max message size to resolve the `code = ResourceExhausted desc = grpc: received message larger than max` errors.