### PR TITLE
Add GCP secret provider support

### DIFF
--- a/helm-charts/Chart.yaml
+++ b/helm-charts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: choreo-apk
 description: A Helm chart for APK components
 type: application
-version: 1.3.0-25
+version: 1.3.0-26
 appVersion: "1.3.0"
 dependencies:
   - name: postgresql

--- a/helm-charts/templates/data-plane/gateway-components/adapter/adapter-deployment.yaml
+++ b/helm-charts/templates/data-plane/gateway-components/adapter/adapter-deployment.yaml
@@ -88,7 +88,7 @@ spec:
             - name: enforcer-jwks-tls-secret-volume
               mountPath: /home/wso2/security/truststore/enforcer.crt
               subPath: tls.crt
-            {{- else if eq .Values.wso2.apk.secretProviderClass.provider "aws" }}
+            {{- else if or (eq .Values.wso2.apk.secretProviderClass.provider "aws") (eq .Values.wso2.apk.secretProviderClass.provider "gcp") }}
             - name: secret-provider-class
               mountPath: /home/wso2/security/keystore/adapter.key
               subPath: apk-server.key

--- a/helm-charts/templates/data-plane/gateway-components/common-controller/common-controller-deployment.yaml
+++ b/helm-charts/templates/data-plane/gateway-components/common-controller/common-controller-deployment.yaml
@@ -98,7 +98,7 @@ spec:
               mountPath: /home/wso2/security/truststore/ratelimiter-ca.crt
               subPath: ratelimiter-ca.crt
             {{- end }}
-            {{- else if eq .Values.wso2.apk.secretProviderClass.provider "aws" }}
+            {{- else if or (eq .Values.wso2.apk.secretProviderClass.provider "aws") (eq .Values.wso2.apk.secretProviderClass.provider "gcp") }}
             - name: secret-provider-class
               mountPath: /home/wso2/security/keystore/commoncontroller.key
               subPath: apk-server.key

--- a/helm-charts/templates/data-plane/gateway-components/gateway-runtime/gateway-runtime-deployment.yaml
+++ b/helm-charts/templates/data-plane/gateway-components/gateway-runtime/gateway-runtime-deployment.yaml
@@ -219,7 +219,7 @@ spec:
               mountPath: /home/wso2/security/truststore/ratelimiter.crt
               subPath: tls.crt
             {{- end }}
-            {{- else if eq .Values.wso2.apk.secretProviderClass.provider "aws" }}
+            {{- else if or (eq .Values.wso2.apk.secretProviderClass.provider "aws") (eq .Values.wso2.apk.secretProviderClass.provider "gcp") }}
             - name: secret-provider-class
               mountPath: /home/wso2/security/keystore/enforcer.key
               subPath: apk-server.key
@@ -466,7 +466,7 @@ spec:
               mountPath: /home/wso2/security/truststore/ratelimiter.crt
               subPath: tls.crt
             {{- end }}
-            {{- else if eq .Values.wso2.apk.secretProviderClass.provider "aws" }}
+            {{- else if or (eq .Values.wso2.apk.secretProviderClass.provider "aws") (eq .Values.wso2.apk.secretProviderClass.provider "gcp") }}
             - name: secret-provider-class
               mountPath: /home/wso2/security/keystore/router.key
               subPath: apk-server.key

--- a/helm-charts/templates/data-plane/ratelimiter/ratelimiter-deployment.yaml
+++ b/helm-charts/templates/data-plane/ratelimiter/ratelimiter-deployment.yaml
@@ -192,7 +192,7 @@ spec:
             - name: secret-provider-class
               mountPath: /home/wso2/security/truststore/router.pem
               subPath: router-ca.crt
-            {{- else if eq .Values.wso2.apk.secretProviderClass.provider "aws" }}
+            {{- else if or (eq .Values.wso2.apk.secretProviderClass.provider "aws") (eq .Values.wso2.apk.secretProviderClass.provider "gcp") }}
             - name: secret-provider-class
               mountPath: /home/wso2/security/keystore/ratelimiter.key
               subPath: apk-server.key

