### PR TITLE
Support exact endpoint configuration in interceptor policy

### DIFF
--- a/adapter/internal/interceptor/interceptor.go
+++ b/adapter/internal/interceptor/interceptor.go
@@ -46,6 +46,7 @@ type HTTPCallConfig struct {
 	ClusterName     string
 	Timeout         string // in milli seconds
 	AuthorityHeader string
+	ResourcePath    *string
 }
 
 // RequestInclusions represents which should be included in the request payload to the interceptor service
@@ -111,7 +112,7 @@ var (
 	 {{- end -}}}
  local req_call_config = {  
 	 {{- range $key, $value := .RequestFlow -}} 
-		 {{- $key }} = {cluster_name = "{{$value.ExternalCall.ClusterName}}", timeout = {{$value.ExternalCall.Timeout}}, authority_header = "{{$value.ExternalCall.AuthorityHeader}}"}, 
+		 {{- $key }} = {cluster_name = "{{$value.ExternalCall.ClusterName}}", timeout = {{$value.ExternalCall.Timeout}}, authority_header = "{{$value.ExternalCall.AuthorityHeader}}", resource_path = "{{if $value.ExternalCall.ResourcePath}}{{$value.ExternalCall.ResourcePath}}{{end}}"}, 
 	 {{- end -}}}
  function envoy_on_request(request_handle)
 	 interceptor.handle_request_interceptor(
@@ -123,7 +124,7 @@ var (
 	responseInterceptorTemplate = `
  local res_call_config = {  
 	 {{- range $key, $value := .ResponseFlow -}} 
-		 {{- $key }} = {cluster_name = "{{$value.ExternalCall.ClusterName}}", timeout={{$value.ExternalCall.Timeout}}, authority_header = "{{$value.ExternalCall.AuthorityHeader}}"}, 
+		 {{- $key }} = {cluster_name = "{{$value.ExternalCall.ClusterName}}", timeout={{$value.ExternalCall.Timeout}}, authority_header = "{{$value.ExternalCall.AuthorityHeader}}", resource_path = "{{if $value.ExternalCall.ResourcePath}}{{$value.ExternalCall.ResourcePath}}{{end}}"}, 
 	 {{- end -}}}
  function envoy_on_response(response_handle)
 	 interceptor.handle_response_interceptor(

--- a/adapter/internal/oasparser/constants/constants.go
+++ b/adapter/internal/oasparser/constants/constants.go
@@ -86,6 +86,7 @@ const (
 	RewritePathType            string = "rewritePathType"
 	InterceptorServiceURL      string = "interceptorServiceURL"
 	InterceptorEndpoints       string = "interceptorEndpoints"
+	InterceptorBasePath        string = "interceptorBasePath"
 	InterceptorServiceIncludes string = "includes"
 	IncludeQueryParams         string = "includeQueryParams"
 	HeaderName                 string = "headerName"

--- a/adapter/internal/oasparser/envoyconf/routes_with_clusters.go
+++ b/adapter/internal/oasparser/envoyconf/routes_with_clusters.go
@@ -417,7 +417,8 @@ func getExistingClusterName(endpoint model.EndpointCluster, clusterEndpointMappi
 // CreateLuaCluster creates lua cluster configuration.
 func CreateLuaCluster(interceptorCerts map[string][]byte, endpoint model.InterceptEndpoint) ([]*clusterv3.Cluster, []*corev3.Address, error) {
 	logger.LoggerOasparser.Debug("creating a lua cluster ", endpoint.ClusterName)
-	return processEndpoints(endpoint.ClusterName, &endpoint.EndpointCluster, endpoint.ClusterTimeout, endpoint.EndpointCluster.Endpoints[0].Basepath, nil)
+	basePath := strings.TrimSuffix(endpoint.EndpointCluster.Endpoints[0].Basepath, "/")
+	return processEndpoints(endpoint.ClusterName, &endpoint.EndpointCluster, endpoint.ClusterTimeout, basePath, nil)
 }
 
 // CreateRateLimitCluster creates cluster relevant to the rate limit service
@@ -599,7 +600,7 @@ func processEndpoints(clusterName string, clusterDetails *model.EndpointCluster,
 		var lbEPs []*endpointv3.LocalityLbEndpoints
 
 		// validating the basepath to be same for all upstreams of an api
-		if strings.TrimSuffix(ep.Basepath, "/") != strings.TrimSuffix(basePath, "/") {
+		if strings.TrimSuffix(ep.Basepath, "/") != basePath {
 			return nil, nil, errors.New("endpoint basepath mismatched for " + ep.RawURL + ". expected : " + basePath + " but found : " + ep.Basepath)
 		}
 		// create addresses for endpoints

--- a/adapter/internal/oasparser/envoyconf/routes_with_clusters.go
+++ b/adapter/internal/oasparser/envoyconf/routes_with_clusters.go
@@ -599,7 +599,7 @@ func processEndpoints(clusterName string, clusterDetails *model.EndpointCluster,
 		var lbEPs []*endpointv3.LocalityLbEndpoints
 
 		// validating the basepath to be same for all upstreams of an api
-		if strings.TrimSuffix(ep.Basepath, "/") != basePath {
+		if strings.TrimSuffix(ep.Basepath, "/") != strings.TrimSuffix(basePath, "/") {
 			return nil, nil, errors.New("endpoint basepath mismatched for " + ep.RawURL + ". expected : " + basePath + " but found : " + ep.Basepath)
 		}
 		// create addresses for endpoints
@@ -1439,6 +1439,7 @@ func GetInlineLuaScript(requestInterceptor map[string]model.InterceptEndpoint, r
 					// which is in nano seconds, so multiplying it in seconds here
 					Timeout:         strconv.FormatInt((op.RequestTimeout * time.Second).Milliseconds(), 10),
 					AuthorityHeader: op.EndpointCluster.Endpoints[0].GetAuthorityHeader(),
+					ResourcePath:    op.ResourcePath,
 				},
 				Include: op.Includes,
 			}
@@ -1454,6 +1455,7 @@ func GetInlineLuaScript(requestInterceptor map[string]model.InterceptEndpoint, r
 					// which is in nano seconds, so multiplying it in seconds here
 					Timeout:         strconv.FormatInt((op.RequestTimeout * time.Second).Milliseconds(), 10),
 					AuthorityHeader: op.EndpointCluster.Endpoints[0].GetAuthorityHeader(),
+					ResourcePath:    op.ResourcePath,
 				},
 				Include: op.Includes,
 			}

--- a/adapter/internal/oasparser/model/adapter_internal_api.go
+++ b/adapter/internal/oasparser/model/adapter_internal_api.go
@@ -255,11 +255,12 @@ type InterceptEndpoint struct {
 	RequestTimeout  time.Duration
 	// Level this is an enum allowing only values {api, resource, operation}
 	// to indicate from which level interceptor is added
-	Level string
+	Level           string
 	// Includes this is an enum allowing only values in
 	// {"request_headers", "request_body", "request_trailer", "response_headers", "response_body", "response_trailer",
 	//"invocation_context" }
-	Includes *interceptor.RequestInclusions
+	Includes        *interceptor.RequestInclusions
+	ResourcePath    *string
 }
 
 // Certificate contains information of a client certificate

--- a/adapter/internal/oasparser/model/api_operation.go
+++ b/adapter/internal/oasparser/model/api_operation.go
@@ -163,6 +163,12 @@ func (operation *Operation) GetCallInterceptorService(isIn bool) InterceptEndpoi
 									includesV = GenerateInterceptorIncludes(includes)
 								}
 							}
+							var resourcePath *string
+							if bp, ok := paramMap[constants.InterceptorBasePath]; ok {
+								if bpStr, ok := bp.(string); ok && bpStr != "" {
+									resourcePath = &bpStr
+								}
+							}
 							return InterceptEndpoint{
 								Enable:          true,
 								EndpointCluster: EndpointCluster{Endpoints: endpoints},
@@ -170,6 +176,7 @@ func (operation *Operation) GetCallInterceptorService(isIn bool) InterceptEndpoi
 								RequestTimeout:  requestTimeoutV,
 								Includes:        includesV,
 								Level:           constants.OperationLevelInterceptor,
+								ResourcePath:    resourcePath,
 							}
 						}
 					}

--- a/adapter/internal/oasparser/model/http_route.go
+++ b/adapter/internal/oasparser/model/http_route.go
@@ -127,9 +127,11 @@ func addOperationLevelInterceptors(policies *OperationPolicies, apiPolicy *dpv1a
 				Namespace: namespace,
 			}
 			endpoints := GetEndpoints(backendName, backendMapping)
+			basePath := GetBackendBasePath(backendName, backendMapping)
 			if len(endpoints) > 0 {
 				policyParameters[constants.InterceptorEndpoints] = endpoints
 				policyParameters[constants.InterceptorServiceIncludes] = requestInterceptor.Includes
+				policyParameters[constants.InterceptorBasePath] = basePath
 				policies.Request = append(policies.Request, Policy{
 					PolicyName: constants.PolicyRequestInterceptor,
 					Action:     constants.ActionInterceptorService,
@@ -148,9 +150,11 @@ func addOperationLevelInterceptors(policies *OperationPolicies, apiPolicy *dpv1a
 				Namespace: namespace,
 			}
 			endpoints := GetEndpoints(backendName, backendMapping)
+			basePath := GetBackendBasePath(backendName, backendMapping)
 			if len(endpoints) > 0 {
 				policyParameters[constants.InterceptorEndpoints] = endpoints
 				policyParameters[constants.InterceptorServiceIncludes] = responseInterceptor.Includes
+				policyParameters[constants.InterceptorBasePath] = basePath
 				policies.Response = append(policies.Response, Policy{
 					PolicyName: constants.PolicyResponseInterceptor,
 					Action:     constants.ActionInterceptorService,

--- a/adapter/internal/operator/synchronizer/gateway_synchronizer.go
+++ b/adapter/internal/operator/synchronizer/gateway_synchronizer.go
@@ -240,6 +240,8 @@ func getInterceptorEndpoint(namespace string, interceptorRef *dpv1alpha4.Interce
 		Name:      interceptorRef.Name}.String()].Spec
 	endpoints := model.GetEndpoints(types.NamespacedName{Namespace: namespace, Name: interceptor.BackendRef.Name},
 		gatewayBackendMapping)
+	basePath := model.GetBackendBasePath(types.NamespacedName{Namespace: namespace, Name: interceptor.BackendRef.Name},
+		gatewayBackendMapping)
 	var clusterName string
 	if isReq {
 		clusterName = constants.GlobalRequestInterceptorClusterName
@@ -250,6 +252,10 @@ func getInterceptorEndpoint(namespace string, interceptorRef *dpv1alpha4.Interce
 		conf := config.ReadConfigs()
 		clusterTimeoutV := conf.Envoy.ClusterTimeoutInSeconds
 		requestTimeoutV := conf.Envoy.ClusterTimeoutInSeconds
+		var resourcePath *string
+		if basePath != "" {
+			resourcePath = &basePath
+		}
 		return &model.InterceptEndpoint{
 			Enable:          true,
 			ClusterName:     clusterName,
@@ -257,6 +263,7 @@ func getInterceptorEndpoint(namespace string, interceptorRef *dpv1alpha4.Interce
 			ClusterTimeout:  clusterTimeoutV,
 			RequestTimeout:  requestTimeoutV,
 			Includes:        model.GenerateInterceptorIncludes(interceptor.Includes),
+			ResourcePath:    resourcePath,
 		}
 	}
 	return nil

--- a/gateway/router/resources/interceptor/lib/interceptor.lua
+++ b/gateway/router/resources/interceptor/lib/interceptor.lua
@@ -295,7 +295,7 @@ end
 
 ---interceptor handler for request flow
 ---@param request_handle table - request_handle
----@param intercept_service_list {method: {cluster_name: string, resource_path: string, timeout: number}}
+---@param intercept_service_list {method: {cluster_name: string, resource_path: string, timeout: number, authority_header: string}}
 ---@param req_flow_includes_list {method: {requestHeaders: boolean, requestBody: boolean, requestTrailer: boolean}}
 ---@param resp_flow_includes_list {method: {requestHeaders: boolean, requestBody: boolean, requestTrailer: boolean, responseHeaders: boolean, responseBody: boolean, responseTrailers: boolean}}
 ---@param inv_context table
@@ -377,7 +377,9 @@ function interceptor.handle_request_interceptor(request_handle, intercept_servic
     -- include request details: request headers, body and trailers to the interceptor_request_body
     include_request_info(req_flow_includes, interceptor_request_body, request_headers_table, request_body_base64, request_trailers_table)
 
-    intercept_service.resource_path = "/api/v1/handle-request"
+    if intercept_service.resource_path == nil or intercept_service.resource_path == "" then
+        intercept_service.resource_path = "/api/v1/handle-request"
+    end
     local interceptor_response_headers, interceptor_response_body_str = send_http_call(request_handle, interceptor_request_body, intercept_service)
     if check_interceptor_call_errors(request_handle, interceptor_response_headers, interceptor_response_body_str, shared_info, request_id, true) then
         return
@@ -421,7 +423,7 @@ end
 
 ---interceptor handler for response flow
 ---@param response_handle table - response_handle
----@param intercept_service_list {method: {cluster_name: string, resource_path: string, timeout: number}}
+---@param intercept_service_list {method: {cluster_name: string, resource_path: string, timeout: number, authority_header: string}}
 ---@param resp_flow_includes_list {method: {requestHeaders: boolean, requestBody: boolean, requestTrailer: boolean, responseHeaders: boolean, responseBody: boolean, responseTrailers: boolean}}
 function interceptor.handle_response_interceptor(response_handle, intercept_service_list, resp_flow_includes_list, wire_log_config)
     local meta = response_handle:streamInfo():dynamicMetadata():get(LUA_FILTER_NAME)
@@ -505,7 +507,9 @@ function interceptor.handle_response_interceptor(response_handle, intercept_serv
     end
     --#endregion
 
-    intercept_service.resource_path = "/api/v1/handle-response"
+    if intercept_service.resource_path == nil or intercept_service.resource_path == "" then
+        intercept_service.resource_path = "/api/v1/handle-response"
+    end
     local interceptor_response_headers, interceptor_response_body_str = send_http_call(response_handle, interceptor_request_body, intercept_service)
     if check_interceptor_call_errors(response_handle, interceptor_response_headers, interceptor_response_body_str, shared_info, request_id, false) then
         return

--- a/test/cucumber-tests/CRs/agent-artifacts.yaml
+++ b/test/cucumber-tests/CRs/agent-artifacts.yaml
@@ -161,7 +161,7 @@ spec:
         app: "interceptor_service"
     spec:
       containers:
-      - image: "tharindu1st/interceptor_service:latest"
+      - image: "thivindu/interceptor_service:latest"
         imagePullPolicy: "Always"
         name: "interceptor-service-deployment"
         ports:

--- a/test/cucumber-tests/CRs/artifacts.yaml
+++ b/test/cucumber-tests/CRs/artifacts.yaml
@@ -161,7 +161,7 @@ spec:
         app: "interceptor_service"
     spec:
       containers:
-      - image: "tharindu1st/interceptor_service:latest"
+      - image: "thivindu/interceptor_service:latest"
         imagePullPolicy: "Always"
         name: "interceptor-service-deployment"
         ports:

--- a/test/cucumber-tests/src/test/java/org/wso2/apk/integration/api/BaseSteps.java
+++ b/test/cucumber-tests/src/test/java/org/wso2/apk/integration/api/BaseSteps.java
@@ -388,7 +388,7 @@ public class BaseSteps {
 
     @Then("I wait for {int} minute")
     public void waitForMinute(int minute) throws InterruptedException {
-        Thread.sleep(minute * 1000);
+        Thread.sleep(minute * 60 * 1000);
     }
 
     @Then("I wait for {int} seconds")

--- a/test/cucumber-tests/src/test/resources/artifacts/apk-confs/interceptors/withCustomPathOperationRequestAndResponse.apk-conf
+++ b/test/cucumber-tests/src/test/resources/artifacts/apk-confs/interceptors/withCustomPathOperationRequestAndResponse.apk-conf
@@ -1,0 +1,34 @@
+name: "InterceptorAPI"
+basePath: "/interceptor"
+version: "1.0.0"
+type: "REST"
+defaultVersion: true
+endpointConfigurations:
+  production:
+  - endpoint: "http://backend.apk-integration-test.svc.cluster.local"
+operations:
+  - target: "/get"
+    verb: "GET"
+    secured: true
+    scopes: []
+    operationPolicies:
+      request:
+        - policyName: "Interceptor"
+          policyVersion: v1
+          parameters:
+            backendUrl: "http://interceptor-service.apk-integration-test.svc.cluster.local:8443/custom/v2/handle-custom-request"
+            headersEnabled: true
+            bodyEnabled: true
+            contextEnabled: true
+      response:
+        - policyName: "Interceptor"
+          policyVersion: v1
+          parameters:
+            backendUrl: "http://interceptor-service.apk-integration-test.svc.cluster.local:8443/custom/v2/handle-custom-response"
+            headersEnabled: true
+            bodyEnabled: true
+            contextEnabled: true
+  - target: "/headers"
+    verb: "GET"
+    secured: true
+    scopes: []

--- a/test/cucumber-tests/src/test/resources/artifacts/apk-confs/interceptors/withCustomPathOperationRequestDefaultResponse.apk-conf
+++ b/test/cucumber-tests/src/test/resources/artifacts/apk-confs/interceptors/withCustomPathOperationRequestDefaultResponse.apk-conf
@@ -1,0 +1,34 @@
+name: "InterceptorAPI"
+basePath: "/interceptor"
+version: "1.0.0"
+type: "REST"
+defaultVersion: true
+endpointConfigurations:
+  production:
+  - endpoint: "http://backend.apk-integration-test.svc.cluster.local"
+operations:
+  - target: "/get"
+    verb: "GET"
+    secured: true
+    scopes: []
+    operationPolicies:
+      request:
+        - policyName: "Interceptor"
+          policyVersion: v1
+          parameters:
+            backendUrl: "http://interceptor-service.apk-integration-test.svc.cluster.local:8443/custom/v2/handle-custom-request"
+            headersEnabled: true
+            bodyEnabled: true
+            contextEnabled: true
+      response:
+        - policyName: "Interceptor"
+          policyVersion: v1
+          parameters:
+            backendUrl: "http://interceptor-service.apk-integration-test.svc.cluster.local:8443"
+            headersEnabled: true
+            bodyEnabled: true
+            contextEnabled: true
+  - target: "/headers"
+    verb: "GET"
+    secured: true
+    scopes: []

--- a/test/cucumber-tests/src/test/resources/artifacts/apk-confs/interceptors/withCustomPathOperationRequestInterceptor.apk-conf
+++ b/test/cucumber-tests/src/test/resources/artifacts/apk-confs/interceptors/withCustomPathOperationRequestInterceptor.apk-conf
@@ -1,0 +1,26 @@
+name: "InterceptorAPI"
+basePath: "/interceptor"
+version: "1.0.0"
+type: "REST"
+defaultVersion: true
+endpointConfigurations:
+  production:
+  - endpoint: "http://backend.apk-integration-test.svc.cluster.local"
+operations:
+  - target: "/get"
+    verb: "GET"
+    secured: true
+    scopes: []
+    operationPolicies:
+      request:
+        - policyName: "Interceptor"
+          policyVersion: v1
+          parameters:
+            backendUrl: "http://interceptor-service.apk-integration-test.svc.cluster.local:8443/custom/v2/handle-custom-request"
+            headersEnabled: true
+            bodyEnabled: true
+            contextEnabled: true
+  - target: "/headers"
+    verb: "GET"
+    secured: true
+    scopes: []

--- a/test/cucumber-tests/src/test/resources/artifacts/apk-confs/interceptors/withCustomPathOperationResponseInterceptor.apk-conf
+++ b/test/cucumber-tests/src/test/resources/artifacts/apk-confs/interceptors/withCustomPathOperationResponseInterceptor.apk-conf
@@ -1,0 +1,26 @@
+name: "InterceptorAPI"
+basePath: "/interceptor"
+version: "1.0.0"
+type: "REST"
+defaultVersion: true
+endpointConfigurations:
+  production:
+  - endpoint: "http://backend.apk-integration-test.svc.cluster.local"
+operations:
+  - target: "/get"
+    verb: "GET"
+    secured: true
+    scopes: []
+    operationPolicies:
+      response:
+        - policyName: "Interceptor"
+          policyVersion: v1
+          parameters:
+            backendUrl: "http://interceptor-service.apk-integration-test.svc.cluster.local:8443/custom/v2/handle-custom-response"
+            headersEnabled: true
+            bodyEnabled: true
+            contextEnabled: true
+  - target: "/headers"
+    verb: "GET"
+    secured: true
+    scopes: []

--- a/test/cucumber-tests/src/test/resources/artifacts/apk-confs/interceptors/withCustomPathRequestAndResponse.apk-conf
+++ b/test/cucumber-tests/src/test/resources/artifacts/apk-confs/interceptors/withCustomPathRequestAndResponse.apk-conf
@@ -1,0 +1,28 @@
+name: "InterceptorAPI"
+basePath: "/interceptor"
+version: "1.0.0"
+type: "REST"
+defaultVersion: true
+endpointConfigurations:
+  production:
+  - endpoint: "http://backend.apk-integration-test.svc.cluster.local"
+operations:
+  - target: "/get"
+    verb: "GET"
+    secured: true
+    scopes: []
+apiPolicies:
+  request:
+    - policyName: "Interceptor"
+      policyVersion: v1
+      parameters:
+        backendUrl: "http://interceptor-service.apk-integration-test.svc.cluster.local:8443/custom/v2/handle-custom-request"
+        headersEnabled: true
+        bodyEnabled: true
+  response:
+    - policyName: "Interceptor"
+      policyVersion: v1
+      parameters:
+        backendUrl: "http://interceptor-service.apk-integration-test.svc.cluster.local:8443/custom/v2/handle-custom-response"
+        headersEnabled: true
+        bodyEnabled: true

--- a/test/cucumber-tests/src/test/resources/artifacts/apk-confs/interceptors/withCustomPathRequestDefaultResponse.apk-conf
+++ b/test/cucumber-tests/src/test/resources/artifacts/apk-confs/interceptors/withCustomPathRequestDefaultResponse.apk-conf
@@ -1,0 +1,28 @@
+name: "InterceptorAPI"
+basePath: "/interceptor"
+version: "1.0.0"
+type: "REST"
+defaultVersion: true
+endpointConfigurations:
+  production:
+  - endpoint: "http://backend.apk-integration-test.svc.cluster.local"
+operations:
+  - target: "/get"
+    verb: "GET"
+    secured: true
+    scopes: []
+apiPolicies:
+  request:
+    - policyName: "Interceptor"
+      policyVersion: v1
+      parameters:
+        backendUrl: "http://interceptor-service.apk-integration-test.svc.cluster.local:8443/custom/v2/handle-custom-request"
+        headersEnabled: true
+        bodyEnabled: true
+  response:
+    - policyName: "Interceptor"
+      policyVersion: v1
+      parameters:
+        backendUrl: "http://interceptor-service.apk-integration-test.svc.cluster.local:8443"
+        headersEnabled: true
+        bodyEnabled: true

--- a/test/cucumber-tests/src/test/resources/artifacts/apk-confs/interceptors/withCustomPathRequestInterceptor.apk-conf
+++ b/test/cucumber-tests/src/test/resources/artifacts/apk-confs/interceptors/withCustomPathRequestInterceptor.apk-conf
@@ -1,0 +1,22 @@
+name: "InterceptorAPI"
+basePath: "/interceptor"
+version: "1.0.0"
+type: "REST"
+defaultVersion: true
+endpointConfigurations:
+  production:
+  - endpoint: "http://backend.apk-integration-test.svc.cluster.local"
+operations:
+  - target: "/get"
+    verb: "GET"
+    secured: true
+    scopes: []
+apiPolicies:
+  request:
+    - policyName: "Interceptor"
+      policyVersion: v1
+      parameters:
+        backendUrl: "http://interceptor-service.apk-integration-test.svc.cluster.local:8443/custom/v2/handle-custom-request"
+        contextEnabled: true
+        headersEnabled: true
+        bodyEnabled: true

--- a/test/cucumber-tests/src/test/resources/artifacts/apk-confs/interceptors/withCustomPathResponseInterceptor.apk-conf
+++ b/test/cucumber-tests/src/test/resources/artifacts/apk-confs/interceptors/withCustomPathResponseInterceptor.apk-conf
@@ -1,0 +1,21 @@
+name: "InterceptorAPI"
+basePath: "/interceptor"
+version: "1.0.0"
+type: "REST"
+defaultVersion: true
+endpointConfigurations:
+  production:
+  - endpoint: "http://backend.apk-integration-test.svc.cluster.local"
+operations:
+  - target: "/get"
+    verb: "GET"
+    secured: true
+    scopes: []
+apiPolicies:
+  response:
+    - policyName: "Interceptor"
+      policyVersion: v1
+      parameters:
+        backendUrl: "http://interceptor-service.apk-integration-test.svc.cluster.local:8443/custom/v2/handle-custom-response"
+        headersEnabled: true
+        bodyEnabled: true

--- a/test/cucumber-tests/src/test/resources/artifacts/apk-confs/interceptors/withDefaultRequestCustomPathResponse.apk-conf
+++ b/test/cucumber-tests/src/test/resources/artifacts/apk-confs/interceptors/withDefaultRequestCustomPathResponse.apk-conf
@@ -1,0 +1,30 @@
+name: "InterceptorAPI"
+basePath: "/interceptor"
+version: "1.0.0"
+type: "REST"
+defaultVersion: true
+endpointConfigurations:
+  production:
+  - endpoint: "http://backend.apk-integration-test.svc.cluster.local"
+operations:
+  - target: "/get"
+    verb: "GET"
+    secured: true
+    scopes: []
+apiPolicies:
+  request:
+    - policyName: "Interceptor"
+      policyVersion: v1
+      parameters:
+        backendUrl: "http://interceptor-service.apk-integration-test.svc.cluster.local:8443"
+        headersEnabled: true
+        bodyEnabled: true
+        contextEnabled: true
+  response:
+    - policyName: "Interceptor"
+      policyVersion: v1
+      parameters:
+        backendUrl: "http://interceptor-service.apk-integration-test.svc.cluster.local:8443/custom/v2/handle-custom-response"
+        headersEnabled: true
+        bodyEnabled: true
+        contextEnabled: true

--- a/test/cucumber-tests/src/test/resources/tests/api/APIDefinitionEndpoint.feature
+++ b/test/cucumber-tests/src/test/resources/tests/api/APIDefinitionEndpoint.feature
@@ -44,7 +44,7 @@ Feature: API Definition Endpoint
     And the definition file "artifacts/definitions/employees_api.json"
     And make the API deployment request
     Then the response status code should be 200
-    And I wait for 1 minute
+    Then I wait for 60 seconds
     Then I set headers
       | Authorization | Bearer ${accessToken} |
     And I send "GET" request to "https://default.gw.wso2.com:9095/test-definition-default/3.14/api-definition" with body ""
@@ -63,7 +63,7 @@ Feature: API Definition Endpoint
     And the definition file "artifacts/definitions/employees_api.json"
     And make the API deployment request
     Then the response status code should be 200
-    And I wait for 1 minute
+    Then I wait for 60 seconds
     Then I set headers
       | Authorization | Bearer ${accessToken} |
     And I send "GET" request to "https://default.sandbox.gw.wso2.com:9095/test-definition-default/3.14/api-definition" with body ""

--- a/test/cucumber-tests/src/test/resources/tests/api/GlobalInterceptor.feature
+++ b/test/cucumber-tests/src/test/resources/tests/api/GlobalInterceptor.feature
@@ -7,7 +7,7 @@ Feature: API Deployment with Global Interceptor
     And make the API deployment request
     Then the response status code should be 200
     And the response body should contain "579ba27a1e03e2fdf099d1b6745e265f2d495606"
-    And I wait for 1 minute
+    Then I wait for 60 seconds
     Then I set headers
       |Authorization|Bearer ${accessToken}|
     And I send "GET" request to "https://default.gw.wso2.com:9095/globalinterceptor/1.0.0/get" with body ""

--- a/test/cucumber-tests/src/test/resources/tests/api/Interceptor.feature
+++ b/test/cucumber-tests/src/test/resources/tests/api/Interceptor.feature
@@ -7,7 +7,7 @@ Feature: API Deployment with Interceptor
     And make the API deployment request
     Then the response status code should be 200
     And the response body should contain "547961eeaafed989119c45ffc13f8b87bfda821d"
-    And I wait for 1 minute
+    Then I wait for 10 seconds
     Then I set headers
       |Authorization|Bearer ${accessToken}|
     And I send "GET" request to "https://default.gw.wso2.com:9095/interceptor/1.0.0/get" with body ""
@@ -18,7 +18,7 @@ Feature: API Deployment with Interceptor
     And make the API deployment request
     Then the response status code should be 200
     And the response body should contain "547961eeaafed989119c45ffc13f8b87bfda821d"
-    And I wait for 1 minute
+    Then I wait for 10 seconds
     Then I set headers
       |Authorization|Bearer ${accessToken}|
     And I send "GET" request to "https://default.gw.wso2.com:9095/interceptor/1.0.0/get" with body ""
@@ -29,7 +29,7 @@ Feature: API Deployment with Interceptor
     And make the API deployment request
     Then the response status code should be 200
     And the response body should contain "547961eeaafed989119c45ffc13f8b87bfda821d"
-    And I wait for 1 minute
+    Then I wait for 10 seconds
     Then I set headers
       |Authorization|Bearer ${accessToken}|
     And I send "GET" request to "https://default.gw.wso2.com:9095/interceptor/1.0.0/get" with body ""
@@ -41,7 +41,7 @@ Feature: API Deployment with Interceptor
     And make the API deployment request
     Then the response status code should be 200
     And the response body should contain "547961eeaafed989119c45ffc13f8b87bfda821d"
-    And I wait for 1 minute
+    Then I wait for 10 seconds
     Then I set headers
       |Authorization|Bearer ${accessToken}|
     And I send "GET" request to "https://default.gw.wso2.com:9095/interceptor/1.0.0/get" with body ""
@@ -53,7 +53,7 @@ Feature: API Deployment with Interceptor
     And make the API deployment request
     Then the response status code should be 200
     And the response body should contain "547961eeaafed989119c45ffc13f8b87bfda821d"
-    And I wait for 1 minute
+    Then I wait for 10 seconds
     Then I set headers
       | Authorization | Bearer ${accessToken} |
     And I send "GET" request to "https://default.gw.wso2.com:9095/interceptor/1.0.0/get" with body ""
@@ -65,7 +65,7 @@ Feature: API Deployment with Interceptor
     And make the API deployment request
     Then the response status code should be 200
     And the response body should contain "547961eeaafed989119c45ffc13f8b87bfda821d"
-    And I wait for 1 minute
+    Then I wait for 10 seconds
     Then I set headers
       | Authorization | Bearer ${accessToken} |
     And I send "GET" request to "https://default.gw.wso2.com:9095/interceptor/1.0.0/get" with body ""
@@ -77,7 +77,7 @@ Feature: API Deployment with Interceptor
     And make the API deployment request
     Then the response status code should be 200
     And the response body should contain "547961eeaafed989119c45ffc13f8b87bfda821d"
-    And I wait for 1 minute
+    Then I wait for 10 seconds
     Then I set headers
       | Authorization | Bearer ${accessToken} |
     And I send "GET" request to "https://default.gw.wso2.com:9095/interceptor/1.0.0/get" with body ""
@@ -89,7 +89,7 @@ Feature: API Deployment with Interceptor
     And make the API deployment request
     Then the response status code should be 200
     And the response body should contain "547961eeaafed989119c45ffc13f8b87bfda821d"
-    And I wait for 1 minute
+    And I wait for 10 seconds
     Then I set headers
       |Authorization|Bearer ${accessToken}|
     And I send "GET" request to "https://default.gw.wso2.com:9095/interceptor/1.0.0/get" with body ""
@@ -101,7 +101,7 @@ Feature: API Deployment with Interceptor
     And make the API deployment request
     Then the response status code should be 200
     And the response body should contain "547961eeaafed989119c45ffc13f8b87bfda821d"
-    And I wait for 1 minute
+    Then I wait for 10 seconds
     Then I set headers
       |Authorization|Bearer ${accessToken}|
     And I send "GET" request to "https://default.gw.wso2.com:9095/interceptor/1.0.0/get" with body ""

--- a/test/cucumber-tests/src/test/resources/tests/api/InterceptorCustomPath.feature
+++ b/test/cucumber-tests/src/test/resources/tests/api/InterceptorCustomPath.feature
@@ -1,0 +1,107 @@
+Feature: Interceptor Custom Resource Path
+  Scenario: Deploying an API with interceptor custom resource paths
+    Given The system is ready
+    And I have a valid subscription
+
+    # Test 1: API-level request interceptor with custom path
+    # backendUrl includes /custom/v2/handle-custom-request, so the interceptor call
+    # hits /custom/v2/handle-custom-request instead of the default /api/v1/handle-request
+    When I use the APK Conf file "artifacts/apk-confs/interceptors/withCustomPathRequestInterceptor.apk-conf"
+    And the definition file "artifacts/definitions/cors_api.yaml"
+    And make the API deployment request
+    Then the response status code should be 200
+    And the response body should contain "547961eeaafed989119c45ffc13f8b87bfda821d"
+    Then I wait for 10 seconds
+    Then I set headers
+      | Authorization | Bearer ${accessToken} |
+    And I send "GET" request to "https://default.gw.wso2.com:9095/interceptor/1.0.0/get" with body ""
+    Then the response status code should be 200
+    And the response body should contain "\"Custom-Interceptor-Header\": \"Custom-path-interceptor-value\""
+    And the response body should not contain "\"Interceptor-Header\""
+
+    # Test 2: API-level response interceptor with custom path
+    # backendUrl includes /custom/v2/handle-custom-response, so the interceptor call
+    # hits /custom/v2/handle-custom-response instead of the default /api/v1/handle-response
+    Then I use the APK Conf file "artifacts/apk-confs/interceptors/withCustomPathResponseInterceptor.apk-conf"
+    And the definition file "artifacts/definitions/cors_api.yaml"
+    And make the API deployment request
+    Then the response status code should be 200
+    And the response body should contain "547961eeaafed989119c45ffc13f8b87bfda821d"
+    Then I wait for 10 seconds
+    Then I set headers
+      | Authorization | Bearer ${accessToken} |
+    And I send "GET" request to "https://default.gw.wso2.com:9095/interceptor/1.0.0/get" with body ""
+    Then the response status code should be 200
+    Then the response headers contains key "custom-interceptor-response-header" and value "Custom-path-response-interceptor-value"
+
+    # Test 3: API-level both request and response interceptors with custom paths
+    Then I use the APK Conf file "artifacts/apk-confs/interceptors/withCustomPathRequestAndResponse.apk-conf"
+    And the definition file "artifacts/definitions/cors_api.yaml"
+    And make the API deployment request
+    Then the response status code should be 200
+    And the response body should contain "547961eeaafed989119c45ffc13f8b87bfda821d"
+    Then I wait for 10 seconds
+    Then I set headers
+      | Authorization | Bearer ${accessToken} |
+    And I send "GET" request to "https://default.gw.wso2.com:9095/interceptor/1.0.0/get" with body ""
+    Then the response status code should be 200
+    And the response body should contain "\"Custom-Interceptor-Header\": \"Custom-path-interceptor-value\""
+    Then the response headers contains key "custom-interceptor-response-header" and value "Custom-path-response-interceptor-value"
+
+    # Test 4: API-level custom request path + default response path
+    # Request interceptor uses custom /custom/v2/handle-custom-request
+    # Response interceptor uses default backendUrl (no path), falling back to /api/v1/handle-response
+    Then I use the APK Conf file "artifacts/apk-confs/interceptors/withCustomPathRequestDefaultResponse.apk-conf"
+    And the definition file "artifacts/definitions/cors_api.yaml"
+    And make the API deployment request
+    Then the response status code should be 200
+    And the response body should contain "547961eeaafed989119c45ffc13f8b87bfda821d"
+    Then I wait for 10 seconds
+    Then I set headers
+      | Authorization | Bearer ${accessToken} |
+    And I send "GET" request to "https://default.gw.wso2.com:9095/interceptor/1.0.0/get" with body ""
+    Then the response status code should be 200
+    And the response body should contain "\"Custom-Interceptor-Header\": \"Custom-path-interceptor-value\""
+    Then the response headers contains key "interceptor-response-header" and value "Interceptor-Response-header-value"
+
+    # Test 5: API-level default request path + custom response path
+    # Request interceptor uses default backendUrl (no path), falling back to /api/v1/handle-request
+    # Response interceptor uses custom /custom/v2/handle-custom-response
+    Then I use the APK Conf file "artifacts/apk-confs/interceptors/withDefaultRequestCustomPathResponse.apk-conf"
+    And the definition file "artifacts/definitions/cors_api.yaml"
+    And make the API deployment request
+    Then the response status code should be 200
+    And the response body should contain "547961eeaafed989119c45ffc13f8b87bfda821d"
+    Then I wait for 10 seconds
+    Then I set headers
+      | Authorization | Bearer ${accessToken} |
+    And I send "GET" request to "https://default.gw.wso2.com:9095/interceptor/1.0.0/get" with body ""
+    Then the response status code should be 200
+    And the response body should contain "\"Interceptor-Header\": \"Interceptor-header-value\""
+    Then the response headers contains key "custom-interceptor-response-header" and value "Custom-path-response-interceptor-value"
+
+    # Test 6: Verify default paths still work (backward compatibility)
+    # backendUrl without path uses defaults /api/v1/handle-request and /api/v1/handle-response
+    Then I use the APK Conf file "artifacts/apk-confs/interceptors/withRequestAndResponse.apk-conf"
+    And the definition file "artifacts/definitions/cors_api.yaml"
+    And make the API deployment request
+    Then the response status code should be 200
+    And the response body should contain "547961eeaafed989119c45ffc13f8b87bfda821d"
+    Then I wait for 10 seconds
+    Then I set headers
+      | Authorization | Bearer ${accessToken} |
+    And I send "GET" request to "https://default.gw.wso2.com:9095/interceptor/1.0.0/get" with body ""
+    Then the response status code should be 200
+    And the response body should contain "\"Interceptor-Header\": \"Interceptor-header-value\""
+    And the response body should not contain "\"Custom-Interceptor-Header\""
+    Then the response headers contains key "interceptor-response-header" and value "Interceptor-Response-header-value"
+
+  Scenario Outline: Undeploy an API
+    Given The system is ready
+    And I have a valid subscription
+    When I undeploy the API whose ID is "<apiID>"
+    Then the response status code should be <expectedStatusCode>
+
+    Examples:
+      | apiID                                    | expectedStatusCode |
+      | 547961eeaafed989119c45ffc13f8b87bfda821d | 202                |

--- a/test/cucumber-tests/src/test/resources/tests/api/resourceInterceptor.feature
+++ b/test/cucumber-tests/src/test/resources/tests/api/resourceInterceptor.feature
@@ -7,7 +7,7 @@ Feature: API Deployment with Resource Interceptor
     And make the API deployment request
     Then the response status code should be 200
     And the response body should contain "547961eeaafed989119c45ffc13f8b87bfda821d"
-    And I wait for 1 minute
+    Then I wait for 60 seconds
     Then I set headers
       |Authorization|Bearer ${accessToken}|
     And I send "GET" request to "https://default.gw.wso2.com:9095/interceptor/1.0.0/get" with body ""

--- a/test/cucumber-tests/src/test/resources/tests/api/resourceInterceptorCustomPath.feature
+++ b/test/cucumber-tests/src/test/resources/tests/api/resourceInterceptorCustomPath.feature
@@ -1,0 +1,95 @@
+Feature: Interceptor Custom Resource Path
+  Scenario: Deploying an API with interceptor custom resource paths
+    Given The system is ready
+    And I have a valid subscription
+
+    # Test 1: Operation-level request interceptor with custom path
+    # Interceptor applied at operation level (operationPolicies) on GET /get only
+    Then I use the APK Conf file "artifacts/apk-confs/interceptors/withCustomPathOperationRequestInterceptor.apk-conf"
+    And the definition file "artifacts/definitions/cors_api.yaml"
+    And make the API deployment request
+    Then the response status code should be 200
+    And the response body should contain "547961eeaafed989119c45ffc13f8b87bfda821d"
+    Then I wait for 10 seconds
+    Then I set headers
+      | Authorization | Bearer ${accessToken} |
+    And I send "GET" request to "https://default.gw.wso2.com:9095/interceptor/1.0.0/get" with body ""
+    Then the response status code should be 200
+    And the response body should contain "\"Custom-Interceptor-Header\": \"Custom-path-interceptor-value\""
+    And the response body should not contain "\"Interceptor-Header\""
+    Then I set headers
+      | Authorization | Bearer ${accessToken} |
+    And I send "GET" request to "https://default.gw.wso2.com:9095/interceptor/1.0.0/headers" with body ""
+    Then the response status code should be 200
+    And the response body should not contain "\"Custom-Interceptor-Header\""
+    And the response body should not contain "\"Interceptor-Header\""
+
+    # Test 2: Operation-level response interceptor with custom path
+    Then I use the APK Conf file "artifacts/apk-confs/interceptors/withCustomPathOperationResponseInterceptor.apk-conf"
+    And the definition file "artifacts/definitions/cors_api.yaml"
+    And make the API deployment request
+    Then the response status code should be 200
+    And the response body should contain "547961eeaafed989119c45ffc13f8b87bfda821d"
+    Then I wait for 10 seconds
+    Then I set headers
+      | Authorization | Bearer ${accessToken} |
+    And I send "GET" request to "https://default.gw.wso2.com:9095/interceptor/1.0.0/get" with body ""
+    Then the response status code should be 200
+    Then the response headers contains key "custom-interceptor-response-header" and value "Custom-path-response-interceptor-value"
+    Then I set headers
+      | Authorization | Bearer ${accessToken} |
+    And I send "GET" request to "https://default.gw.wso2.com:9095/interceptor/1.0.0/headers" with body ""
+    Then the response status code should be 200
+    Then the response headers not contains key "custom-interceptor-response-header"
+
+    # Test 3: Operation-level both request and response interceptors with custom paths
+    Then I use the APK Conf file "artifacts/apk-confs/interceptors/withCustomPathOperationRequestAndResponse.apk-conf"
+    And the definition file "artifacts/definitions/cors_api.yaml"
+    And make the API deployment request
+    Then the response status code should be 200
+    And the response body should contain "547961eeaafed989119c45ffc13f8b87bfda821d"
+    Then I wait for 10 seconds
+    Then I set headers
+      | Authorization | Bearer ${accessToken} |
+    And I send "GET" request to "https://default.gw.wso2.com:9095/interceptor/1.0.0/get" with body ""
+    Then the response status code should be 200
+    And the response body should contain "\"Custom-Interceptor-Header\": \"Custom-path-interceptor-value\""
+    Then the response headers contains key "custom-interceptor-response-header" and value "Custom-path-response-interceptor-value"
+    Then I set headers
+      | Authorization | Bearer ${accessToken} |
+    And I send "GET" request to "https://default.gw.wso2.com:9095/interceptor/1.0.0/headers" with body ""
+    Then the response status code should be 200
+    And the response body should not contain "\"Custom-Interceptor-Header\""
+    Then the response headers not contains key "custom-interceptor-response-header"
+
+    # Test 4: Operation-level custom request path + default response path
+    # Request interceptor uses custom path, response interceptor uses default /api/v1/handle-response
+    Then I use the APK Conf file "artifacts/apk-confs/interceptors/withCustomPathOperationRequestDefaultResponse.apk-conf"
+    And the definition file "artifacts/definitions/cors_api.yaml"
+    And make the API deployment request
+    Then the response status code should be 200
+    And the response body should contain "547961eeaafed989119c45ffc13f8b87bfda821d"
+    Then I wait for 10 seconds
+    Then I set headers
+      | Authorization | Bearer ${accessToken} |
+    And I send "GET" request to "https://default.gw.wso2.com:9095/interceptor/1.0.0/get" with body ""
+    Then the response status code should be 200
+    And the response body should contain "\"Custom-Interceptor-Header\": \"Custom-path-interceptor-value\""
+    Then the response headers contains key "interceptor-response-header" and value "Interceptor-Response-header-value"
+    Then I set headers
+      | Authorization | Bearer ${accessToken} |
+    And I send "GET" request to "https://default.gw.wso2.com:9095/interceptor/1.0.0/headers" with body ""
+    Then the response status code should be 200
+    And the response body should not contain "\"Custom-Interceptor-Header\""
+    And the response body should not contain "\"Interceptor-Header\""
+    Then the response headers not contains key "interceptor-response-header"
+
+  Scenario Outline: Undeploy an API
+    Given The system is ready
+    And I have a valid subscription
+    When I undeploy the API whose ID is "<apiID>"
+    Then the response status code should be <expectedStatusCode>
+
+    Examples:
+      | apiID                                    | expectedStatusCode |
+      | 547961eeaafed989119c45ffc13f8b87bfda821d | 202                |

--- a/test/interceptor-backend/ballerina/Dependencies.toml
+++ b/test/interceptor-backend/ballerina/Dependencies.toml
@@ -5,12 +5,12 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.7.0"
+distribution-version = "2201.5.0"
 
 [[package]]
 org = "ballerina"
 name = "auth"
-version = "2.9.0"
+version = "2.8.0"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -22,7 +22,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "cache"
-version = "3.6.0"
+version = "3.5.0"
 dependencies = [
 	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -33,7 +33,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "constraint"
-version = "1.3.0"
+version = "1.2.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -41,7 +41,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "crypto"
-version = "2.4.0"
+version = "2.3.2"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
@@ -50,7 +50,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "file"
-version = "1.8.1"
+version = "1.7.1"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -61,7 +61,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.9.0"
+version = "2.8.9"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},
@@ -86,14 +86,13 @@ dependencies = [
 	{org = "ballerina", name = "url"}
 ]
 modules = [
-	{org = "ballerina", packageName = "http", moduleName = "http"},
-	{org = "ballerina", packageName = "http", moduleName = "http.httpscerr"}
+	{org = "ballerina", packageName = "http", moduleName = "http"}
 ]
 
 [[package]]
 org = "ballerina"
 name = "io"
-version = "1.5.0"
+version = "1.4.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"}
@@ -107,7 +106,7 @@ version = "0.0.0"
 [[package]]
 org = "ballerina"
 name = "jwt"
-version = "2.9.0"
+version = "2.8.0"
 dependencies = [
 	{org = "ballerina", name = "cache"},
 	{org = "ballerina", name = "crypto"},
@@ -201,7 +200,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "log"
-version = "2.8.1"
+version = "2.7.1"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -215,7 +214,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "mime"
-version = "2.8.0"
+version = "2.7.1"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -225,7 +224,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "oauth2"
-version = "2.9.0"
+version = "2.8.0"
 dependencies = [
 	{org = "ballerina", name = "cache"},
 	{org = "ballerina", name = "crypto"},
@@ -238,7 +237,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.1.0"
+version = "1.0.7"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -246,7 +245,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "os"
-version = "1.7.0"
+version = "1.6.0"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"}
@@ -267,7 +266,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "task"
-version = "2.4.0"
+version = "2.3.2"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
@@ -276,7 +275,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "time"
-version = "2.3.0"
+version = "2.2.5"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -284,7 +283,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "url"
-version = "2.3.0"
+version = "2.2.4"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]

--- a/test/interceptor-backend/ballerina/Dockerfile
+++ b/test/interceptor-backend/ballerina/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:24.10
+FROM ubuntu:24.04
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/test/interceptor-backend/ballerina/customPathInterceptor.bal
+++ b/test/interceptor-backend/ballerina/customPathInterceptor.bal
@@ -1,0 +1,24 @@
+import ballerina/http;
+
+http:Service customPathInterceptorService = service object {
+    # Handle Request at custom path
+    #
+    # + payload - Content of the request
+    # + return - Successful operation
+    isolated resource function post 'handle\-custom\-request(@http:Payload RequestHandlerRequestBody payload) returns OkRequestHandlerResponseBody {
+        OkRequestHandlerResponseBody okRequestHandlerResponseBody = {body: {headersToAdd: {"Custom-Interceptor-Header": "Custom-path-interceptor-value"}}};
+        return okRequestHandlerResponseBody;
+    }
+    # Handle Response at custom path
+    #
+    # + payload - Content of the request
+    # + return - Successful operation
+    isolated resource function post 'handle\-custom\-response(@http:Payload ResponseHandlerRequestBody payload) returns OkResponseHandlerResponseBody {
+        return {body: {headersToAdd: {"Custom-Interceptor-Response-Header": "Custom-path-response-interceptor-value"}}};
+    }
+
+    isolated resource function get health() returns http:Ok {
+        json status = {"health": "Ok"};
+        return {body: status};
+    }
+};

--- a/test/interceptor-backend/ballerina/init.bal
+++ b/test/interceptor-backend/ballerina/init.bal
@@ -20,9 +20,11 @@ listener http:Listener ep2 = new (8445, secureSocket = {
 
 function init() returns error? {
     check ep0.attach(interceptorService, "/api/v1");
+    check ep0.attach(customPathInterceptorService, "/custom/v2");
     check ep0.'start();
     runtime:registerListener(ep0);
     check ep1.attach(interceptorService, "/api/v1");
+    check ep1.attach(customPathInterceptorService, "/custom/v2");
     check ep1.'start();
     runtime:registerListener(ep1);
     check ep2.attach(gwInterceptorService, "/api/v1");

--- a/test/k8s-resources/interceptor-service.yaml
+++ b/test/k8s-resources/interceptor-service.yaml
@@ -59,7 +59,7 @@ spec:
         app: "interceptor_service"
     spec:
       containers:
-      - image: "tharindu1st/interceptor_service:latest"
+      - image: "thivindu/interceptor_service:latest"
         imagePullPolicy: "IfNotPresent"
         name: "interceptor-service-deployment"
         ports:


### PR DESCRIPTION
## Purpose
This pull request introduces support for specifying the exact path of the interceptor service that the request should hit in the interceptor policy.

Sample policy config in apk-conf - 

```
apiPolicies:
  request:
    - policyName: "Interceptor"
      policyVersion: v1
      parameters:
        backendUrl: "http://auth-interceptor-svc.interceptor.svc.cluster.local:9081/api/v1/handle-token-request"
        headersEnabled: true
        bodyEnabled: true
        trailersEnabled: false
        contextEnabled: true
```

Related to - https://github.com/wso2/apk/issues/3317

## Goals
Support exact endpoint configuration in interceptor policy

## Approach
This specifies a `resource_path` for interceptor service calls, enabling more flexible routing to interceptor endpoints. The changes ensure that the `resource_path` is propagated throughout the configuration, set in generated Lua scripts, and defaults to `/api/v1/handle-request` or `/api/v1/handle-response` if not provided. Additionally, the handling of base paths and their consistency across endpoints is improved.

**Interceptor Resource Path Support**

* Added a new `ResourcePath` field to the interceptor configuration structures (`HTTPCallConfig`, `InterceptEndpoint`) and ensured it is populated from configuration and policy parameters. This allows specifying custom resource paths for interceptor service calls. [[1]](diffhunk://#diff-c31d21eb936c532eb7597ad70c41eaf36b9e0ff037163f806b83c234ea4732c0R49) [[2]](diffhunk://#diff-edf87c134bb33c25a6085e5d721211a0ac341fc181ce4e268771b7fe1807545bR263) [[3]](diffhunk://#diff-e656d9b3f3b82ef0bc0ad9ce077ec0ab661ed6f685c0ae6ad48d0f853f653f6cR166-R179) [[4]](diffhunk://#diff-f149a98e36b8daaeb2e74748600342b1f99f976fcfbc2763393181fd23175026R1442) [[5]](diffhunk://#diff-f149a98e36b8daaeb2e74748600342b1f99f976fcfbc2763393181fd23175026R1458) [[6]](diffhunk://#diff-0f7847e14a97ff3cd02c68a5fae7f1b23f89b9e1e31af0b4378eb9e19c6781afR243-R244) [[7]](diffhunk://#diff-0f7847e14a97ff3cd02c68a5fae7f1b23f89b9e1e31af0b4378eb9e19c6781afR255-R266)
* Updated the Lua interceptor logic to use the provided `resource_path`, defaulting to `/api/v1/handle-request` or `/api/v1/handle-response` if not specified. This ensures backward compatibility and correct routing. [[1]](diffhunk://#diff-c62666830c8355e8bc53be730debc26da46af835d1fdaea7ad303bf33880b101R380-R382) [[2]](diffhunk://#diff-c62666830c8355e8bc53be730debc26da46af835d1fdaea7ad303bf33880b101R510-R512)
* Modified the Go templates that generate Lua configuration to include the `resource_path` in both request and response interceptor flows. [[1]](diffhunk://#diff-c31d21eb936c532eb7597ad70c41eaf36b9e0ff037163f806b83c234ea4732c0L114-R115) [[2]](diffhunk://#diff-c31d21eb936c532eb7597ad70c41eaf36b9e0ff037163f806b83c234ea4732c0L126-R127)

**Configuration and Policy Handling**

* Added the `interceptorBasePath` constant and updated the logic to extract and propagate the interceptor base path from backend mappings and policy parameters, ensuring the correct resource path is passed through the system. [[1]](diffhunk://#diff-344f2f79050c2327f9cd9488afa852468857444472613959b48a15eadeb040c9R89) [[2]](diffhunk://#diff-4a007a22d42a2f6c2f66ad83d13f3ba1c782bff21b193237800992f8f931f32cR130-R134) [[3]](diffhunk://#diff-4a007a22d42a2f6c2f66ad83d13f3ba1c782bff21b193237800992f8f931f32cR153-R157)

**Testing and Validation**

* Added new test API configurations (`apk-conf` files) that specify custom resource paths for various interceptor scenarios, ensuring the feature is thoroughly tested. [[1]](diffhunk://#diff-c336abe0efd39331f8f85340e374b7d4bb1012b796b26198f17ab18fa63b639aR1-R34) [[2]](diffhunk://#diff-461433df79063a0b7bc676cceb341c490de8258f9d66199b28de322b6685cf39R1-R34) [[3]](diffhunk://#diff-6f3e33de43334c33d854dc99e4fc792d76ceaf30d66593b01005fc12ceb86336R1-R26) [[4]](diffhunk://#diff-996416931a761e9fdde6e5dc72c8d3509f3292cf16d8b7f11382586cdd8a317fR1-R26) [[5]](diffhunk://#diff-7c80a56eacc541933c26fb9cbc6b1ee34c3da3d862d4f331ed3045b76fb9184bR1-R28)
* Updated test deployment images for the interceptor service to use a new image repository. [[1]](diffhunk://#diff-1adb0c8cd4b2cfc01b5f767a919879647d45a80cd09fc5516349bd1ff1c49c28L164-R164) [[2]](diffhunk://#diff-213849c46b8ee26c10445646f139c06efa8c11b202e4dcd4c9b2f48b83d0da5bL164-R164)
* Fixed a bug in the test step for waiting minutes (was incorrectly waiting seconds instead of minutes).

**Documentation and Type Updates**

* Updated Lua documentation comments to reflect the new `resource_path` and `authority_header` fields in the interceptor service list. [[1]](diffhunk://#diff-c62666830c8355e8bc53be730debc26da46af835d1fdaea7ad303bf33880b101L298-R298) [[2]](diffhunk://#diff-c62666830c8355e8bc53be730debc26da46af835d1fdaea7ad303bf33880b101L424-R426)

