### PR TITLE
Helm chart improvements to support custom pod labels, annotations, node selectors and adding sidecar containers to gateway runtime pod

### DIFF
--- a/helm-charts/README.md
+++ b/helm-charts/README.md
@@ -197,6 +197,8 @@ A Helm chart for APK components
 | wso2.apk.dp.gatewayRuntime.deployment.nodeSelector | object | `{}` | Configure Node Selector for the deployment.  |
 | wso2.apk.dp.gatewayRuntime.deployment.pod.annotations | object | `{}` | Annotations for pods. |
 | wso2.apk.dp.gatewayRuntime.deployment.pod.labels | object | `{}` | Labels for pods. |
+| wso2.apk.dp.gatewayRuntime.deployment.extraContainers | list | `[]` | Extra sidecar containers to inject into the gateway runtime pod. |
+| wso2.apk.dp.gatewayRuntime.deployment.extraVolumes | list | `[]` | Extra volumes to add to the gateway runtime pod (used alongside extraContainers). |
 | wso2.apk.dp.gatewayRuntime.deployment.affinity | object | `{"podAntiAffinity":{"preferredDuringSchedulingIgnoredDuringExecution":[{"podAffinityTerm":{"labelSelector":{"matchExpressions":[{"key":"app.kubernetes.io/app","operator":"In","values":["gateway-runtime"]}]}}}]}}` | Configure Affinity for the deployment.  |
 | wso2.apk.dp.gatewayRuntime.deployment.router.resources.requests.memory | string | `"128Mi"` | CPU request for the container |
 | wso2.apk.dp.gatewayRuntime.deployment.router.resources.requests.cpu | string | `"100m"` | Memory request for the container |
@@ -321,7 +323,7 @@ A Helm chart for APK components
 | idp.idpds.deployment.replicas | int | `1` | Number of replicas |
 | idp.idpds.deployment.imagePullPolicy | string | `"Always"` | Image pull policy |
 | idp.idpds.deployment.image | string | `"wso2/apk-idp-domain-service:1.3.0"` | Image |
-| idp.idpds.deployment.nodeSelector | string | `{}` | Configure Node Selector for the deployment.  |
+| idp.idpds.deployment.nodeSelector | object | `{}` | Configure Node Selector for the deployment.  |
 | idp.idpds.deployment.pod.annotations | object | `{}` | Annotations for pods. |
 | idp.idpds.deployment.pod.labels | object | `{}` | Labels for pods. |
 | idp.idpui.deployment.resources.requests.memory | string | `"128Mi"` | CPU request for the container |
@@ -338,7 +340,7 @@ A Helm chart for APK components
 | idp.idpui.deployment.replicas | int | `1` | Number of replicas |
 | idp.idpui.deployment.imagePullPolicy | string | `"Always"` | Image pull policy |
 | idp.idpui.deployment.image | string | `"wso2/apk-idp-ui:1.3.0"` | Image |
-| idp.idpui.deployment.nodeSelector | string | `{}` | Configure Node Selector for the deployment.  |
+| idp.idpui.deployment.nodeSelector | object | `{}` | Configure Node Selector for the deployment.  |
 | idp.idpui.deployment.pod.annotations | object | `{}` | Annotations for pods. |
 | idp.idpui.deployment.pod.labels | object | `{}` | Labels for pods. |
 | idp.idpui.configs.idpLoginUrl | string | `"https://idp.am.wso2.com:9095/commonauth/login"` | identity server Login URL |

--- a/helm-charts/README.md
+++ b/helm-charts/README.md
@@ -77,6 +77,8 @@ A Helm chart for APK components
 | wso2.apk.dp.configdeployer.enabled | bool | `true` |  |
 | wso2.apk.dp.configdeployer.deployment.affinity | object | `{"podAntiAffinity":{"preferredDuringSchedulingIgnoredDuringExecution":[{"podAffinityTerm":{"labelSelector":{"matchExpressions":[{"key":"app.kubernetes.io/app","operator":"In","values":["config-ds"]}]}}}]}}` | Configure Affinity for the deployment.  |
 | wso2.apk.dp.configdeployer.deployment.nodeSelector | object | `{}` | Configure Node Selector for the deployment.  |