--- a/helm-charts/templates/secret-providers/secret-provider-gcp.yaml
+++ b/helm-charts/templates/secret-providers/secret-provider-gcp.yaml
@@ -1,0 +1,73 @@
+# Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+{{- if .Values.wso2.apk.secretProviderClass.enabled }}
+{{- if eq .Values.wso2.apk.secretProviderClass.provider "gcp" }}
+apiVersion: secrets-store.csi.x-k8s.io/v1
+kind: SecretProviderClass
+metadata:
+  name: {{ template "apk-helm.resource.prefix" . }}-secrets
+  namespace: {{ .Release.Namespace }}
+spec:
+  provider: gcp
+  secretObjects:
+    - secretName: {{ template "apk-helm.resource.prefix" . }}-secrets
+      type: Opaque
+      data:
+        - objectName: ratelimiter_redis_credentials
+          key: ratelimiter_redis_credentials
+    - secretName: {{ template "apk-helm.resource.prefix" . }}-router-tls   
+      type: Opaque
+      data:
+        - objectName: apk-server.key
+          key: tls.key
+        - objectName: apk-server.crt
+          key: tls.crt
+        - objectName: apim-internal-intermediate-ca.crt
+          key: apim-internal-intermediate-ca.crt
+    - secretName: {{ template "apk-helm.resource.prefix" . }}-system-listener-tls
+      type: Opaque
+      data:
+        - objectName: system-api-listener.key
+          key: tls.key
+        - objectName: system-api-listener.crt
+          key: tls.crt
+  parameters:
+    secrets: |
+      - resourceName: {{ .Values.wso2.apk.secretProviderClass.secrets.ratelimiterRedisCredentials.secretName | quote }}
+        path: "ratelimiter_redis_credentials"
+      - resourceName: {{ .Values.wso2.apk.secretProviderClass.secrets.adapterKey.secretName | quote }}
+        path: "apk-server.key"
+      - resourceName: {{ .Values.wso2.apk.secretProviderClass.secrets.adapterCert.secretName | quote }}
+        path: "apk-server.crt"
+      - resourceName: {{ .Values.wso2.apk.secretProviderClass.secrets.adapterCaCert.secretName | quote }}
+        path: "apim-internal-intermediate-ca.crt"
+      - resourceName: {{ .Values.wso2.apk.secretProviderClass.secrets.systemApiListenerKey.secretName | quote }}
+        path: "system-api-listener.key"
+      - resourceName: {{ .Values.wso2.apk.secretProviderClass.secrets.systemApiListenerCert.secretName | quote }}
+        path: "system-api-listener.crt"
+      - resourceName: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerJwksKey.secretName | quote }}
+        path: "enforcer-jwks.key"
+      - resourceName: {{ .Values.wso2.apk.secretProviderClass.secrets.enforcerJwksCert.secretName | quote }}
+        path: "enforcer-jwks.crt"
+    {{- if and .Values.wso2.apk.dp.gatewayRuntime.tracing .Values.wso2.apk.dp.gatewayRuntime.tracing.enabled .Values.wso2.apk.dp.gatewayRuntime.tracing.configProperties .Values.wso2.apk.dp.gatewayRuntime.tracing.configProperties.tls .Values.wso2.apk.dp.gatewayRuntime.tracing.configProperties.tls.enabled }}
+      - resourceName: {{ .Values.wso2.apk.secretProviderClass.secrets.tracingCaCert.secretName | quote }}
+        path: "tracing-ca.crt"
+      - resourceName: {{ .Values.wso2.apk.secretProviderClass.secrets.tracingCert.secretName | quote }}
+        path: "tracing.crt"
+    {{- end }}
+{{- end }}
+{{- end }}


### PR DESCRIPTION
## Purpose

This pull request adds support for Google Cloud Platform (GCP) as a secret provider in the Helm charts, alongside the existing AWS support. It introduces a new SecretProviderClass template for GCP and updates deployment templates to handle both AWS and GCP providers. The chart version is also incremented to reflect these changes.

## Purpose

**Secret provider enhancements:**

* Added a new `secret-provider-gcp.yaml` template to configure GCP as a SecretProviderClass, enabling Kubernetes deployments to fetch secrets from GCP Secret Manager.
* Updated deployment templates (`adapter-deployment.yaml`, `common-controller-deployment.yaml`, `gateway-runtime-deployment.yaml`, `ratelimiter-deployment.yaml`) to support both AWS and GCP as secret providers by modifying conditional logic to check for either provider. 

**Chart versioning:**

* Bumped the Helm chart version from `1.3.0-25` to `1.3.0-26` in `Chart.yaml` to reflect the new features.