+| wso2.apk.dp.configdeployer.deployment.pod.annotations | object | `{}` | Annotations for pods. |
+| wso2.apk.dp.configdeployer.deployment.pod.labels | object | `{}` | Labels for pods. |
 | wso2.apk.dp.configdeployer.deployment.resources.requests.memory | string | `"128Mi"` | CPU request for the container |
 | wso2.apk.dp.configdeployer.deployment.resources.requests.cpu | string | `"100m"` | Memory request for the container |
 | wso2.apk.dp.configdeployer.deployment.resources.limits.memory | string | `"1028Mi"` | CPU limit for the container |
@@ -114,6 +116,8 @@ A Helm chart for APK components
 | wso2.apk.dp.adapter.deployment.security.sslHostname | string | `"adapter"` | Enable security for adapter. |
 | wso2.apk.dp.adapter.deployment.affinity | object | `{"podAntiAffinity":{"preferredDuringSchedulingIgnoredDuringExecution":[{"podAffinityTerm":{"labelSelector":{"matchExpressions":[{"key":"app.kubernetes.io/app","operator":"In","values":["adapter"]}]}}}]}}` | Configure Affinity for the deployment.  |
 | wso2.apk.dp.adapter.deployment.nodeSelector | object | `{}` | Configure Node Selector for the deployment.  |
+| wso2.apk.dp.adapter.deployment.pod.annotations | object | `{}` | Annotations for pods. |
+| wso2.apk.dp.adapter.deployment.pod.labels | object | `{}` | Labels for pods. |
 | wso2.apk.dp.adapter.configs.apiNamespaces | string | `nil` | Optionally configure namespaces to watch for apis. |
 | wso2.apk.dp.adapter.configs.tls.secretName | string | `""` | TLS secret name for adapter public certificate. |
 | wso2.apk.dp.adapter.configs.tls.certKeyFilename | string | `""` | TLS certificate file name. |
@@ -139,6 +143,8 @@ A Helm chart for APK components
 | wso2.apk.dp.commonController.deployment.configs.apiNamespaces | list | `["apk-v12"]` | Optionally configure namespaces to watch for apis,ratelimitpolicies,etc. |
 | wso2.apk.dp.commonController.deployment.affinity | object | `{"podAntiAffinity":{"preferredDuringSchedulingIgnoredDuringExecution":[{"podAffinityTerm":{"labelSelector":{"matchExpressions":[{"key":"app.kubernetes.io/app","operator":"In","values":["common-controller"]}]}}}]}}` | Configure Affinity for the deployment.  |
 | wso2.apk.dp.commonController.deployment.nodeSelector | object | `{}` | Configure Node Selector for the deployment.  |
+| wso2.apk.dp.commonController.deployment.pod.annotations | object | `{}` | Annotations for pods. |
+| wso2.apk.dp.commonController.deployment.pod.labels | object | `{}` | Labels for pods. |
 | wso2.apk.dp.commonController.deployment.redis.host | string | `"redis-master"` | Redis host |
 | wso2.apk.dp.commonController.deployment.redis.port | string | `"6379"` | Redis port |
 | wso2.apk.dp.commonController.deployment.redis.username | string | `"default"` | Redis user name |
@@ -184,9 +190,13 @@ A Helm chart for APK components
 | wso2.apk.dp.ratelimiter.deployment.configs.tls.certCAFilename | string | `""` | TLS CA certificate file name. |
 | wso2.apk.dp.ratelimiter.deployment.affinity | object | `{"podAntiAffinity":{"preferredDuringSchedulingIgnoredDuringExecution":[{"podAffinityTerm":{"labelSelector":{"matchExpressions":[{"key":"app.kubernetes.io/app","operator":"In","values":["rate-limiter"]}]}}}]}}` | Configure Affinity for the deployment.  |
 | wso2.apk.dp.ratelimiter.deployment.nodeSelector | object | `{}` | Configure Node Selector for the deployment.  |
+| wso2.apk.dp.ratelimiter.deployment.pod.annotations | object | `{}` | Annotations for pods. |
+| wso2.apk.dp.ratelimiter.deployment.pod.labels | object | `{}` | Labels for pods. |
 | wso2.apk.dp.gatewayRuntime.service.annotations | string | `nil` | Gateway service related annotations. |
 | wso2.apk.dp.gatewayRuntime.deployment.replicas | int | `1` | Number of replicas |
 | wso2.apk.dp.gatewayRuntime.deployment.nodeSelector | object | `{}` | Configure Node Selector for the deployment.  |
+| wso2.apk.dp.gatewayRuntime.deployment.pod.annotations | object | `{}` | Annotations for pods. |
+| wso2.apk.dp.gatewayRuntime.deployment.pod.labels | object | `{}` | Labels for pods. |
 | wso2.apk.dp.gatewayRuntime.deployment.affinity | object | `{"podAntiAffinity":{"preferredDuringSchedulingIgnoredDuringExecution":[{"podAffinityTerm":{"labelSelector":{"matchExpressions":[{"key":"app.kubernetes.io/app","operator":"In","values":["gateway-runtime"]}]}}}]}}` | Configure Affinity for the deployment.  |
 | wso2.apk.dp.gatewayRuntime.deployment.router.resources.requests.memory | string | `"128Mi"` | CPU request for the container |
 | wso2.apk.dp.gatewayRuntime.deployment.router.resources.requests.cpu | string | `"100m"` | Memory request for the container |
@@ -311,6 +321,9 @@ A Helm chart for APK components
 | idp.idpds.deployment.replicas | int | `1` | Number of replicas |
 | idp.idpds.deployment.imagePullPolicy | string | `"Always"` | Image pull policy |
 | idp.idpds.deployment.image | string | `"wso2/apk-idp-domain-service:1.3.0"` | Image |
+| idp.idpds.deployment.nodeSelector | string | `{}` | Configure Node Selector for the deployment.  |
+| idp.idpds.deployment.pod.annotations | object | `{}` | Annotations for pods. |
+| idp.idpds.deployment.pod.labels | object | `{}` | Labels for pods. |
 | idp.idpui.deployment.resources.requests.memory | string | `"128Mi"` | CPU request for the container |
 | idp.idpui.deployment.resources.requests.cpu | string | `"100m"` | Memory request for the container |
 | idp.idpui.deployment.resources.limits.memory | string | `"1028Mi"` | CPU limit for the container |
@@ -325,6 +338,9 @@ A Helm chart for APK components
 | idp.idpui.deployment.replicas | int | `1` | Number of replicas |
 | idp.idpui.deployment.imagePullPolicy | string | `"Always"` | Image pull policy |
 | idp.idpui.deployment.image | string | `"wso2/apk-idp-ui:1.3.0"` | Image |
+| idp.idpui.deployment.nodeSelector | string | `{}` | Configure Node Selector for the deployment.  |
+| idp.idpui.deployment.pod.annotations | object | `{}` | Annotations for pods. |
+| idp.idpui.deployment.pod.labels | object | `{}` | Labels for pods. |
 | idp.idpui.configs.idpLoginUrl | string | `"https://idp.am.wso2.com:9095/commonauth/login"` | identity server Login URL |
 | idp.idpui.configs.idpAuthCallBackUrl | string | `"https://idp.am.wso2.com:9095/oauth2/auth-callback"` | identity server authCallBackUrl |
 | gatewaySystem.enabled | bool | `true` | Enable gateway system to install gateway system components |

--- a/helm-charts/templates/data-plane/config-deployer/config-ds-deployment.yaml
+++ b/helm-charts/templates/data-plane/config-deployer/config-ds-deployment.yaml
@@ -31,8 +31,14 @@ spec:
     metadata:
       labels:
 {{ include "apk-helm.pod.selectorLabels" (dict "root" . "app" "configdeployer-ds" ) | indent 8}}
+{{- with .Values.wso2.apk.dp.configdeployer.deployment.pod.labels }}
+{{ toYaml . | indent 8 }}
+{{- end }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/data-plane/config-deployer/config-ds-configmap.yaml") . | sha256sum }}
+{{- with .Values.wso2.apk.dp.configdeployer.deployment.pod.annotations }}
+{{ toYaml . | indent 8 }}
+{{- end }}
     spec:
       affinity: {{- include "apk-helm.deployment.affinity" ( dict "value" .Values.wso2.apk.dp.configdeployer.deployment.affinity "app" "config-ds" "context" $) | nindent 8 }}
       {{- if .Values.wso2.apk.dp.configdeployer.deployment.nodeSelector }}

--- a/helm-charts/templates/data-plane/gateway-components/adapter/adapter-deployment.yaml
+++ b/helm-charts/templates/data-plane/gateway-components/adapter/adapter-deployment.yaml
@@ -31,8 +31,14 @@ spec:
     metadata:
       labels:
 {{ include "apk-helm.pod.selectorLabels" (dict "root" . "app" "adapter" ) | indent 8}}
+{{- with .Values.wso2.apk.dp.adapter.deployment.pod.labels }}
+{{ toYaml . | indent 8 }}
+{{- end }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/data-plane/gateway-components/log-conf.yaml") . | sha256sum }}
+{{- with .Values.wso2.apk.dp.adapter.deployment.pod.annotations }}
+{{ toYaml . | indent 8 }}
+{{- end }}
     spec:
       affinity: {{- include "apk-helm.deployment.affinity" ( dict "value" .Values.wso2.apk.dp.adapter.deployment.affinity "app" "adapter" "context" $) | nindent 8 }}
       {{- if .Values.wso2.apk.dp.adapter.deployment.nodeSelector }}

--- a/helm-charts/templates/data-plane/gateway-components/common-controller/common-controller-deployment.yaml
+++ b/helm-charts/templates/data-plane/gateway-components/common-controller/common-controller-deployment.yaml
@@ -31,8 +31,14 @@ spec:
     metadata:
       labels:
 {{ include "apk-helm.pod.selectorLabels" (dict "root" . "app" "commoncontroller" ) | indent 8}}
+{{- with .Values.wso2.apk.dp.commonController.deployment.pod.labels }}
+{{ toYaml . | indent 8 }}
+{{- end }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/data-plane/gateway-components/common-log-conf.yaml") . | sha256sum }}
+{{- with .Values.wso2.apk.dp.commonController.deployment.pod.annotations }}
+{{ toYaml . | indent 8 }}
+{{- end }}
     spec:
       affinity: {{- include "apk-helm.deployment.affinity" ( dict "value" .Values.wso2.apk.dp.commonController.deployment.affinity "app" "common-controller" "context" $) | nindent 8 }}
       {{- if .Values.wso2.apk.dp.commonController.deployment.nodeSelector }}

--- a/helm-charts/templates/data-plane/gateway-components/gateway-runtime/gateway-runtime-deployment.yaml
+++ b/helm-charts/templates/data-plane/gateway-components/gateway-runtime/gateway-runtime-deployment.yaml
@@ -421,6 +421,9 @@ spec:
             initialDelaySeconds: {{ .Values.wso2.apk.dp.gatewayRuntime.deployment.router.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.wso2.apk.dp.gatewayRuntime.deployment.router.readinessProbe.periodSeconds }}
             failureThreshold: {{ .Values.wso2.apk.dp.gatewayRuntime.deployment.router.readinessProbe.failureThreshold }}
+      {{- if .Values.wso2.apk.dp.gatewayRuntime.deployment.extraContainers }}
+{{ toYaml .Values.wso2.apk.dp.gatewayRuntime.deployment.extraContainers | indent 8 }}
+      {{- end }}
       {{- if and .Values.wso2.subscription .Values.wso2.subscription.imagePullSecrets}}
       imagePullSecrets:
         - name: {{ .Values.wso2.subscription.imagePullSecrets }}
@@ -496,5 +499,8 @@ spec:
           {{ end }}
         - name: tmp
           emptyDir: {}
+      {{- if .Values.wso2.apk.dp.gatewayRuntime.deployment.extraVolumes }}
+{{ toYaml .Values.wso2.apk.dp.gatewayRuntime.deployment.extraVolumes | indent 8 }}
+      {{- end }}
           {{end}}
 {{ end }}

--- a/helm-charts/templates/data-plane/gateway-components/gateway-runtime/gateway-runtime-deployment.yaml
+++ b/helm-charts/templates/data-plane/gateway-components/gateway-runtime/gateway-runtime-deployment.yaml
@@ -34,8 +34,14 @@ spec:
     metadata:
       labels:
 {{ include "apk-helm.pod.selectorLabels" (dict "root" . "app" "gateway" ) | indent 8}}
+{{- with .Values.wso2.apk.dp.gatewayRuntime.deployment.pod.labels }}
+{{ toYaml . | indent 8 }}
+{{- end }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/data-plane/gateway-components/log-conf.yaml") . | sha256sum }}
+{{- with .Values.wso2.apk.dp.gatewayRuntime.deployment.pod.annotations }}
+{{ toYaml . | indent 8 }}
+{{- end }}
     spec:
       affinity: {{- include "apk-helm.deployment.affinity" ( dict "value" .Values.wso2.apk.dp.gatewayRuntime.deployment.affinity "app" "gateway-runtime" "context" $) | nindent 8 }}
       {{- if .Values.wso2.apk.dp.gatewayRuntime.deployment.nodeSelector }}

--- a/helm-charts/templates/data-plane/ratelimiter/ratelimiter-deployment.yaml
+++ b/helm-charts/templates/data-plane/ratelimiter/ratelimiter-deployment.yaml
@@ -31,6 +31,13 @@ spec:
     metadata:
       labels:
 {{ include "apk-helm.pod.selectorLabels" (dict "root" . "app" "ratelimiter" ) | indent 8}}
+{{- with .Values.wso2.apk.dp.ratelimiter.deployment.pod.labels }}
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- if .Values.wso2.apk.dp.ratelimiter.deployment.pod.annotations }}
+      annotations:
+{{ toYaml .Values.wso2.apk.dp.ratelimiter.deployment.pod.annotations | indent 8 }}
+{{- end }}
     spec:
       affinity: {{- include "apk-helm.deployment.affinity" ( dict "value" .Values.wso2.apk.dp.ratelimiter.deployment.affinity "app" "rate-limiter" "context" $) | nindent 8 }}
       {{- if .Values.wso2.apk.dp.ratelimiter.deployment.nodeSelector }}

--- a/helm-charts/templates/idp/idp-ds/idp-ds-deployment.yaml
+++ b/helm-charts/templates/idp/idp-ds/idp-ds-deployment.yaml
@@ -31,10 +31,19 @@ spec:
     metadata:
       labels:
 {{ include "apk-helm.pod.selectorLabels" (dict "root" . "app" "idp-ds" ) | indent 8}}
+{{- with .Values.idp.idpds.deployment.pod.labels }}
+{{ toYaml . | indent 8 }}
+{{- end }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/idp/idp-ds/idp-ds-configmap.yaml") . | sha256sum }}
+{{- with .Values.idp.idpds.deployment.pod.annotations }}
+{{ toYaml . | indent 8 }}
+{{- end }}
     spec:
       automountServiceAccountToken: false
+      {{- if .Values.idp.idpds.deployment.nodeSelector }}
+      nodeSelector: {{- include "apk-helm.deployment.nodeSelector" ( dict "value" .Values.idp.idpds.deployment.nodeSelector "context" $) | nindent 8 }}
+      {{- end }}
       initContainers:
         - name: init-db
           image: busybox:1.32

--- a/helm-charts/templates/idp/idp-ui/idp-ui-deployment.yaml
+++ b/helm-charts/templates/idp/idp-ui/idp-ui-deployment.yaml
@@ -31,8 +31,18 @@ spec:
     metadata:
       labels:
 {{ include "apk-helm.pod.selectorLabels" (dict "root" . "app" "idp-ui" ) | indent 8}}
+{{- with .Values.idp.idpui.deployment.pod.labels }}
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- if .Values.idp.idpui.deployment.pod.annotations }}
+      annotations:
+{{ toYaml .Values.idp.idpui.deployment.pod.annotations | indent 8 }}
+{{- end }}
     spec:
       automountServiceAccountToken: false
+      {{- if .Values.idp.idpui.deployment.nodeSelector }}
+      nodeSelector: {{- include "apk-helm.deployment.nodeSelector" ( dict "value" .Values.idp.idpui.deployment.nodeSelector "context" $) | nindent 8 }}
+      {{- end }}
       containers:
         - name: idpui
           image: {{ .Values.idp.idpui.deployment.image }}

--- a/helm-charts/values.yaml
+++ b/helm-charts/values.yaml
@@ -97,6 +97,14 @@ wso2:
           replicas: 1
           imagePullPolicy: Always
           image: wso2/apk-config-deployer-service:1.3.0
+          # Configure Node Selector for the deployment
+          nodeSelector: {}
+          # Pod-specific configurations
+          pod:
+            # -- Annotations for pods
+            annotations: {}
+            # -- Labels for pods
+            labels: {}
         # debug: true
           # configs:
           #   tls:
@@ -124,6 +132,14 @@ wso2:
           replicas: 1
           imagePullPolicy: Always
           image: wso2/apk-adapter:1.3.0
+          # Configure Node Selector for the deployment
+          nodeSelector: {}
+          # Pod-specific configurations
+          pod:
+            # -- Annotations for pods
+            annotations: {}
+            # -- Labels for pods
+            labels: {}
           security:
             sslHostname: "adapter"
           logging:
@@ -158,6 +174,14 @@ wso2:
           replicas: 1
           imagePullPolicy: Always
           image: wso2/apk-common-controller:1.3.0
+          # Configure Node Selector for the deployment
+          nodeSelector: {}
+          # Pod-specific configurations
+          pod:
+            # -- Annotations for pods
+            annotations: {}
+            # -- Labels for pods
+            labels: {}
           security:
             sslHostname: "commoncontroller"
           # configs:
@@ -187,6 +211,14 @@ wso2:
           image: wso2/apk-ratelimiter:1.3.0
           security:
             sslHostname: "ratelimiter"
+          # Configure Node Selector for the deployment
+          nodeSelector: {}
+          # Pod-specific configurations
+          pod:
+            # -- Annotations for pods
+            annotations: {}
+            # -- Labels for pods
+            labels: {}
           # configs:
           #   tls:
           #     secretName: "ratelimiter-cert"
@@ -196,6 +228,14 @@ wso2:
       gatewayRuntime:
         deployment:
           replicas: 1
+          # Configure Node Selector for the deployment
+          nodeSelector: {}
+          # Pod-specific configurations
+          pod:
+            # -- Annotations for pods
+            annotations: {}
+            # -- Labels for pods
+            labels: {}
           router:
             resources:
               requests:
@@ -323,6 +363,14 @@ idp:
       replicas: 1
       imagePullPolicy: Always
       image: wso2/apk-idp-domain-service:1.3.0
+      # Configure Node Selector for the deployment
+      nodeSelector: {}
+      # Pod-specific configurations
+      pod:
+        # -- Annotations for pods
+        annotations: {}
+        # -- Labels for pods
+        labels: {}
   idpui:
     deployment:
       resources:
@@ -344,6 +392,14 @@ idp:
       replicas: 1
       imagePullPolicy: Always
       image: wso2/apk-idp-ui:1.3.0
+      # Configure Node Selector for the deployment
+      nodeSelector: {}
+      # Pod-specific configurations
+      pod:
+        # -- Annotations for pods
+        annotations: {}
+        # -- Labels for pods
+        labels: {}
     configs:
       idpLoginUrl: "https://idp.am.wso2.com:9095/commonauth/login"
       idpAuthCallBackUrl: "https://idp.am.wso2.com:9095/oauth2/auth-callback"

--- a/helm-charts/values.yaml
+++ b/helm-charts/values.yaml
@@ -236,6 +236,10 @@ wso2:
             annotations: {}
             # -- Labels for pods
             labels: {}
+          # -- Extra sidecar containers to inject into the gateway runtime pod
+          extraContainers: []
+          # -- Extra volumes to add to the gateway runtime pod (used alongside extraContainers)
+          extraVolumes: []
           router:
             resources:
               requests:

--- a/helm-charts/values.yaml.template
+++ b/helm-charts/values.yaml.template
@@ -504,6 +504,11 @@ wso2:
                       operator: In
                       values:
                       - gateway-runtime
+          # -- Extra sidecar containers to inject into the gateway runtime pod.
+          extraContainers: []
+          # -- Extra volumes to add to the gateway runtime pod (used alongside extraContainers).
+          # Volume names must match the volumeMounts defined in extraContainers.
+          extraVolumes: []
           router:
             resources:
               requests:

--- a/helm-charts/values.yaml.template
+++ b/helm-charts/values.yaml.template
@@ -204,6 +204,12 @@ wso2:
           imagePullPolicy: Always
           # -- Image
           image: wso2/apk-config-deployer-service:1.3.0
+          # Pod-specific configurations
+          pod:
+            # -- Annotations for pods
+            annotations: {}
+            # -- Labels for pods
+            labels: {}
           configs:
             # -- Enable authorization for runtime api.
             authorization: true
@@ -259,6 +265,12 @@ wso2:
           imagePullPolicy: Always
           # -- Image
           image: wso2/apk-adapter:1.3.0
+          # Pod-specific configurations
+          pod:
+            # -- Annotations for pods
+            annotations: {}
+            # -- Labels for pods
+            labels: {}
           security:
             # -- Enable security for adapter.
             sslHostname: "adapter"
@@ -330,6 +342,12 @@ wso2:
           imagePullPolicy: Always
           # -- Image
           image: wso2/apk-common-controller:1.3.0
+          # Pod-specific configurations
+          pod:
+            # -- Annotations for pods
+            annotations: {}
+            # -- Labels for pods
+            labels: {}
           security:
             # -- hostname for the common controller
             sslHostname: "commoncontroller"
@@ -454,6 +472,12 @@ wso2:
                       - rate-limiter
           # -- Configure Node Selector for the deployment. 
           nodeSelector: {}
+          # Pod-specific configurations
+          pod:
+            # -- Annotations for pods
+            annotations: {}
+            # -- Labels for pods
+            labels: {}
       gatewayRuntime:
         service:
           # -- Gateway service related annotations.
@@ -463,6 +487,12 @@ wso2:
           replicas: 1
           # -- Configure Node Selector for the deployment. 
           nodeSelector: {}
+          # Pod-specific configurations
+          pod:
+            # -- Annotations for pods
+            annotations: {}
+            # -- Labels for pods
+            labels: {}
           # -- Configure Affinity for the deployment. 
           affinity:
             podAntiAffinity:
@@ -795,6 +825,14 @@ idp:
       imagePullPolicy: Always
       # -- Image
       image: wso2/apk-idp-domain-service:1.3.0
+      # -- Configure Node Selector for the deployment.
+      nodeSelector: {}
+      # Pod-specific configurations
+      pod:
+        # -- Annotations for pods
+        annotations: {}
+        # -- Labels for pods
+        labels: {}
   idpui:
     deployment:
       resources:
@@ -830,6 +868,14 @@ idp:
       imagePullPolicy: Always
       # -- Image
       image: wso2/apk-idp-ui:1.3.0
+      # -- Configure Node Selector for the deployment. 
+      nodeSelector: {}
+      # Pod-specific configurations
+      pod:
+        # -- Annotations for pods
+        annotations: {}
+        # -- Labels for pods
+        labels: {}
     configs:
       # -- identity server Login URL
       idpLoginUrl: "https://idp.am.wso2.com:9095/commonauth/login"


### PR DESCRIPTION
This pull request enhances the configurability of the Helm charts for APK components by introducing new options for pod-level customization and deployment flexibility. The main changes add support for specifying custom pod annotations, labels, and node selectors for various components. Additionally, the gateway runtime deployment now supports injecting extra containers and volumes.

Related to - 
https://github.com/wso2/apk/issues/3321
https://github.com/wso2/apk/issues/3323

Doc PR - https://github.com/wso2/docs-apk/pull/798

**Pod customization enhancements:**

* Added support for specifying `pod.annotations` and `pod.labels` for the following components: `configdeployer`, `adapter`, `commonController`, `ratelimiter`, `gatewayRuntime`, `idpds`, and `idpui` in both `values.yaml` and their respective deployment templates, allowing for more granular pod-level metadata configuration. [[1]](diffhunk://#diff-574071cc3528d16bd7f68ae36386fc3a7ed6e2ad77d27b3508b06ae231b94b35R80-R81) [[2]](diffhunk://#diff-574071cc3528d16bd7f68ae36386fc3a7ed6e2ad77d27b3508b06ae231b94b35R119-R120) [[3]](diffhunk://#diff-574071cc3528d16bd7f68ae36386fc3a7ed6e2ad77d27b3508b06ae231b94b35R146-R147) [[4]](diffhunk://#diff-574071cc3528d16bd7f68ae36386fc3a7ed6e2ad77d27b3508b06ae231b94b35R193-R201) [[5]](diffhunk://#diff-574071cc3528d16bd7f68ae36386fc3a7ed6e2ad77d27b3508b06ae231b94b35R326-R328) [[6]](diffhunk://#diff-574071cc3528d16bd7f68ae36386fc3a7ed6e2ad77d27b3508b06ae231b94b35R343-R345) [[7]](diffhunk://#diff-3ea4a390c0949643e55a9a4ffd4a03e83515115e690e3e07c42fc9551bd1b79dR34-R41) [[8]](diffhunk://#diff-e4aa4a81599d1b7bf56f12f51b8bf97c706bc1254dd600703023f0ffbf5622acR34-R41) [[9]](diffhunk://#diff-98ca5fad80aeda54cba78a42eaa4e4fce44d08047c260fe2761cb6033909cbe0R34-R41) [[10]](diffhunk://#diff-4b2fce2615e3769fb8344f0316f2a9f772fea51e50e53beae6160feb8aaa9e6dR37-R44) [[11]](diffhunk://#diff-8cf891ad0ab667ceb600e79984c249f50a9cad4badea1301c1f0db80ba9df31bR34-R40) [[12]](diffhunk://#diff-fc78efecb95222f6708bf7e54ffb0469596c024ad6012c807b9260cc9c1b0c62R34-R46) [[13]](diffhunk://#diff-c72271e7c6c2e978826ce201a05054ccc3219968f0552568241cf359defd788dR34-R45) [[14]](diffhunk://#diff-cff50e75d125f9facaba91994056a4dbc79de3fbb695c287dc880b602f53f62fR100-R107) [[15]](diffhunk://#diff-cff50e75d125f9facaba91994056a4dbc79de3fbb695c287dc880b602f53f62fR135-R142) [[16]](diffhunk://#diff-cff50e75d125f9facaba91994056a4dbc79de3fbb695c287dc880b602f53f62fR177-R184) [[17]](diffhunk://#diff-cff50e75d125f9facaba91994056a4dbc79de3fbb695c287dc880b602f53f62fR214-R221) [[18]](diffhunk://#diff-cff50e75d125f9facaba91994056a4dbc79de3fbb695c287dc880b602f53f62fR370-R377) [[19]](diffhunk://#diff-cff50e75d125f9facaba91994056a4dbc79de3fbb695c287dc880b602f53f62fR399-R406) [[20]](diffhunk://#diff-af2c654d0ae98c77d66bb7d95a8073464e79e630bfaa17ce6c338c2f32b7c396R207-R212)

* Introduced `nodeSelector` configuration for the same set of components, enabling targeted scheduling of pods to specific nodes. [[1]](diffhunk://#diff-574071cc3528d16bd7f68ae36386fc3a7ed6e2ad77d27b3508b06ae231b94b35R80-R81) [[2]](diffhunk://#diff-574071cc3528d16bd7f68ae36386fc3a7ed6e2ad77d27b3508b06ae231b94b35R119-R120) [[3]](diffhunk://#diff-574071cc3528d16bd7f68ae36386fc3a7ed6e2ad77d27b3508b06ae231b94b35R146-R147) [[4]](diffhunk://#diff-574071cc3528d16bd7f68ae36386fc3a7ed6e2ad77d27b3508b06ae231b94b35R193-R201) [[5]](diffhunk://#diff-574071cc3528d16bd7f68ae36386fc3a7ed6e2ad77d27b3508b06ae231b94b35R326-R328) [[6]](diffhunk://#diff-574071cc3528d16bd7f68ae36386fc3a7ed6e2ad77d27b3508b06ae231b94b35R343-R345) [[7]](diffhunk://#diff-fc78efecb95222f6708bf7e54ffb0469596c024ad6012c807b9260cc9c1b0c62R34-R46) [[8]](diffhunk://#diff-c72271e7c6c2e978826ce201a05054ccc3219968f0552568241cf359defd788dR34-R45) [[9]](diffhunk://#diff-cff50e75d125f9facaba91994056a4dbc79de3fbb695c287dc880b602f53f62fR100-R107) [[10]](diffhunk://#diff-cff50e75d125f9facaba91994056a4dbc79de3fbb695c287dc880b602f53f62fR135-R142) [[11]](diffhunk://#diff-cff50e75d125f9facaba91994056a4dbc79de3fbb695c287dc880b602f53f62fR177-R184) [[12]](diffhunk://#diff-cff50e75d125f9facaba91994056a4dbc79de3fbb695c287dc880b602f53f62fR214-R221) [[13]](diffhunk://#diff-cff50e75d125f9facaba91994056a4dbc79de3fbb695c287dc880b602f53f62fR231-R242) [[14]](diffhunk://#diff-cff50e75d125f9facaba91994056a4dbc79de3fbb695c287dc880b602f53f62fR370-R377) [[15]](diffhunk://#diff-cff50e75d125f9facaba91994056a4dbc79de3fbb695c287dc880b602f53f62fR399-R406)

**Gateway runtime extensibility:**

* Added support for `extraContainers` and `extraVolumes` in the `gatewayRuntime` deployment, allowing users to inject additional sidecar containers and volumes into the pod for advanced use cases. [[1]](diffhunk://#diff-574071cc3528d16bd7f68ae36386fc3a7ed6e2ad77d27b3508b06ae231b94b35R193-R201) [[2]](diffhunk://#diff-4b2fce2615e3769fb8344f0316f2a9f772fea51e50e53beae6160feb8aaa9e6dR424-R426) [[3]](diffhunk://#diff-4b2fce2615e3769fb8344f0316f2a9f772fea51e50e53beae6160feb8aaa9e6dR502-R504) [[4]](diffhunk://#diff-cff50e75d125f9facaba91994056a4dbc79de3fbb695c287dc880b602f53f62fR231-R242)